### PR TITLE
Fix Spoolman sync for transparent/natural filament spools

### DIFF
--- a/backend/app/services/spoolman.py
+++ b/backend/app/services/spoolman.py
@@ -541,9 +541,14 @@ class SpoolmanClient:
 
         # Need valid color to create filament
         tray_color = tray_data.get("tray_color", "")
-        if not tray_color or tray_color in ("", "00000000"):
-            logger.debug(f"Skipping tray with invalid color: {tray_color}")
+        if not tray_color or tray_color.strip() == "":
+            logger.debug("Skipping tray with empty color")
             return None
+
+        # Handle transparent/natural filament (RRGGBBAA with alpha=00)
+        # Replace with cream color that represents how natural PLA actually looks
+        if tray_color == "00000000":
+            tray_color = "F5E6D3FF"  # Light cream/natural color
 
         # Get sub_brands, falling back to tray_type
         tray_sub_brands = tray_data.get("tray_sub_brands", "")


### PR DESCRIPTION
Fix Spoolman sync for transparent/natural filament spools

Transparent spools (like Natural PLA Support) report color "00000000"
which was being skipped as invalid. Now these spools are synced with
a light cream color (F5E6D3) that represents how natural PLA looks.

Fixes #190