### PR TITLE
bug/spoolman-creates-dublicate-spools

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -560,8 +560,16 @@ async def on_ams_change(printer_id: int, ams_data: list):
             # OPTIMIZATION: Fetch all spools once before processing trays
             # This eliminates redundant API calls (one per tray) when syncing multiple trays
             logger.debug("[Printer %s] Fetching spools cache for AMS sync...", printer_id)
-            cached_spools = await client.get_spools()
-            logger.debug("[Printer %s] Cached %d spools for batch sync", printer_id, len(cached_spools))
+            try:
+                cached_spools = await client.get_spools()
+                logger.debug("[Printer %s] Cached %d spools for batch sync", printer_id, len(cached_spools))
+            except Exception as e:
+                logger.error(
+                    "[Printer %s] Failed to fetch spools cache after retries, aborting AMS sync: %s",
+                    printer_id,
+                    e,
+                )
+                return
 
             # Sync each AMS tray
             synced = 0


### PR DESCRIPTION
## Description

This error creates duplicate spool's (see screenshot) on application start. Haven't seen on other occasions.

```
2026-02-07 22:38:46,761 DEBUG [httpcore.http11] receive_response_headers.failed exception=ReadError(ClosedResourceError())
2026-02-07 22:38:46,762 ERROR [backend.app.services.spoolman] Failed to get spools from Spoolman:
```

This PR Optimizes AMS-to-Spoolman sync performance and adds connection resilience for large spool databases (300+ spools).

**Problem**: Each AMS tray independently fetched all spools from Spoolman, causing redundant API calls per sync operation. This caused timeouts and poor performance with large spool databases. 

**Solution**: Fetch all spools once and reuse cached data across all tray operations. Added retry logic (3 attempts, 500ms delay) with connection recreation to handle transient network errors, ensuring the optimization remains reliable.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test addition or update

## Changes Made

- Added optional `cached_spools` parameter to sync functions (backward compatible)
- Fetch spools once before loops in `on_ams_change`, `sync_single_printer`, and `sync_all_printers`
- Added retry logic to `get_spools()` with connection recreation on errors
- Configured `httpx.Limits` to prevent stale connection reuse
- Added 9 new unit tests (all 1018 tests passing)

## Screenshots

<img width="2457" height="240" alt="image" src="https://github.com/user-attachments/assets/751c0222-f53b-451a-ba75-fe3580c64783" />

## Testing

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: P1S

**Test Environment:**
- Spoolman instance with **300 spools**
- 2 × P1S printers:
  - Printer 1: 1 AMS unit (4 trays)
  - Printer 2: 2 AMS units (8 trays)
- Total: 12 AMS trays being synced

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

**Future improvement**: The ideal solution would be enhancing Spoolman's API to support querying by extra data/tag, eliminating the need for client-side caching. Spoolman has a new release and appears actively maintained again, making this a viable contribution opportunity. I'll look into that.
