### PR TITLE
Add energy cost to archive card

### DIFF
--- a/frontend/src/pages/ArchivesPage.tsx
+++ b/frontend/src/pages/ArchivesPage.tsx
@@ -7,7 +7,7 @@ import {
   Trash2,
   Clock,
   Package,
-  Disc3,
+  Coins,
   Layers,
   Search,
   Filter,
@@ -928,14 +928,16 @@ function ArchiveCard({
             <div className="flex items-center gap-3 text-bambu-gray">
               {archive.cost != null && (
                 <div className="flex items-center gap-1.5">
-                  <Disc3 className="w-3 h-3" />
+                  <Coins className="w-3 h-3" />
                   {currency}{archive.cost.toFixed(2)}
                 </div>
               )}
-              <div className="flex items-center gap-1.5" title={`${t('stats.energyUsed')}: ${archive.energy_kwh?.toFixed(3) || 'N/A'} kWh`}>
-                <Zap className="w-3 h-3" />
-                {currency}{(archive.energy_cost ?? 0).toFixed(2)}
-              </div>
+                {archive.energy_cost != null && (
+                  <div className="flex items-center gap-1.5" title={`${t('stats.energyUsed')}: ${archive.energy_kwh?.toFixed(3) || 'N/A'} kWh`}>
+                    <Zap className="w-3 h-3" />
+                    {currency}{archive.energy_cost.toFixed(2)}
+                  </div>
+                )}
             </div>
           )}
           {(archive.layer_height || archive.total_layers) && (


### PR DESCRIPTION
## Description

Add a UI indicator of energy used for a given print in Archive.

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #539 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

<!-- List the specific changes made in this PR -->

- Added a UI icon besides Filament Cost that displays Energy Cost based on `PrintArchive` `energy_cost`.
- Added on-hover tooltip with energy usage expressed in kWH
- Used existing localization, no new strings added

## Screenshots
<img width="381" height="294" alt="Screenshot 2026-03-02 152338" src="https://github.com/user-attachments/assets/5ab6d997-e9f5-4a7c-8250-df1865aef679" />


## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: H2C

## Checklist

- [x] My code follows the project's coding style
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes
A "Total" field could be added, but given the usually huge difference between filament and energy cist, it might be redundant.
