### PR TITLE
Make dev mode warning dismissable

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -157,6 +157,14 @@ export function Layout() {
     refetchInterval: 30 * 1000,
     refetchOnWindowFocus: true,
   });
+  // Dismissible developer mode warning banner
+  const [dismissedDevModeWarning, setDismissedDevModeWarning] = useState(() => {
+    return sessionStorage.getItem('dismissedDevModeWarning') === '1';
+  });
+  const handleDismissDevModeWarning = () => {
+    setDismissedDevModeWarning(true);
+    sessionStorage.setItem('dismissedDevModeWarning', '1');
+  };
 
   // Fetch pending queue items count for badge
   const { data: queueItems } = useQuery({
@@ -816,7 +824,7 @@ export function Layout() {
             </div>
           </div>
         )}
-        {devModeWarnings && devModeWarnings.length > 0 && (
+        {devModeWarnings && devModeWarnings.length > 0 && !dismissedDevModeWarning && (
           <div className="bg-orange-500/20 border-b border-orange-500/30 px-4 py-2 flex items-center justify-between">
             <div className="flex items-center gap-2 text-sm">
               <ShieldAlert className="w-4 h-4 text-orange-500" />
@@ -832,6 +840,14 @@ export function Layout() {
                 {t('printers.howToEnable', { defaultValue: 'How to enable' })}
               </a>
             </div>
+            <button
+              onClick={handleDismissDevModeWarning}
+              className="ml-4 p-1 rounded hover:bg-orange-500/40 focus:outline-none"
+              aria-label="Dismiss developer mode warning"
+              title="Dismiss"
+            >
+              <X className="w-4 h-4 text-orange-300" />
+            </button>
           </div>
         )}
         {/* Persistent update banner */}


### PR DESCRIPTION
## Description

Make dev mode warning dismissible by adding a button. This setting persists sessions restarts. The idea is that if you do not want to enable Dev mode, the warning is just annoying. 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made
- Added `dismissedDevModeWarning` 
- Copied `dismissUpdateBanner` to maintain consistency

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: H2C

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [ ] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

Can be made to persist only the current session, and get restored after. Might be annoying to do.