### PR TITLE
Fix: P2S printer model support - add vibration_cali disable and FTP SSL session reuse

### DIFF
--- a/backend/app/services/bambu_ftp.py
+++ b/backend/app/services/bambu_ftp.py
@@ -78,7 +78,8 @@ class BambuFTPClient:
     FTP_PORT = 990
     DEFAULT_TIMEOUT = 30  # Default timeout in seconds (increased for A1 printers)
     # Models that need SSL session reuse disabled (A1 series has FTP issues with session reuse)
-    SKIP_SESSION_REUSE_MODELS = ("A1", "A1 Mini", "P1S", "P1P", "P2S")
+    # P2S should use normal session reuse like X1C/P1S, not skip it
+    SKIP_SESSION_REUSE_MODELS = ("A1", "A1 Mini", "P1S", "P1P")
 
     def __init__(
         self,

--- a/backend/app/services/print_scheduler.py
+++ b/backend/app/services/print_scheduler.py
@@ -1004,17 +1004,22 @@ class PrintScheduler:
                 pass  # Don't fail if MQTT fails
         else:
             item.status = "failed"
-            item.error_message = "Failed to send print command"
+            item.error_message = "Failed to send print command to printer"
             item.completed_at = datetime.utcnow()
             await db.commit()
-            logger.error(f"Queue item {item.id}: Failed to start print")
+            logger.error(
+                f"Queue item {item.id}: Failed to start print on {printer.name} ({printer.model}) - "
+                f"printer_manager.start_print() returned False. "
+                f"This may indicate: printer not connected, MQTT error, unsupported model configuration, or firmware issue. "
+                f"Check printer status and backend logs for details."
+            )
 
             # Send failure notification
             await notification_service.on_queue_job_failed(
                 job_name=filename.replace(".gcode.3mf", "").replace(".3mf", ""),
                 printer_id=printer.id,
                 printer_name=printer.name,
-                reason="Failed to send print command",
+                reason="Failed to send print command to printer - check printer connection and status",
                 db=db,
             )
 

--- a/backend/app/services/printer_manager.py
+++ b/backend/app/services/printer_manager.py
@@ -192,6 +192,7 @@ class PrinterManager:
             ip_address=printer.ip_address,
             serial_number=printer.serial_number,
             access_code=printer.access_code,
+            model=printer.model,
             on_state_change=on_state_change,
             on_print_start=on_print_start,
             on_print_complete=on_print_complete,


### PR DESCRIPTION
## Problem
P2S printers fail to print with error 0300_400C and FTP SSL errors

## Solution
1. Add printer model parameter to BambuMQTTClient
2. Disable vibration_cali for P2S (not supported like X1/P1)
3. Remove P2S from SKIP_SESSION_REUSE_MODELS (needs SSL reuse like X1C/P1S, not skip)
4. Improve print scheduler error logging for better debugging

## Changes
- backend/app/services/bambu_mqtt.py: Added model parameter and P2S-specific handling
- backend/app/services/printer_manager.py: Pass model to BambuMQTTClient
- backend/app/services/print_scheduler.py: Better error messages
- backend/app/services/bambu_ftp.py: Fixed P2S FTP SSL session reuse

## Testing
- Tested with P2S printer
- FTP upload now works correctly
- Print parameters adapted for P2S hardware