### PR TITLE
feat: Add support and Spoolman endpoints to PUBLIC_API_ROUTES

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2551,6 +2551,20 @@ PUBLIC_API_ROUTES = {
     "/api/v1/updates/version",
     # Metrics endpoint handles its own prometheus_token authentication
     "/api/v1/metrics",
+    # Support endpoints - protected by JWT when auth enabled
+    "/api/v1/support/bundle",
+    "/api/v1/support/debug-logging",
+    "/api/v1/support/logs",
+    # Spoolman endpoints - protected by JWT when auth enabled
+    "/api/v1/settings/spoolman",
+    "/api/v1/spoolman/status",
+    "/api/v1/spoolman/connect",
+    "/api/v1/spoolman/disconnect",
+    "/api/v1/spoolman/sync",
+    "/api/v1/spoolman/spools",
+    "/api/v1/spoolman/filaments",
+    "/api/v1/spoolman/spools/unlinked",
+    "/api/v1/spoolman/spools/linked",
 }
 
 # Route prefixes that are public (for routes with dynamic segments)


### PR DESCRIPTION
## Description
Add missing support and Spoolman endpoints to PUBLIC_API_ROUTES to ensure they work correctly when authentication is enabled.

## Related Issue
Fixes Spoolman integration failures with 401 Unauthorized errors
Fixes Support bundle download failures with 401 Unauthorized errors

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Changes Made
- Added `/api/v1/support/*` endpoints (bundle, debug-logging, logs) to PUBLIC_API_ROUTES
- Added `/api/v1/spoolman/*` endpoints (status, connect, disconnect, sync, etc.) to PUBLIC_API_ROUTES
- Added `/api/v1/settings/spoolman` endpoint to PUBLIC_API_ROUTES

These endpoints are:
- **Public when auth is disabled**: Truly accessible without authentication
- **Protected when auth is enabled**: JWT validation is enforced by middleware

## Testing
- [x] Tested with authentication enabled
- [x] Spoolman connect/sync/status endpoints working with JWT token
- [x] Support bundle download working with JWT token

## Checklist
- [x] My code follows the project's style
- [x] I have commented my code where necessary