### PR TITLE
[Fix]: AMS slot modal infinite scroll loop on Windows

### DIFF
--- a/frontend/src/components/ConfigureAmsSlotModal.tsx
+++ b/frontend/src/components/ConfigureAmsSlotModal.tsx
@@ -808,10 +808,11 @@ export function ConfigureAmsSlotModal({
   useEffect(() => {
     if (!isLoading && selectedPresetId && selectedPresetId !== scrolledToRef.current) {
       const raf = requestAnimationFrame(() => {
-        const el = document.querySelector(`[data-preset-id="${CSS.escape(selectedPresetId)}"]`);
+          const modal = document.querySelector('[class*="fixed inset-0 z-50"]');
+          const el = modal?.querySelector(`[data-preset-id="${CSS.escape(selectedPresetId)}"]`);
         if (el) {
           scrolledToRef.current = selectedPresetId;
-          el.scrollIntoView({ block: 'center' });
+          el.scrollIntoView({ block: 'nearest' });
         }
       });
       return () => cancelAnimationFrame(raf);


### PR DESCRIPTION
## Related Issue

Fixes #575 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

Inline callback refs on preset buttons called scrollIntoView on every
re-render, creating a scroll → re-render → scrollIntoView loop on
Windows.
Replace with a useEffect + data attribute approach that only
scrolls when the selected preset actually changes.

**Preselect filament for printer-configured AMS slots**

When an AMS slot was configured directly on the printer (no
savedPresetId), the modal didn't preselect the filament even though
it was in the list. Add a third fallback that matches trayInfoIdx
against the full filteredPresets list (cloud and builtin sources).

## Testing

- [X] I have tested this on my local machine
- [X] I have tested with my printer model: WINDOWS

## Checklist

- [X] My code follows the project's coding style
- [X] I have commented my code where necessary
- [X] I have updated the documentation (if needed)
- [X] My changes generate no new warnings
- [X] I have tested my changes thoroughly
