### PR TITLE
First attempt to automation, Location == automation means printer aut…

### DIFF
--- a/backend/app/services/printer_manager.py
+++ b/backend/app/services/printer_manager.py
@@ -106,6 +106,7 @@ class PrinterManager:
         self._current_print_user: dict[int, dict] = {}  # {printer_id: {"user_id": int, "username": str}}
         # Track plate-cleared acknowledgments for queue flow
         self._plate_cleared: set[int] = set()  # printer_ids where user confirmed plate is cleared
+        self._automation: dict[int, bool] = {} # Cache printer is automated, auto clear
 
     def get_printer(self, printer_id: int) -> PrinterInfo | None:
         """Get printer info by ID."""
@@ -195,6 +196,8 @@ class PrinterManager:
                 self._schedule_async(self._on_print_start(printer_id, data))
 
         def on_print_complete(data: dict):
+            if self._automation[printer_id] and data["status"] == "completed":
+                self.set_plate_cleared(printer_id)
             if self._on_print_complete:
                 self._schedule_async(self._on_print_complete(printer_id, data))
 
@@ -222,6 +225,7 @@ class PrinterManager:
         self._clients[printer_id] = client
         self._models[printer_id] = printer.model  # Cache model for feature detection
         self._printer_info[printer_id] = PrinterInfo(printer.name, printer.serial_number)
+        self._automation[printer_id] = (printer.location == "automation")
 
         # Wait a moment for connection
         await asyncio.sleep(1)


### PR DESCRIPTION

## Description

First attempt to automation, Location == automation means printer aut…o clear on successful completion

## Related Issue

Implementation of Feature #184 


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

<!-- List the specific changes made in this PR -->

- For a printer with Location as the single word automation when a print is successful the plate is automatically cleared
- There are no changes to the printer model or the UI on this commit
- The UI will briefly show the Clear plate button while the upload and MQTT command are being delivered on the background.

## Screenshots

<!-- If applicable, add screenshots to demonstrate your changes -->

## Testing

<!-- Describe how you tested your changes -->

- [X] I have tested this on my local machine
- [ ] I have tested with my printer model: <!-- e.g., X1C, P1S, A1 -->

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation (if needed)
- [ ] My changes generate no new warnings
- [ ] I have tested my changes thoroughly

## Additional Notes

<!-- Add any additional information that reviewers should know -->
This is plain hack to get the feature started, with some guidelines on what to transpose to the UI and printer model