### PR TITLE
Printer card UI improvements and AMSUnitCard extraction

### DIFF
--- a/frontend/src/__tests__/components/Card.test.tsx
+++ b/frontend/src/__tests__/components/Card.test.tsx
@@ -69,7 +69,8 @@ describe('CardContent', () => {
 
   it('applies padding styling', () => {
     const { container } = render(<CardContent>Content</CardContent>);
-    expect(container.firstChild).toHaveClass('p-6');
+    expect(container.firstChild).toHaveClass('p-3');
+    expect(container.firstChild).toHaveClass('lg:p-6');
   });
 
   it('applies custom className', () => {

--- a/frontend/src/components/AMSUnitCard.tsx
+++ b/frontend/src/components/AMSUnitCard.tsx
@@ -1,0 +1,1015 @@
+import { useTranslation } from 'react-i18next';
+import { MoreVertical, RefreshCw } from 'lucide-react';
+import { FilamentHoverCard, EmptySlotHoverCard } from './FilamentHoverCard';
+import { AMSNameHoverCard } from './AMSNameHoverCard';
+import { useTheme } from '../contexts/ThemeContext';
+import type { AMSUnit, AMSTray, LinkedSpoolInfo, SpoolAssignment, Permission } from '../api/client';
+
+const BAMBU_FILAMENT_COLORS: Record<string, string> = {
+  // PLA Basic (A00)
+  'A00-W1': 'Jade White',
+  'A00-P0': 'Beige',
+  'A00-D2': 'Light Gray',
+  'A00-Y0': 'Yellow',
+  'A00-Y2': 'Sunflower Yellow',
+  'A00-A1': 'Pumpkin Orange',
+  'A00-A0': 'Orange',
+  'A00-Y4': 'Gold',
+  'A00-G3': 'Bright Green',
+  'A00-G1': 'Bambu Green',
+  'A00-G2': 'Mistletoe Green',
+  'A00-R3': 'Hot Pink',
+  'A00-P6': 'Magenta',
+  'A00-R0': 'Red',
+  'A00-R2': 'Maroon Red',
+  'A00-P5': 'Purple',
+  'A00-P2': 'Indigo Purple',
+  'A00-B5': 'Turquoise',
+  'A00-B8': 'Cyan',
+  'A00-B3': 'Cobalt Blue',
+  'A00-N0': 'Brown',
+  'A00-N1': 'Cocoa Brown',
+  'A00-Y3': 'Bronze',
+  'A00-D0': 'Gray',
+  'A00-D1': 'Silver',
+  'A00-B1': 'Blue Grey',
+  'A00-D3': 'Dark Gray',
+  'A00-K0': 'Black',
+  // PLA Basic Gradient (A00-M*)
+  'A00-M3': 'Pink Citrus',
+  'A00-M6': 'Dusk Glare',
+  'A00-M0': 'Arctic Whisper',
+  'A00-M1': 'Solar Breeze',
+  'A00-M5': 'Blueberry Bubblegum',
+  'A00-M4': 'Mint Lime',
+  'A00-M2': 'Ocean to Meadow',
+  'A00-M7': 'Cotton Candy Cloud',
+  // PLA Lite (A18)
+  'A18-K0': 'Black',
+  'A18-D0': 'Gray',
+  'A18-W0': 'White',
+  'A18-R0': 'Red',
+  'A18-Y0': 'Yellow',
+  'A18-B0': 'Cyan',
+  'A18-B1': 'Blue',
+  'A18-P0': 'Matte Beige',
+  // PLA Matte (A01)
+  'A01-W2': 'Ivory White',
+  'A01-W3': 'Bone White',
+  'A01-Y2': 'Lemon Yellow',
+  'A01-A2': 'Mandarin Orange',
+  'A01-P3': 'Sakura Pink',
+  'A01-P4': 'Lilac Purple',
+  'A01-R3': 'Plum',
+  'A01-R1': 'Scarlet Red',
+  'A01-R4': 'Dark Red',
+  'A01-G0': 'Apple Green',
+  'A01-G1': 'Grass Green',
+  'A01-G7': 'Dark Green',
+  'A01-B4': 'Ice Blue',
+  'A01-B0': 'Sky Blue',
+  'A01-B3': 'Marine Blue',
+  'A01-B6': 'Dark Blue',
+  'A01-Y3': 'Desert Tan',
+  'A01-N1': 'Latte Brown',
+  'A01-N3': 'Caramel',
+  'A01-R2': 'Terracotta',
+  'A01-N2': 'Dark Brown',
+  'A01-N0': 'Dark Chocolate',
+  'A01-D3': 'Ash Gray',
+  'A01-D0': 'Nardo Gray',
+  'A01-K1': 'Charcoal',
+  // PLA Glow (A12)
+  'A12-G0': 'Green',
+  'A12-R0': 'Pink',
+  'A12-A0': 'Orange',
+  'A12-Y0': 'Yellow',
+  'A12-B0': 'Blue',
+  // PLA Marble (A07)
+  'A07-R5': 'Red Granite',
+  'A07-D4': 'White Marble',
+  // PLA Aero (A11)
+  'A11-W0': 'White',
+  'A11-K0': 'Black',
+  // PLA Sparkle (A08)
+  'A08-G3': 'Alpine Green Sparkle',
+  'A08-D5': 'Slate Gray Sparkle',
+  'A08-B7': 'Royal Purple Sparkle',
+  'A08-R2': 'Crimson Red Sparkle',
+  'A08-K2': 'Onyx Black Sparkle',
+  'A08-Y1': 'Classic Gold Sparkle',
+  // PLA Metal (A02)
+  'A02-B2': 'Cobalt Blue Metallic',
+  'A02-G2': 'Oxide Green Metallic',
+  'A02-Y1': 'Iridium Gold Metallic',
+  'A02-D2': 'Iron Gray Metallic',
+  // PLA Translucent (A17)
+  'A17-B1': 'Blue',
+  'A17-A0': 'Orange',
+  'A17-P0': 'Purple',
+  // PLA Silk+ (A06)
+  'A06-Y1': 'Gold',
+  'A06-D0': 'Titan Gray',
+  'A06-D1': 'Silver',
+  'A06-W0': 'White',
+  'A06-R0': 'Candy Red',
+  'A06-G0': 'Candy Green',
+  'A06-G1': 'Mint',
+  'A06-B1': 'Blue',
+  'A06-B0': 'Baby Blue',
+  'A06-P0': 'Purple',
+  'A06-R1': 'Rose Gold',
+  'A06-R2': 'Pink',
+  'A06-Y0': 'Champagne',
+  // PLA Silk Multi-Color (A05)
+  'A05-M8': 'Dawn Radiance',
+  'A05-M4': 'Aurora Purple',
+  'A05-M1': 'South Beach',
+  'A05-T3': 'Neon City',
+  'A05-T2': 'Midnight Blaze',
+  'A05-T1': 'Gilded Rose',
+  'A05-T4': 'Blue Hawaii',
+  'A05-T5': 'Velvet Eclipse',
+  // PLA Galaxy (A15)
+  'A15-B0': 'Purple',
+  'A15-G0': 'Green',
+  'A15-G1': 'Nebulae',
+  'A15-R0': 'Brown',
+  // PLA Wood (A16)
+  'A16-K0': 'Black Walnut',
+  'A16-R0': 'Rosewood',
+  'A16-N0': 'Clay Brown',
+  'A16-G0': 'Classic Birch',
+  'A16-W0': 'White Oak',
+  'A16-Y0': 'Ochre Yellow',
+  // PLA-CF (A50)
+  'A50-D6': 'Lava Gray',
+  'A50-K0': 'Black',
+  'A50-B6': 'Royal Blue',
+  // PLA Tough+ (A10)
+  'A10-W0': 'White',
+  'A10-D0': 'Gray',
+  // PLA Tough (A09)
+  'A09-B5': 'Lavender Blue',
+  'A09-B4': 'Light Blue',
+  'A09-A0': 'Orange',
+  'A09-D1': 'Silver',
+  'A09-R3': 'Vermilion Red',
+  'A09-Y0': 'Yellow',
+  // PETG HF (G02)
+  'G02-K0': 'Black',
+  'G02-W0': 'White',
+  'G02-R0': 'Red',
+  'G02-D0': 'Gray',
+  'G02-D1': 'Dark Gray',
+  'G02-Y1': 'Cream',
+  'G02-Y0': 'Yellow',
+  'G02-A0': 'Orange',
+  'G02-N1': 'Peanut Brown',
+  'G02-G1': 'Lime Green',
+  'G02-G0': 'Green',
+  'G02-G2': 'Forest Green',
+  'G02-B1': 'Lake Blue',
+  'G02-B0': 'Blue',
+  // PETG Translucent (G01)
+  'G01-G1': 'Translucent Teal',
+  'G01-B0': 'Translucent Light Blue',
+  'G01-C0': 'Clear',
+  'G01-D0': 'Translucent Gray',
+  'G01-G0': 'Translucent Olive',
+  'G01-N0': 'Translucent Brown',
+  'G01-A0': 'Translucent Orange',
+  'G01-P1': 'Translucent Pink',
+  'G01-P0': 'Translucent Purple',
+  // PETG-CF (G50)
+  'G50-P7': 'Violet Purple',
+  'G50-K0': 'Black',
+  // ABS (B00)
+  'B00-D1': 'Silver',
+  'B00-K0': 'Black',
+  'B00-W0': 'White',
+  'B00-G6': 'Bambu Green',
+  'B00-G7': 'Olive',
+  'B00-Y1': 'Tangerine Yellow',
+  'B00-A0': 'Orange',
+  'B00-R0': 'Red',
+  'B00-B4': 'Azure',
+  'B00-B0': 'Blue',
+  'B00-B6': 'Navy Blue',
+  // ABS-GF (B50)
+  'B50-A0': 'Orange',
+  'B50-K0': 'Black',
+  // ASA (B01)
+  'B01-W0': 'White',
+  'B01-K0': 'Black',
+  'B01-D0': 'Gray',
+  // ASA Aero (B02)
+  'B02-W0': 'White',
+  // PC (C00)
+  'C00-C1': 'Transparent',
+  'C00-C0': 'Clear Black',
+  'C00-K0': 'Black',
+  'C00-W0': 'White',
+  // PC FR (C01)
+  'C01-K0': 'Black',
+  // TPU for AMS (U02)
+  'U02-B0': 'Blue',
+  'U02-D0': 'Gray',
+  'U02-K0': 'Black',
+  // PAHT-CF (N04)
+  'N04-K0': 'Black',
+  // PA6-GF (N08)
+  'N08-K0': 'Black',
+  // Support for PLA/PETG (S02, S05)
+  'S02-W0': 'Nature',
+  'S02-W1': 'White',
+  'S05-C0': 'Black',
+  // Support for ABS (S06)
+  'S06-W0': 'White',
+  // Support for PA/PET (S03)
+  'S03-G1': 'Green',
+  // PVA (S04)
+  'S04-Y0': 'Clear',
+};
+
+// Fallback color codes for unknown material prefixes
+const BAMBU_COLOR_CODE_FALLBACK: Record<string, string> = {
+  'W0': 'White', 'W1': 'Jade White', 'W2': 'Ivory White', 'W3': 'Bone White',
+  'Y0': 'Yellow', 'Y1': 'Gold', 'Y2': 'Sunflower Yellow', 'Y3': 'Bronze', 'Y4': 'Gold',
+  'A0': 'Orange', 'A1': 'Pumpkin Orange', 'A2': 'Mandarin Orange',
+  'R0': 'Red', 'R1': 'Scarlet Red', 'R2': 'Maroon Red', 'R3': 'Hot Pink', 'R4': 'Dark Red', 'R5': 'Red Granite',
+  'P0': 'Beige', 'P1': 'Pink', 'P2': 'Indigo Purple', 'P3': 'Sakura Pink', 'P4': 'Lilac Purple', 'P5': 'Purple', 'P6': 'Magenta', 'P7': 'Violet Purple',
+  'B0': 'Blue', 'B1': 'Blue Grey', 'B2': 'Cobalt Blue', 'B3': 'Cobalt Blue', 'B4': 'Ice Blue', 'B5': 'Turquoise', 'B6': 'Navy Blue', 'B7': 'Royal Purple', 'B8': 'Cyan',
+  'G0': 'Green', 'G1': 'Grass Green', 'G2': 'Mistletoe Green', 'G3': 'Bright Green', 'G6': 'Bambu Green', 'G7': 'Dark Green',
+  'N0': 'Brown', 'N1': 'Peanut Brown', 'N2': 'Dark Brown', 'N3': 'Caramel',
+  'D0': 'Gray', 'D1': 'Silver', 'D2': 'Light Gray', 'D3': 'Dark Gray', 'D4': 'White Marble', 'D5': 'Slate Gray', 'D6': 'Lava Gray',
+  'K0': 'Black', 'K1': 'Charcoal', 'K2': 'Onyx Black',
+  'C0': 'Clear Black', 'C1': 'Transparent',
+  'M0': 'Arctic Whisper', 'M1': 'Solar Breeze', 'M2': 'Ocean to Meadow', 'M3': 'Pink Citrus', 'M4': 'Aurora Purple', 'M5': 'Blueberry Bubblegum', 'M6': 'Dusk Glare', 'M7': 'Cotton Candy Cloud', 'M8': 'Dawn Radiance',
+  'T1': 'Gilded Rose', 'T2': 'Midnight Blaze', 'T3': 'Neon City', 'T4': 'Blue Hawaii', 'T5': 'Velvet Eclipse',
+};
+
+// Get color name from Bambu Lab tray_id_name (e.g., "A00-Y2" -> "Sunflower Yellow")
+function getBambuColorName(trayIdName: string | null | undefined): string | null {
+  if (!trayIdName) return null;
+
+  // First try exact match with full tray_id_name
+  if (BAMBU_FILAMENT_COLORS[trayIdName]) {
+    return BAMBU_FILAMENT_COLORS[trayIdName];
+  }
+
+  // Fall back to color code suffix lookup for unknown material prefixes
+  const parts = trayIdName.split('-');
+  if (parts.length < 2) return null;
+  const colorCode = parts[1];
+  return BAMBU_COLOR_CODE_FALLBACK[colorCode] || null;
+}
+
+// Convert hex color to basic color name
+function hexToBasicColorName(hex: string | null | undefined): string {
+  if (!hex || hex.length < 6) return 'Unknown';
+
+  // Parse RGB from hex (format: RRGGBBAA or RRGGBB)
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  // Calculate HSL for better color classification
+  const max = Math.max(r, g, b) / 255;
+  const min = Math.min(r, g, b) / 255;
+  const l = (max + min) / 2;
+
+  let h = 0;
+  let s = 0;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    const rNorm = r / 255;
+    const gNorm = g / 255;
+    const bNorm = b / 255;
+
+    if (max === rNorm) {
+      h = ((gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0)) / 6;
+    } else if (max === gNorm) {
+      h = ((bNorm - rNorm) / d + 2) / 6;
+    } else {
+      h = ((rNorm - gNorm) / d + 4) / 6;
+    }
+  }
+
+  // Convert to degrees
+  h = h * 360;
+
+  // Classify by lightness first
+  if (l < 0.15) return 'Black';
+  if (l > 0.85) return 'White';
+
+  // Low saturation = gray
+  if (s < 0.15) {
+    if (l < 0.4) return 'Dark Gray';
+    if (l > 0.6) return 'Light Gray';
+    return 'Gray';
+  }
+
+  // Classify by hue
+  // Brown is orange/yellow hue with lower lightness
+  if (h >= 15 && h < 45 && l < 0.45) return 'Brown';
+  if (h >= 45 && h < 70 && l < 0.40) return 'Brown';
+
+  if (h < 15 || h >= 345) return 'Red';
+  if (h < 45) return 'Orange';
+  if (h < 70) return 'Yellow';
+  if (h < 150) return 'Green';
+  if (h < 200) return 'Cyan';
+  if (h < 260) return 'Blue';
+  if (h < 290) return 'Purple';
+  return 'Pink';
+}
+
+// Format K value with 3 decimal places, default to 0.020 if null
+function formatKValue(k: number | null | undefined): string {
+  const value = k ?? 0.020;
+  return value.toFixed(3);
+}
+
+// Nozzle side indicators (Bambu Lab style - square badge with L/R)
+function NozzleBadge({ side }: { side: 'L' | 'R' }) {
+  const { mode } = useTheme();
+  // Light mode: #e7f5e9 (light green), Dark mode: #1a4d2e (dark green)
+  const bgColor = mode === 'dark' ? '#1a4d2e' : '#e7f5e9';
+  return (
+    <span
+      className="inline-flex items-center justify-center w-4 h-4 text-[10px] font-bold rounded"
+      style={{ backgroundColor: bgColor, color: '#00ae42' }}
+    >
+      {side}
+    </span>
+  );
+}
+
+/**
+ * Check if a tray contains a Bambu Lab spool (RFID-tagged).
+ * Only checks hardware identifiers (tray_uuid, tag_uid) — NOT tray_info_idx,
+ * which is a filament profile/preset ID that third-party spools also get when
+ * the user selects a generic Bambu preset (e.g. "GFA00" for Generic PLA).
+ */
+function isBambuLabSpool(tray: {
+  tray_uuid?: string | null;
+  tag_uid?: string | null;
+} | null | undefined): boolean {
+  if (!tray) return false;
+
+  // Check tray_uuid (32 hex chars, non-zero)
+  if (tray.tray_uuid && tray.tray_uuid !== '00000000000000000000000000000000') {
+    return true;
+  }
+
+  // Check tag_uid (16 hex chars, non-zero)
+  if (tray.tag_uid && tray.tag_uid !== '0000000000000000') {
+    return true;
+  }
+
+  return false;
+}
+
+// Get AMS label: AMS-A/B/C/D for regular AMS, HT-A/B for AMS-HT (single spool)
+// Always use tray count as the source of truth (1 tray = AMS-HT, 4 trays = regular AMS)
+// AMS-HT uses IDs 128+ while regular AMS uses 0-3
+function getAmsLabel(amsId: number | string, trayCount: number): string {
+  // Ensure amsId is a number (backend might send string)
+  const id = typeof amsId === 'string' ? parseInt(amsId, 10) : amsId;
+  const safeId = isNaN(id) ? 0 : id;
+  const isHt = trayCount === 1;
+  // AMS-HT uses IDs starting at 128, regular AMS uses 0-3
+  const normalizedId = safeId >= 128 ? safeId - 128 : safeId;
+  const letter = String.fromCharCode(65 + normalizedId); // 0=A, 1=B, 2=C, 3=D
+  return isHt ? `HT-${letter}` : `AMS-${letter}`;
+}
+
+// Get fill bar color based on spool fill level
+function getFillBarColor(fillLevel: number): string {
+  if (fillLevel > 50) return '#00ae42'; // Green - good
+  if (fillLevel >= 15) return '#f59e0b'; // Amber - warning (<= 50%)
+  return '#ef4444'; // Red - critical (< 15%)
+}
+
+// Calculate fill level from Spoolman weight data (used as fallback when AMS reports 0%)
+function getSpoolmanFillLevel(
+  linkedSpool: LinkedSpoolInfo | undefined
+): number | null {
+  if (!linkedSpool?.remaining_weight || !linkedSpool?.filament_weight
+    || linkedSpool.filament_weight <= 0) return null;
+  return Math.min(100, Math.round(
+    (linkedSpool.remaining_weight / linkedSpool.filament_weight) * 100
+  ));
+}
+
+// Water drop SVG - empty outline (Bambu Lab style from bambu-humidity)
+function WaterDropEmpty({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 36 54" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M17.8131 0.00538C18.4463 -0.15091 20.3648 3.14642 20.8264 3.84781C25.4187 10.816 35.3089 26.9368 35.9383 34.8694C37.4182 53.5822 11.882 61.3357 2.53721 45.3789C-1.73471 38.0791 0.016 32.2049 3.178 25.0232C6.99221 16.3662 12.6411 7.90372 17.8131 0.00538ZM18.3738 7.24807L17.5881 7.48441C14.4452 12.9431 10.917 18.2341 8.19369 23.9368C4.6808 31.29 1.18317 38.5479 7.69403 45.5657C17.3058 55.9228 34.9847 46.8808 31.4604 32.8681C29.2558 24.0969 22.4207 15.2913 18.3776 7.24807H18.3738Z" fill="#C3C2C1" />
+    </svg>
+  );
+}
+
+// Water drop SVG - half filled with blue water (Bambu Lab style from bambu-humidity)
+function WaterDropHalf({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 35 53" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M17.3165 0.0038C17.932 -0.14959 19.7971 3.08645 20.2458 3.77481C24.7103 10.6135 34.3251 26.4346 34.937 34.2198C36.3757 52.5848 11.5505 60.1942 2.46584 44.534C-1.68714 37.3735 0.0148 31.6085 3.08879 24.5603C6.79681 16.0605 12.2884 7.75907 17.3165 0.0038ZM17.8615 7.11561L17.0977 7.34755C14.0423 12.7048 10.6124 17.8974 7.96483 23.4941C4.54975 30.7107 1.14949 37.8337 7.47908 44.721C16.8233 54.8856 34.01 46.0117 30.5838 32.2595C28.4405 23.6512 21.7957 15.0093 17.8652 7.11561H17.8615Z" fill="#C3C2C1" />
+      <path d="M5.03547 30.112C9.64453 30.4936 11.632 35.7985 16.4154 35.791C19.6339 35.7873 20.2161 33.2283 22.3853 31.6197C31.6776 24.7286 33.5835 37.4894 27.9881 44.4254C18.1878 56.5653 -1.16063 44.6013 5.03917 30.1158L5.03547 30.112Z" fill="#1F8FEB" />
+    </svg>
+  );
+}
+
+// Water drop SVG - fully filled with blue water (Bambu Lab style from bambu-humidity)
+function WaterDropFull({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 36 54" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M17.9625 4.48059L4.77216 26.3154L2.08228 40.2175L10.0224 50.8414H23.1594L33.3246 42.1693V30.2455L17.9625 4.48059Z" fill="#1F8FEB" />
+      <path d="M17.7948 0.00538C18.4273 -0.15091 20.3438 3.14642 20.8048 3.84781C25.3921 10.816 35.2715 26.9368 35.9001 34.8694C37.3784 53.5822 11.8702 61.3357 2.53562 45.3789C-1.73163 38.0829 0.0134 32.2087 3.1757 25.027C6.98574 16.3662 12.6284 7.90372 17.7948 0.00538ZM18.3549 7.24807L17.57 7.48441C14.4306 12.9431 10.9063 18.2341 8.1859 23.9368C4.67686 31.29 1.18305 38.5479 7.68679 45.5657C17.2881 55.9228 34.9476 46.8808 31.4271 32.8681C29.2249 24.0969 22.3974 15.2913 18.3587 7.24807H18.3549Z" fill="#C3C2C1" />
+    </svg>
+  );
+}
+
+// Humidity indicator with water drop that fills based on level (Bambu Lab style)
+// Reference: https://github.com/theicedmango/bambu-humidity
+interface HumidityIndicatorProps {
+  humidity: number | string;
+  goodThreshold?: number;  // <= this is green
+  fairThreshold?: number;  // <= this is orange, > is red
+  onClick?: () => void;
+  compact?: boolean;  // Smaller version for grid layout
+}
+
+function HumidityIndicator({ humidity, goodThreshold = 40, fairThreshold = 60, onClick, compact }: HumidityIndicatorProps) {
+  const humidityValue = typeof humidity === 'string' ? parseInt(humidity, 10) : humidity;
+  const good = typeof goodThreshold === 'number' ? goodThreshold : 40;
+  const fair = typeof fairThreshold === 'number' ? fairThreshold : 60;
+
+  // Status thresholds (configurable via settings)
+  // Good: ≤goodThreshold (green #22a352), Fair: ≤fairThreshold (gold #d4a017), Bad: >fairThreshold (red #c62828)
+  let textColor: string;
+  let statusText: string;
+
+  if (isNaN(humidityValue)) {
+    textColor = '#C3C2C1';
+    statusText = 'Unknown';
+  } else if (humidityValue <= good) {
+    textColor = '#22a352'; // Green - Good
+    statusText = 'Good';
+  } else if (humidityValue <= fair) {
+    textColor = '#d4a017'; // Gold - Fair
+    statusText = 'Fair';
+  } else {
+    textColor = '#c62828'; // Red - Bad
+    statusText = 'Bad';
+  }
+
+  // Fill level based on status: Good=Empty (dry), Fair=Half, Bad=Full (wet)
+  let DropComponent: React.FC<{ className?: string }>;
+  if (isNaN(humidityValue)) {
+    DropComponent = WaterDropEmpty;
+  } else if (humidityValue <= good) {
+    DropComponent = WaterDropEmpty; // Good - empty drop (dry)
+  } else if (humidityValue <= fair) {
+    DropComponent = WaterDropHalf; // Fair - half filled
+  } else {
+    DropComponent = WaterDropFull; // Bad - full (too humid)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1 ${onClick ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}`}
+      title={`Humidity: ${humidityValue}% - ${statusText}${onClick ? ' (click for history)' : ''}`}
+    >
+      <DropComponent className={compact ? "w-2.5 h-3" : "w-3 h-4"} />
+      <span className={`font-medium tabular-nums ${compact ? 'text-[10px]' : 'text-xs'}`} style={{ color: textColor }}>{humidityValue}%</span>
+    </button>
+  );
+}
+
+// Thermometer SVG - empty outline
+function ThermometerEmpty({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke="#C3C2C1" strokeWidth="1" fill="none" />
+      <circle cx="6" cy="15" r="2.5" stroke="#C3C2C1" strokeWidth="1" fill="none" />
+    </svg>
+  );
+}
+
+// Thermometer SVG - half filled (gold - same as humidity fair)
+function ThermometerHalf({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="4.5" y="8" width="3" height="4.5" fill="#d4a017" rx="0.5" />
+      <circle cx="6" cy="15" r="2" fill="#d4a017" />
+      <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke="#C3C2C1" strokeWidth="1" fill="none" />
+    </svg>
+  );
+}
+
+// Thermometer SVG - fully filled (red - same as humidity bad)
+function ThermometerFull({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="4.5" y="3" width="3" height="9.5" fill="#c62828" rx="0.5" />
+      <circle cx="6" cy="15" r="2" fill="#c62828" />
+      <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke="#C3C2C1" strokeWidth="1" fill="none" />
+    </svg>
+  );
+}
+
+// Temperature indicator with dynamic icon and coloring
+interface TemperatureIndicatorProps {
+  temp: number;
+  goodThreshold?: number;  // <= this is blue
+  fairThreshold?: number;  // <= this is orange, > is red
+  onClick?: () => void;
+  compact?: boolean;  // Smaller version for grid layout
+}
+
+function TemperatureIndicator({ temp, goodThreshold = 28, fairThreshold = 35, onClick, compact }: TemperatureIndicatorProps) {
+  // Ensure thresholds are numbers
+  const good = typeof goodThreshold === 'number' ? goodThreshold : 28;
+  const fair = typeof fairThreshold === 'number' ? fairThreshold : 35;
+
+  let textColor: string;
+  let statusText: string;
+  let ThermoComponent: React.FC<{ className?: string }>;
+
+  if (temp <= good) {
+    textColor = '#22a352'; // Green - good (same as humidity)
+    statusText = 'Good';
+    ThermoComponent = ThermometerEmpty;
+  } else if (temp <= fair) {
+    textColor = '#d4a017'; // Gold - fair (same as humidity)
+    statusText = 'Fair';
+    ThermoComponent = ThermometerHalf;
+  } else {
+    textColor = '#c62828'; // Red - bad (same as humidity)
+    statusText = 'Bad';
+    ThermoComponent = ThermometerFull;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1 ${onClick ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}`}
+      title={`Temperature: ${temp}°C - ${statusText}${onClick ? ' (click for history)' : ''}`}
+    >
+      <ThermoComponent className={compact ? "w-2.5 h-3" : "w-3 h-4"} />
+      <span className={`tabular-nums text-right ${compact ? 'text-[10px] w-8' : 'w-12'}`} style={{ color: textColor }}>{temp}°C</span>
+    </button>
+  );
+}
+
+interface AMSUnitCardProps {
+  ams: AMSUnit;
+  isDualNozzle: boolean;
+  amsExtruderMap: Record<string, number>;
+  effectiveTrayNow: number | null | undefined;
+  filamentInfo?: Record<string, { name: string; k: number | null }>;
+  slotPresets?: Record<number, { preset_id: string; preset_name: string }>;
+  amsThresholds?: {
+    humidityGood: number;
+    humidityFair: number;
+    tempGood: number;
+    tempFair: number;
+  };
+  printerId: number;
+  printerState?: string | null;
+  // Spoolman
+  spoolmanEnabled: boolean;
+  hasUnlinkedSpools: boolean;
+  linkedSpools?: Record<string, LinkedSpoolInfo>;
+  spoolmanUrl?: string | null | undefined;
+  // Inventory
+  onGetAssignment?: (printerId: number, amsId: number, trayId: number) => SpoolAssignment | undefined;
+  onUnassignSpool?: (printerId: number, amsId: number, trayId: number) => void;
+  // Slot menu state
+  amsSlotMenu: { amsId: number; slotId: number } | null;
+  setAmsSlotMenu: (menu: { amsId: number; slotId: number } | null) => void;
+  // Refreshing
+  refreshingSlot: { amsId: number; slotId: number } | null;
+  onRefreshSlot: (amsId: number, slotId: number) => void;
+  // Permissions
+  hasPermission: (permission: Permission) => boolean;
+  // Modal openers
+  onOpenAmsHistory: (amsId: number, amsLabel: string, mode: 'humidity' | 'temperature') => void;
+  onOpenLinkSpool: (tagUid: string, trayUuid: string, printerId: number, amsId: number, trayId: number) => void;
+  onOpenAssignSpool: (printerId: number, amsId: number, trayId: number, trayInfo: { type: string; color: string; location: string }) => void;
+  onOpenConfigureSlot: (config: {
+    amsId: number;
+    trayId: number;
+    trayCount: number;
+    trayType?: string;
+    trayColor?: string;
+    traySubBrands?: string;
+    trayInfoIdx?: string;
+    extruderId?: number;
+    caliIdx?: number | null;
+    savedPresetId?: string;
+  }) => void;
+  // AMS labels
+  amsLabels?: Record<number, string>;
+  onAmsLabelSaved: () => void;
+}
+
+export function AMSUnitCard({
+  ams,
+  isDualNozzle,
+  amsExtruderMap,
+  effectiveTrayNow,
+  filamentInfo,
+  slotPresets,
+  amsThresholds,
+  printerId,
+  printerState,
+  spoolmanEnabled,
+  hasUnlinkedSpools,
+  linkedSpools,
+  spoolmanUrl,
+  onGetAssignment,
+  onUnassignSpool,
+  amsSlotMenu,
+  setAmsSlotMenu,
+  refreshingSlot,
+  onRefreshSlot,
+  hasPermission,
+  onOpenAmsHistory,
+  onOpenLinkSpool,
+  onOpenAssignSpool,
+  onOpenConfigureSlot,
+  amsLabels,
+  onAmsLabelSaved,
+}: AMSUnitCardProps) {
+  const { t } = useTranslation();
+  const amsLabel = getAmsLabel(ams.id, ams.tray.length);
+  const isExternal = ams.id === 255
+  const isHt = ams.tray.length <= 1 && !isExternal;
+  const isSingleSlot = isHt || isExternal;
+  const mappedExtruderId = amsExtruderMap[String(ams.id)];
+
+  // Resolve tray, slot index, and global tray ID per tray entry
+  const resolveSlotInfo = (tray: AMSTray | undefined, arrayIdx: number) => {
+    if (isExternal) {
+      const extTrayId = tray?.id ?? 254;
+      const slotTrayId = extTrayId - 254; // 0 or 1
+      return { tray, slotIdx: slotTrayId, globalTrayId: extTrayId, slotPresetKey: 255 * 4 + slotTrayId };
+    }
+    if (isHt) {
+      const htTray = ams.tray[0];
+      const htSlotId = htTray?.id ?? 0;
+      return { tray: htTray, slotIdx: htSlotId, globalTrayId: ams.id * 4 + htSlotId, slotPresetKey: ams.id * 4 + htSlotId };
+    }
+    const slotIdx = arrayIdx;
+    const resolved = ams.tray[slotIdx] || ams.tray.find(t => t.id === slotIdx);
+    const globalTrayId = ams.id * 4 + slotIdx;
+    return { tray: resolved, slotIdx, globalTrayId, slotPresetKey: globalTrayId };
+  };
+
+  // For external: iterate sorted trays; for HT: single tray; for regular: 4 slots
+  const slotEntries = isExternal
+    ? [...ams.tray].sort((a, b) => (a.id ?? 254) - (b.id ?? 254))
+    : isHt
+      ? [ams.tray[0]]
+      : [undefined, undefined, undefined, undefined]; // placeholders for [0,1,2,3]
+
+  const renderSlot = (trayEntry: AMSTray | undefined, arrayIdx: number) => {
+    const { tray, slotIdx, globalTrayId, slotPresetKey } = resolveSlotInfo(trayEntry, arrayIdx);
+    const hasFillLevel = tray?.tray_type && tray.remain >= 0;
+    const isEmpty = !tray?.tray_type;
+    const isActive = effectiveTrayNow === globalTrayId;
+    const cloudInfo = tray?.tray_info_idx ? filamentInfo?.[tray.tray_info_idx] : null;
+    const slotPreset = slotPresets?.[slotPresetKey];
+
+    // Fill level fallback chain
+    const trayTag = tray?.tray_uuid?.toUpperCase();
+    const linkedSpool = trayTag ? linkedSpools?.[trayTag] : undefined;
+    const spoolmanFill = getSpoolmanFillLevel(linkedSpool);
+    const inventoryAssignment = onGetAssignment?.(printerId, ams.id, slotIdx);
+    const inventoryFill = (() => {
+      const sp = inventoryAssignment?.spool;
+      if (sp && sp.label_weight > 0 && sp.weight_used > 0) {
+        return Math.round(Math.max(0, sp.label_weight - sp.weight_used) / sp.label_weight * 100);
+      }
+      return null;
+    })();
+
+    // External spools have no AMS remain; regular/HT use AMS remain as primary
+    const effectiveFill = isExternal
+      ? (spoolmanFill ?? inventoryFill ?? null)
+      : (hasFillLevel && tray.remain > 0
+        ? tray.remain
+        : (spoolmanFill ?? inventoryFill ?? (hasFillLevel ? tray.remain : null)));
+    const fillSource = (hasFillLevel && tray.remain === 0 && (spoolmanFill !== null || inventoryFill !== null))
+      ? (spoolmanFill !== null ? 'spoolman' as const : 'inventory' as const)
+      : 'ams' as const;
+
+    // Build filament data for hover card
+    const filamentData = tray?.tray_type ? {
+      vendor: (isBambuLabSpool(tray) ? 'Bambu Lab' : 'Generic') as 'Bambu Lab' | 'Generic',
+      profile: cloudInfo?.name || slotPreset?.preset_name || tray.tray_sub_brands || tray.tray_type,
+      colorName: getBambuColorName(tray.tray_id_name) || hexToBasicColorName(tray.tray_color),
+      colorHex: tray.tray_color || null,
+      kFactor: formatKValue(tray.k),
+      fillLevel: effectiveFill,
+      trayUuid: tray.tray_uuid || null,
+      tagUid: tray.tag_uid || null,
+      fillSource,
+    } : null;
+
+    // For external empty trays, filamentData is set but we need to know it's truly empty
+    const hasFilament = isExternal ? !isEmpty : !!filamentData;
+
+    const isRefreshing = refreshingSlot?.amsId === ams.id &&
+      refreshingSlot?.slotId === slotIdx;
+
+    // Nozzle label for external dual-nozzle slots
+    const extNozzleLabel = isExternal && isDualNozzle
+      ? ((tray?.id ?? 254) === 254 ? t('printers.extL') : t('printers.extR'))
+      : '';
+
+    // Location label for assign spool modal
+    const locationLabel = isExternal
+      ? (extNozzleLabel || t('printers.external'))
+      : isHt
+        ? getAmsLabel(ams.id, ams.tray.length)
+        : `${getAmsLabel(ams.id, ams.tray.length)} Slot ${slotIdx + 1}`;
+
+    // ExtruderId for configure slot
+    const configExtruderId = isExternal
+      ? (isDualNozzle ? ((tray?.id ?? 254) === 254 ? 1 : 0) : undefined)
+      : mappedExtruderId;
+
+    const slotVisual = (
+      <div
+        className={`bg-bambu-dark-tertiary rounded p-1 text-center ${isEmpty ? 'opacity-50' : ''} ${isActive ? `${isSingleSlot ? 'ring-2' : 'ring-1'} ring-bambu-green ring-offset-1 ring-offset-bambu-dark` : ''}`}
+      >
+        <div
+          className="w-3.5 h-3.5 rounded-full mx-auto mb-0.5 border-2"
+          style={{
+            backgroundColor: tray?.tray_color ? `#${tray.tray_color}` : (tray?.tray_type ? '#333' : 'transparent'),
+            borderColor: isEmpty ? '#666' : 'rgba(255,255,255,0.1)',
+            borderStyle: isEmpty ? 'dashed' : 'solid',
+          }}
+        />
+        <div className={`text-[9px] font-bold truncate ${isExternal && isEmpty ? 'text-white/40' : 'text-white'}`}>
+          {tray?.tray_type || '—'}
+        </div>
+        {/* Fill bar */}
+        <div className="mt-1 h-1.5 bg-black/30 rounded-full overflow-hidden">
+          {effectiveFill !== null && effectiveFill >= 0 && (isSingleSlot || tray) && !isEmpty ? (
+            <div
+              className="h-full rounded-full transition-all"
+              style={{
+                width: `${effectiveFill}%`,
+                backgroundColor: getFillBarColor(effectiveFill),
+              }}
+            />
+          ) : (tray?.tray_type && !isEmpty) ? (
+            <div className="h-full w-full rounded-full bg-white/50 dark:bg-gray-500/40" />
+          ) : null}
+        </div>
+      </div>
+    );
+
+    return (
+      <div key={isExternal ? (tray?.id ?? arrayIdx) : slotIdx} className={`relative group ${isSingleSlot && !isExternal ? 'flex-1 min-w-0' : ''}`}>
+        {/* Loading overlay during RFID re-read */}
+        {!isExternal && isRefreshing && (
+          <div className="absolute inset-0 bg-bambu-dark-tertiary/80 rounded flex items-center justify-center z-20">
+            <RefreshCw className="w-4 h-4 text-bambu-green animate-spin" />
+          </div>
+        )}
+        {/* Menu button - appears on hover, hidden when printer busy (not for external spools) */}
+        {!isExternal && printerState !== 'RUNNING' && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setAmsSlotMenu(
+                amsSlotMenu?.amsId === ams.id && amsSlotMenu?.slotId === slotIdx
+                  ? null
+                  : { amsId: ams.id, slotId: slotIdx }
+              );
+            }}
+            className="absolute -top-1 -right-1 w-4 h-4 bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10 hover:bg-bambu-dark-tertiary"
+            title={t('printers.slotOptions')}
+          >
+            <MoreVertical className="w-2.5 h-2.5 text-bambu-gray" />
+          </button>
+        )}
+        {/* Dropdown menu (not for external spools) */}
+        {!isExternal && printerState !== 'RUNNING' && amsSlotMenu?.amsId === ams.id && amsSlotMenu?.slotId === slotIdx && (
+          <div className="absolute top-full left-0 mt-1 z-50 bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-lg shadow-xl py-1 min-w-[120px]">
+            <button
+              className={`w-full px-3 py-1.5 text-left text-xs flex items-center gap-2 ${hasPermission('printers:ams_rfid')
+                ? 'text-white hover:bg-bambu-dark-tertiary'
+                : 'text-bambu-gray/50 cursor-not-allowed'
+                }`}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!hasPermission('printers:ams_rfid')) return;
+                onRefreshSlot(ams.id, slotIdx);
+                setAmsSlotMenu(null);
+              }}
+              disabled={isRefreshing || !hasPermission('printers:ams_rfid')}
+              title={!hasPermission('printers:ams_rfid') ? t('printers.permission.noAmsRfid') : undefined}
+            >
+              <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+              {t('printers.rfid.reread')}
+            </button>
+          </div>
+        )}
+        {/* Hover card wraps only the visual content */}
+        {hasFilament && filamentData ? (
+          <FilamentHoverCard
+            data={filamentData}
+            spoolman={{
+              enabled: spoolmanEnabled,
+              hasUnlinkedSpools,
+              linkedSpoolId: filamentData.trayUuid ? linkedSpools?.[filamentData.trayUuid.toUpperCase()]?.id : undefined,
+              spoolmanUrl,
+              onLinkSpool: spoolmanEnabled && filamentData.trayUuid ? (uuid) => {
+                onOpenLinkSpool(
+                  filamentData.tagUid || '',
+                  uuid,
+                  printerId,
+                  ams.id,
+                  slotIdx,
+                );
+              } : undefined,
+            }}
+            inventory={spoolmanEnabled ? undefined : (() => {
+              const assignment = onGetAssignment?.(printerId, ams.id, slotIdx);
+              return {
+                assignedSpool: assignment?.spool ? {
+                  id: assignment.spool.id,
+                  material: assignment.spool.material,
+                  brand: assignment.spool.brand,
+                  color_name: assignment.spool.color_name,
+                  remainingWeightGrams: assignment.spool.label_weight > 0
+                    ? Math.max(0, assignment.spool.label_weight - assignment.spool.weight_used)
+                    : null,
+                } : null,
+                onAssignSpool: (isExternal || filamentData.vendor !== 'Bambu Lab') ? () => onOpenAssignSpool(
+                  printerId,
+                  ams.id,
+                  slotIdx,
+                  {
+                    type: filamentData.profile,
+                    color: filamentData.colorHex || '',
+                    location: locationLabel,
+                  },
+                ) : undefined,
+                onUnassignSpool: assignment && (isExternal || filamentData.vendor !== 'Bambu Lab') ? () => onUnassignSpool?.(printerId, ams.id, slotIdx) : undefined,
+              };
+            })()}
+            configureSlot={{
+              enabled: hasPermission('printers:control'),
+              onConfigure: () => onOpenConfigureSlot({
+                amsId: ams.id,
+                trayId: slotIdx,
+                trayCount: isExternal ? 1 : ams.tray.length,
+                trayType: tray?.tray_type || undefined,
+                trayColor: tray?.tray_color || undefined,
+                traySubBrands: tray?.tray_sub_brands || undefined,
+                trayInfoIdx: tray?.tray_info_idx || undefined,
+                extruderId: configExtruderId,
+                caliIdx: tray?.cali_idx,
+                savedPresetId: slotPreset?.preset_id,
+              }),
+            }}
+          >
+            {slotVisual}
+          </FilamentHoverCard>
+        ) : (
+          <EmptySlotHoverCard
+            configureSlot={{
+              enabled: hasPermission('printers:control'),
+              onConfigure: () => onOpenConfigureSlot({
+                amsId: ams.id,
+                trayId: slotIdx,
+                trayCount: isExternal ? 1 : ams.tray.length,
+                extruderId: configExtruderId,
+              }),
+            }}
+          >
+            {slotVisual}
+          </EmptySlotHoverCard>
+        )}
+      </div>
+    );
+  };
+
+  const statsIndicators = (vertical?: boolean) => (
+    (ams.humidity != null || ams.temp != null) ? (
+      <div className={`flex ${vertical ? 'flex-col' : 'items-center'} gap-1.5 ${vertical ? 'shrink-0' : ''}`}>
+        {ams.humidity != null && (
+          <HumidityIndicator
+            humidity={ams.humidity}
+            goodThreshold={amsThresholds?.humidityGood}
+            fairThreshold={amsThresholds?.humidityFair}
+            onClick={() => onOpenAmsHistory(
+              ams.id,
+              getAmsLabel(ams.id, ams.tray.length),
+              'humidity',
+            )}
+            compact
+          />
+        )}
+        {ams.temp != null && (
+          <TemperatureIndicator
+            temp={ams.temp}
+            goodThreshold={amsThresholds?.tempGood}
+            fairThreshold={amsThresholds?.tempFair}
+            onClick={() => onOpenAmsHistory(
+              ams.id,
+              getAmsLabel(ams.id, ams.tray.length),
+              'temperature',
+            )}
+            compact
+          />
+        )}
+      </div>
+    ) : null
+  );
+
+  const labelAndNozzle = (
+    <div className="flex items-center gap-1.5">
+      {isExternal ? (
+        <span className="text-[10px] text-white font-medium">EXT</span>
+      ) : (
+        <AMSNameHoverCard
+          ams={ams}
+          printerId={printerId}
+          label={amsLabel}
+          amsLabels={amsLabels}
+          canEdit={hasPermission('printers:update')}
+          onSaved={onAmsLabelSaved}
+        >
+          <span className="text-[10px] text-white font-medium cursor-default">
+            {amsLabels?.[ams.id] || amsLabel}
+          </span>
+        </AMSNameHoverCard>
+      )}
+      {isDualNozzle && !isExternal && (
+        <NozzleBadge side={mappedExtruderId === 1 ? 'L' : 'R'} />
+      )}
+      {isDualNozzle && isExternal && ams.tray.map(t => (
+        <NozzleBadge key={t.id ?? 254} side={(t.id ?? 254) === 254 ? 'R' : 'L'} />
+      ))}
+    </div>
+  );
+
+  // External spools card
+  if (isExternal) {
+    const trayCount = ams.tray.length;
+    return (
+      <div className={`p-2.5 bg-bambu-dark rounded-lg border border-bambu-dark-tertiary/30 ${trayCount === 1 ? 'flex-[1] min-w-[50px] max-w-[100px]' : 'flex-[2] min-w-[100px] max-w-[100px]'}`}>
+        <div className="flex items-center gap-1 mb-2">
+          {labelAndNozzle}
+        </div>
+        <div className={`grid ${trayCount > 1 ? 'grid-cols-2' : 'grid-cols-1'} gap-1.5`}>
+          {slotEntries.map((tray, i) => renderSlot(tray, i))}
+        </div>
+      </div>
+    );
+  }
+
+  // HT AMS card (single slot)
+  if (isHt) {
+    return (
+      <div className="flex-[2] min-w-[120px] p-2.5 bg-bambu-dark rounded-lg border border-bambu-dark-tertiary/30">
+        <div className="flex items-center justify-between mb-2 flex-wrap gap-1">
+          {labelAndNozzle}
+          <div className="flex gap-1.5 w-full">
+            {slotEntries.map((tray, i) => renderSlot(tray, i))}
+            {statsIndicators(true)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Regular AMS card (4 slots)
+  return (
+    <div className="flex-[4] min-w-[180px] p-2.5 bg-bambu-dark rounded-lg border border-bambu-dark-tertiary/30">
+      <div className="flex items-center justify-between mb-2">
+        {labelAndNozzle}
+        {statsIndicators()}
+      </div>
+      <div className="grid grid-cols-4 gap-1.5">
+        {slotEntries.map((tray, i) => renderSlot(tray, i))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/AmsNameHoverCard.tsx
+++ b/frontend/src/components/AmsNameHoverCard.tsx
@@ -1,0 +1,198 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { api } from '../api/client';
+import type { AMSUnit } from '../api/client';
+
+export function AMSNameHoverCard({
+  ams,
+  printerId,
+  label,
+  amsLabels,
+  canEdit,
+  onSaved,
+  children,
+}: {
+  ams: AMSUnit;
+  printerId: number;
+  label: string;           // auto-generated label, e.g. "AMS-A"
+  amsLabels?: Record<number, string>;
+  canEdit: boolean;
+  onSaved: () => void;
+  children: React.ReactNode;
+}) {
+  const { t } = useTranslation();
+  const [isVisible, setIsVisible] = useState(false);
+  const [position, setPosition] = useState<'top' | 'bottom'>('top');
+  const [editValue, setEditValue] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (isVisible) {
+      setEditValue(amsLabels?.[ams.id] ?? '');
+      setSaveError(null);
+      requestAnimationFrame(() => {
+        if (triggerRef.current && cardRef.current) {
+          const rect = triggerRef.current.getBoundingClientRect();
+          const spaceAbove = rect.top - 56;
+          const spaceBelow = window.innerHeight - rect.bottom;
+          setPosition(spaceAbove < cardRef.current.offsetHeight + 12 && spaceBelow > spaceAbove ? 'bottom' : 'top');
+        }
+      });
+    }
+  }, [isVisible, amsLabels, ams.id]);
+
+  const handleMouseEnter = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setIsVisible(true), 80);
+  };
+  const handleMouseLeave = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    if (!isInputFocused) {
+      timeoutRef.current = setTimeout(() => setIsVisible(false), 200);
+    }
+  };
+  useEffect(() => () => { if (timeoutRef.current) clearTimeout(timeoutRef.current); }, []);
+
+  const handleSave = async () => {
+    if (!canEdit) return;
+    if (!printerId) { setSaveError(t('printers.amsPopup.printerIdUnavailable')); return; }
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const trimmed = editValue.trim();
+      if (trimmed) {
+        await api.saveAmsLabel(printerId, ams.id, trimmed, ams.serial_number);
+      } else {
+        await api.deleteAmsLabel(printerId, ams.id, ams.serial_number);
+      }
+      onSaved();
+      setIsVisible(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (!canEdit) return;
+    if (!printerId) { setSaveError(t('printers.amsPopup.printerIdUnavailable')); return; }
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await api.deleteAmsLabel(printerId, ams.id, ams.serial_number);
+      setEditValue('');
+      onSaved();
+      setIsVisible(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      ref={triggerRef}
+      className="relative inline-block"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+
+      {isVisible && (
+        <div
+          ref={cardRef}
+          className={`
+            absolute left-0 z-50
+            ${position === 'top' ? 'bottom-full mb-2' : 'top-full mt-2'}
+            animate-in fade-in-0 zoom-in-95 duration-150
+          `}
+          style={{ maxWidth: 'calc(100vw - 24px)' }}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <div className="w-52 bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-lg shadow-xl overflow-hidden backdrop-blur-sm p-2.5 space-y-2">
+            {/* AMS auto-label */}
+            <div className="text-[10px] uppercase tracking-wider text-bambu-gray font-medium">{label}</div>
+
+            {/* Serial number */}
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[10px] tracking-wide text-bambu-gray font-medium shrink-0">
+                {t('printers.amsPopup.serialNumber')}
+              </span>
+              <span className="text-[10px] text-white font-mono truncate">{ams.serial_number || '—'}</span>
+            </div>
+
+            {/* Firmware version */}
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[10px] tracking-wide text-bambu-gray font-medium shrink-0">
+                {t('printers.amsPopup.firmwareVersion')}
+              </span>
+              <span className="text-[10px] text-white font-mono truncate">{ams.sw_ver || '—'}</span>
+            </div>
+
+            {/* Divider */}
+            <div className="h-px bg-bambu-dark-tertiary/50" />
+
+            {/* Friendly name editor */}
+            <div className="space-y-1">
+              <span className="text-[10px] text-bambu-gray font-medium block">
+                {t('printers.amsPopup.friendlyName')}
+              </span>
+              <input
+                type="text"
+                value={editValue}
+                onChange={(e) => canEdit && setEditValue(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSave()}
+                onFocus={() => setIsInputFocused(true)}
+                onBlur={(e) => {
+                  setIsInputFocused(false);
+                  // Don't close if focus moved to another element inside the card (e.g. Save/Clear button)
+                  if (cardRef.current?.contains(e.relatedTarget as Node)) return;
+                  if (timeoutRef.current) clearTimeout(timeoutRef.current);
+                  timeoutRef.current = setTimeout(() => setIsVisible(false), 200);
+                }}
+                placeholder={canEdit ? t('printers.amsPopup.friendlyNamePlaceholder') : (amsLabels?.[ams.id] || '—')}
+                disabled={!canEdit}
+                title={!canEdit ? t('printers.amsPopup.noEditPermission') : undefined}
+                className="w-full bg-bambu-dark border border-bambu-dark-tertiary rounded px-2 py-1 text-xs text-white placeholder-bambu-gray/60 focus:outline-none focus:border-bambu-green disabled:opacity-50 disabled:cursor-not-allowed"
+                maxLength={100}
+              />
+              {canEdit && (
+                <div className="space-y-1">
+                  {saveError && (
+                    <p className="text-[10px] text-red-400 break-words">{saveError}</p>
+                  )}
+                  <div className="flex gap-1 justify-end">
+                    <button
+                      onClick={handleSave}
+                      disabled={isSaving}
+                      className="px-2 py-0.5 text-[10px] bg-bambu-green text-white rounded hover:bg-bambu-green/80 disabled:opacity-50"
+                    >
+                      {t('printers.amsPopup.save')}
+                    </button>
+                    {amsLabels?.[ams.id] && (
+                      <button
+                        onClick={handleClear}
+                        disabled={isSaving}
+                        className="px-2 py-0.5 text-[10px] bg-bambu-dark-tertiary text-bambu-gray rounded hover:bg-bambu-dark-tertiary/70 disabled:opacity-50"
+                      >
+                        {t('printers.amsPopup.clear')}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -29,5 +29,5 @@ export function CardHeader({ children, className = '' }: CardProps) {
 }
 
 export function CardContent({ children, className = '' }: CardProps) {
-  return <div className={`p-6 ${className}`}>{children}</div>;
+  return <div className={`p-3 lg:p-6 ${className}`}>{children}</div>;
 }

--- a/frontend/src/components/PrinterQueueWidget.tsx
+++ b/frontend/src/components/PrinterQueueWidget.tsx
@@ -76,7 +76,7 @@ export function PrinterQueueWidget({ printerId, printerModel, printerState, plat
   if (needsClearPlate) {
     const displayItem = nextAutoItem || nextItem;
     return (
-      <div className="mb-3 p-3 bg-bambu-dark rounded-lg border border-yellow-400/30">
+      <div className="p-3 bg-bambu-dark rounded-lg border border-yellow-400/30">
         <div className="flex items-center gap-3 mb-2">
           <Calendar className="w-5 h-5 text-yellow-400 flex-shrink-0" />
           <div className="min-w-0 flex-1">
@@ -117,7 +117,7 @@ export function PrinterQueueWidget({ printerId, printerModel, printerState, plat
   return (
     <Link
       to="/queue"
-      className="block mb-3 p-3 bg-bambu-dark rounded-lg hover:bg-bambu-dark-tertiary transition-colors"
+      className="p-3 bg-bambu-dark rounded-lg hover:bg-bambu-dark-tertiary transition-colors"
     >
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0 flex-1">

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -454,6 +454,7 @@ export default {
       save: 'Speichern',
       clear: 'Löschen',
       noEditPermission: 'Sie haben keine Berechtigung, AMS-Einheiten umzubenennen',
+      printerIdUnavailable: 'Drucker-ID nicht verfügbar',
     },
     // Firmware modal
     firmwareModal: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -454,6 +454,7 @@ export default {
       save: 'Save',
       clear: 'Clear',
       noEditPermission: 'You do not have permission to rename AMS units',
+      printerIdUnavailable: 'Printer ID unavailable',
     },
     // Firmware modal
     firmwareModal: {

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -453,7 +453,8 @@ export default {
       firmwareVersion: 'Firmware',
       save: 'Enregistrer',
       clear: 'Effacer',
-      noEditPermission: 'Vous n\'avez pas la permission de renommer les unités AMS',
+      noEditPermission: "Vous n'avez pas la permission de renommer les unités AMS",
+      printerIdUnavailable: 'ID imprimante indisponible',
     },
     // Firmware modal
     firmwareModal: {

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -454,6 +454,7 @@ export default {
       save: 'Salva',
       clear: 'Cancella',
       noEditPermission: 'Non hai il permesso di rinominare le unità AMS',
+      printerIdUnavailable: 'ID stampante non disponibile',
     },
     // Firmware modal
     firmwareModal: {

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -454,6 +454,7 @@ export default {
       save: '保存',
       clear: 'クリア',
       noEditPermission: 'AMS ユニットの名前を変更する権限がありません',
+      printerIdUnavailable: 'プリンターIDが利用できません',
     },
     // Firmware modal
     firmwareModal: {

--- a/frontend/src/i18n/locales/pt-BR.ts
+++ b/frontend/src/i18n/locales/pt-BR.ts
@@ -454,6 +454,7 @@ export default {
       save: 'Salvar',
       clear: 'Limpar',
       noEditPermission: 'Você não tem permissão para renomear unidades AMS',
+      printerIdUnavailable: 'ID da impressora indisponível',
     },
     // Firmware modal
     firmwareModal: {

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '../contexts/AuthContext';
 import {
   Plus,
@@ -60,17 +59,17 @@ import { MQTTDebugModal } from '../components/MQTTDebugModal';
 import { HMSErrorModal, filterKnownHMSErrors } from '../components/HMSErrorModal';
 import { PrinterQueueWidget } from '../components/PrinterQueueWidget';
 import { AMSHistoryModal } from '../components/AMSHistoryModal';
-import { FilamentHoverCard, EmptySlotHoverCard } from '../components/FilamentHoverCard';
 import { LinkSpoolModal } from '../components/LinkSpoolModal';
 import { AssignSpoolModal } from '../components/AssignSpoolModal';
 import { ConfigureAmsSlotModal } from '../components/ConfigureAmsSlotModal';
+import { AMSUnitCard } from '../components/AMSUnitCard';
+import { FilamentHoverCard, EmptySlotHoverCard } from '../components/FilamentHoverCard';
 import { useToast } from '../contexts/ToastContext';
 import { ChamberLight } from '../components/icons/ChamberLight';
 import { SkipObjectsModal, SkipObjectsIcon } from '../components/SkipObjectsModal';
 import { FileUploadModal } from '../components/FileUploadModal';
 import { PrintModal } from '../components/PrintModal';
 import { PrinterInfoModal } from '../components/PrinterInfoModal';
-import { getGlobalTrayId } from '../utils/amsHelpers';
 import { getPrinterImage, getWifiStrength } from '../utils/printer';
 import { FilamentSlotCircle } from '../components/FilamentSlotCircle';
 import { hexToColorName, parseFilamentColor, isLightColor } from '../utils/colors';
@@ -343,21 +342,6 @@ function formatKValue(k: number | null | undefined): string {
   return value.toFixed(3);
 }
 
-// Nozzle side indicators (Bambu Lab style - square badge with L/R)
-function NozzleBadge({ side }: { side: 'L' | 'R' }) {
-  const { mode } = useTheme();
-  // Light mode: #e7f5e9 (light green), Dark mode: #1a4d2e (dark green)
-  const bgColor = mode === 'dark' ? '#1a4d2e' : '#e7f5e9';
-  return (
-    <span
-      className="inline-flex items-center justify-center w-4 h-4 text-[10px] font-bold rounded"
-      style={{ backgroundColor: bgColor, color: '#00ae42' }}
-    >
-      {side}
-    </span>
-  );
-}
-
 // Expand nozzle type codes to material names
 // Handles full text ("hardened_steel"), 2-char codes ("HS"/"HH"), and 4-char codes ("HS01")
 // Material mapping: 00=stainless steel, 01=hardened steel, 05=tungsten carbide
@@ -497,11 +481,10 @@ function NozzleSlotHoverCard({ slot, index, activeStatus, filamentName, children
                 {/* Status badge */}
                 <div className="flex items-center justify-between">
                   <span className="text-[10px] uppercase tracking-wider text-bambu-gray font-medium">{t('printers.nozzleStatus')}</span>
-                  <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
-                    activeStatus || isMounted
-                      ? 'bg-green-900/50 text-green-400'
-                      : 'bg-bambu-dark-tertiary text-bambu-gray'
-                  }`}>
+                  <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${activeStatus || isMounted
+                    ? 'bg-green-900/50 text-green-400'
+                    : 'bg-bambu-dark-tertiary text-bambu-gray'
+                    }`}>
                     {activeStatus ? t('printers.nozzleActive') : isMounted ? t('printers.nozzleMounted') : t('printers.nozzleDocked')}
                   </span>
                 </div>
@@ -640,11 +623,10 @@ function DualNozzleHoverCard({ leftSlot, rightSlot, activeNozzle, filamentInfo, 
         )}
         <div className="flex items-center justify-between">
           <span className="text-[10px] text-bambu-gray">{t('printers.nozzleStatus')}</span>
-          <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
-            isActive
-              ? 'bg-green-900/50 text-green-400'
-              : 'bg-bambu-dark-tertiary text-bambu-gray'
-          }`}>
+          <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${isActive
+            ? 'bg-green-900/50 text-green-400'
+            : 'bg-bambu-dark-tertiary text-bambu-gray'
+            }`}>
             {isActive ? t('printers.nozzleActive') : t('printers.nozzleIdle')}
           </span>
         </div>
@@ -756,15 +738,14 @@ function NozzleRackCard({ slots, filamentInfo }: { slots: import('../api/client'
           return (
             <NozzleSlotHoverCard key={slot.id >= 0 ? slot.id : `empty-${i}`} slot={slot} index={i} filamentName={slot.filament_id ? filamentInfo?.[slot.filament_id]?.name : undefined}>
               <div
-                className={`w-7 h-7 rounded flex items-center justify-center cursor-default transition-colors border-b-2 ${
-                  isEmpty
-                    ? 'bg-bambu-dark-tertiary/20 border-bambu-dark-tertiary/20'
-                    : 'bg-bambu-dark-tertiary/40 border-bambu-dark-tertiary/40'
-                }`}
+                className={`w-7 h-7 rounded flex items-center justify-center cursor-default transition-colors border-b-2 ${isEmpty
+                  ? 'bg-bambu-dark-tertiary/20 border-bambu-dark-tertiary/20'
+                  : 'bg-bambu-dark-tertiary/40 border-bambu-dark-tertiary/40'
+                  }`}
                 style={filamentBg ? { backgroundColor: filamentBg } : undefined}
               >
                 <span className={`text-[10px] font-semibold ${isEmpty ? 'text-bambu-gray/30' : lightBg ? 'text-black/80' : 'text-white'}`}
-                      style={filamentBg && !lightBg ? { textShadow: '0 1px 3px rgba(0,0,0,0.9)' } : undefined}
+                  style={filamentBg && !lightBg ? { textShadow: '0 1px 3px rgba(0,0,0,0.9)' } : undefined}
                 >
                   {isEmpty ? '—' : (slot.nozzle_diameter || '?')}
                 </span>
@@ -774,67 +755,6 @@ function NozzleRackCard({ slots, filamentInfo }: { slots: import('../api/client'
         })}
       </div>
     </div>
-  );
-}
-
-// Water drop SVG - empty outline (Bambu Lab style from bambu-humidity)
-function WaterDropEmpty({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 36 54" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M17.8131 0.00538C18.4463 -0.15091 20.3648 3.14642 20.8264 3.84781C25.4187 10.816 35.3089 26.9368 35.9383 34.8694C37.4182 53.5822 11.882 61.3357 2.53721 45.3789C-1.73471 38.0791 0.016 32.2049 3.178 25.0232C6.99221 16.3662 12.6411 7.90372 17.8131 0.00538ZM18.3738 7.24807L17.5881 7.48441C14.4452 12.9431 10.917 18.2341 8.19369 23.9368C4.6808 31.29 1.18317 38.5479 7.69403 45.5657C17.3058 55.9228 34.9847 46.8808 31.4604 32.8681C29.2558 24.0969 22.4207 15.2913 18.3776 7.24807H18.3738Z" fill="#C3C2C1"/>
-    </svg>
-  );
-}
-
-// Water drop SVG - half filled with blue water (Bambu Lab style from bambu-humidity)
-function WaterDropHalf({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 35 53" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M17.3165 0.0038C17.932 -0.14959 19.7971 3.08645 20.2458 3.77481C24.7103 10.6135 34.3251 26.4346 34.937 34.2198C36.3757 52.5848 11.5505 60.1942 2.46584 44.534C-1.68714 37.3735 0.0148 31.6085 3.08879 24.5603C6.79681 16.0605 12.2884 7.75907 17.3165 0.0038ZM17.8615 7.11561L17.0977 7.34755C14.0423 12.7048 10.6124 17.8974 7.96483 23.4941C4.54975 30.7107 1.14949 37.8337 7.47908 44.721C16.8233 54.8856 34.01 46.0117 30.5838 32.2595C28.4405 23.6512 21.7957 15.0093 17.8652 7.11561H17.8615Z" fill="#C3C2C1"/>
-      <path d="M5.03547 30.112C9.64453 30.4936 11.632 35.7985 16.4154 35.791C19.6339 35.7873 20.2161 33.2283 22.3853 31.6197C31.6776 24.7286 33.5835 37.4894 27.9881 44.4254C18.1878 56.5653 -1.16063 44.6013 5.03917 30.1158L5.03547 30.112Z" fill="#1F8FEB"/>
-    </svg>
-  );
-}
-
-// Water drop SVG - fully filled with blue water (Bambu Lab style from bambu-humidity)
-function WaterDropFull({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 36 54" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M17.9625 4.48059L4.77216 26.3154L2.08228 40.2175L10.0224 50.8414H23.1594L33.3246 42.1693V30.2455L17.9625 4.48059Z" fill="#1F8FEB"/>
-      <path d="M17.7948 0.00538C18.4273 -0.15091 20.3438 3.14642 20.8048 3.84781C25.3921 10.816 35.2715 26.9368 35.9001 34.8694C37.3784 53.5822 11.8702 61.3357 2.53562 45.3789C-1.73163 38.0829 0.0134 32.2087 3.1757 25.027C6.98574 16.3662 12.6284 7.90372 17.7948 0.00538ZM18.3549 7.24807L17.57 7.48441C14.4306 12.9431 10.9063 18.2341 8.1859 23.9368C4.67686 31.29 1.18305 38.5479 7.68679 45.5657C17.2881 55.9228 34.9476 46.8808 31.4271 32.8681C29.2249 24.0969 22.3974 15.2913 18.3587 7.24807H18.3549Z" fill="#C3C2C1"/>
-    </svg>
-  );
-}
-
-// Thermometer SVG - empty outline
-function ThermometerEmpty({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke="#C3C2C1" strokeWidth="1" fill="none"/>
-      <circle cx="6" cy="15" r="2.5" stroke="#C3C2C1" strokeWidth="1" fill="none"/>
-    </svg>
-  );
-}
-
-// Thermometer SVG - half filled (gold - same as humidity fair)
-function ThermometerHalf({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="4.5" y="8" width="3" height="4.5" fill="#d4a017" rx="0.5"/>
-      <circle cx="6" cy="15" r="2" fill="#d4a017"/>
-      <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke="#C3C2C1" strokeWidth="1" fill="none"/>
-    </svg>
-  );
-}
-
-// Thermometer SVG - fully filled (red - same as humidity bad)
-function ThermometerFull({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="4.5" y="3" width="3" height="9.5" fill="#c62828" rx="0.5"/>
-      <circle cx="6" cy="15" r="2" fill="#c62828"/>
-      <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke="#C3C2C1" strokeWidth="1" fill="none"/>
-    </svg>
   );
 }
 
@@ -863,9 +783,9 @@ function HeaterThermometer({ className, color, isHeating }: HeaterThermometerPro
     // Filled thermometer with glow - heater is ON
     return (
       <svg className={className} style={glowStyle} viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect x="4.5" y="3" width="3" height="9.5" fill={fillColor} rx="0.5"/>
-        <circle cx="6" cy="15" r="2" fill={fillColor}/>
-        <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke={fillColor} strokeWidth="1" fill="none"/>
+        <rect x="4.5" y="3" width="3" height="9.5" fill={fillColor} rx="0.5" />
+        <circle cx="6" cy="15" r="2" fill={fillColor} />
+        <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke={fillColor} strokeWidth="1" fill="none" />
       </svg>
     );
   }
@@ -873,129 +793,12 @@ function HeaterThermometer({ className, color, isHeating }: HeaterThermometerPro
   // Empty thermometer - heater is OFF
   return (
     <svg className={className} viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke={fillColor} strokeWidth="1" fill="none"/>
-      <circle cx="6" cy="15" r="2.5" stroke={fillColor} strokeWidth="1" fill="none"/>
+      <path d="M6 0.5C4.6 0.5 3.5 1.6 3.5 3V12.1C2.6 12.8 2 13.9 2 15C2 17.2 3.8 19 6 19C8.2 19 10 17.2 10 15C10 13.9 9.4 12.8 8.5 12.1V3C8.5 1.6 7.4 0.5 6 0.5Z" stroke={fillColor} strokeWidth="1" fill="none" />
+      <circle cx="6" cy="15" r="2.5" stroke={fillColor} strokeWidth="1" fill="none" />
     </svg>
   );
 }
 
-// Humidity indicator with water drop that fills based on level (Bambu Lab style)
-// Reference: https://github.com/theicedmango/bambu-humidity
-interface HumidityIndicatorProps {
-  humidity: number | string;
-  goodThreshold?: number;  // <= this is green
-  fairThreshold?: number;  // <= this is orange, > is red
-  onClick?: () => void;
-  compact?: boolean;  // Smaller version for grid layout
-}
-
-function HumidityIndicator({ humidity, goodThreshold = 40, fairThreshold = 60, onClick, compact }: HumidityIndicatorProps) {
-  const humidityValue = typeof humidity === 'string' ? parseInt(humidity, 10) : humidity;
-  const good = typeof goodThreshold === 'number' ? goodThreshold : 40;
-  const fair = typeof fairThreshold === 'number' ? fairThreshold : 60;
-
-  // Status thresholds (configurable via settings)
-  // Good: ≤goodThreshold (green #22a352), Fair: ≤fairThreshold (gold #d4a017), Bad: >fairThreshold (red #c62828)
-  let textColor: string;
-  let statusText: string;
-
-  if (isNaN(humidityValue)) {
-    textColor = '#C3C2C1';
-    statusText = 'Unknown';
-  } else if (humidityValue <= good) {
-    textColor = '#22a352'; // Green - Good
-    statusText = 'Good';
-  } else if (humidityValue <= fair) {
-    textColor = '#d4a017'; // Gold - Fair
-    statusText = 'Fair';
-  } else {
-    textColor = '#c62828'; // Red - Bad
-    statusText = 'Bad';
-  }
-
-  // Fill level based on status: Good=Empty (dry), Fair=Half, Bad=Full (wet)
-  let DropComponent: React.FC<{ className?: string }>;
-  if (isNaN(humidityValue)) {
-    DropComponent = WaterDropEmpty;
-  } else if (humidityValue <= good) {
-    DropComponent = WaterDropEmpty; // Good - empty drop (dry)
-  } else if (humidityValue <= fair) {
-    DropComponent = WaterDropHalf; // Fair - half filled
-  } else {
-    DropComponent = WaterDropFull; // Bad - full (too humid)
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`flex items-center gap-1 ${onClick ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}`}
-      title={`Humidity: ${humidityValue}% - ${statusText}${onClick ? ' (click for history)' : ''}`}
-    >
-      <DropComponent className={compact ? "w-2.5 h-3" : "w-3 h-4"} />
-      <span className={`font-medium tabular-nums ${compact ? 'text-[10px]' : 'text-xs'}`} style={{ color: textColor }}>{humidityValue}%</span>
-    </button>
-  );
-}
-
-// Temperature indicator with dynamic icon and coloring
-interface TemperatureIndicatorProps {
-  temp: number;
-  goodThreshold?: number;  // <= this is blue
-  fairThreshold?: number;  // <= this is orange, > is red
-  onClick?: () => void;
-  compact?: boolean;  // Smaller version for grid layout
-}
-
-function TemperatureIndicator({ temp, goodThreshold = 28, fairThreshold = 35, onClick, compact }: TemperatureIndicatorProps) {
-  // Ensure thresholds are numbers
-  const good = typeof goodThreshold === 'number' ? goodThreshold : 28;
-  const fair = typeof fairThreshold === 'number' ? fairThreshold : 35;
-
-  let textColor: string;
-  let statusText: string;
-  let ThermoComponent: React.FC<{ className?: string }>;
-
-  if (temp <= good) {
-    textColor = '#22a352'; // Green - good (same as humidity)
-    statusText = 'Good';
-    ThermoComponent = ThermometerEmpty;
-  } else if (temp <= fair) {
-    textColor = '#d4a017'; // Gold - fair (same as humidity)
-    statusText = 'Fair';
-    ThermoComponent = ThermometerHalf;
-  } else {
-    textColor = '#c62828'; // Red - bad (same as humidity)
-    statusText = 'Bad';
-    ThermoComponent = ThermometerFull;
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`flex items-center gap-1 ${onClick ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}`}
-      title={`Temperature: ${temp}°C - ${statusText}${onClick ? ' (click for history)' : ''}`}
-    >
-      <ThermoComponent className={compact ? "w-2.5 h-3" : "w-3 h-4"} />
-      <span className={`tabular-nums text-right ${compact ? 'text-[10px] w-8' : 'w-12'}`} style={{ color: textColor }}>{temp}°C</span>
-    </button>
-  );
-}
-
-// Get AMS label: AMS-A/B/C/D for regular AMS, HT-A/B for AMS-HT (single spool)
-// Always use tray count as the source of truth (1 tray = AMS-HT, 4 trays = regular AMS)
-// AMS-HT uses IDs 128+ while regular AMS uses 0-3
-function getAmsLabel(amsId: number | string, trayCount: number): string {
-  // Ensure amsId is a number (backend might send string)
-  const id = typeof amsId === 'string' ? parseInt(amsId, 10) : amsId;
-  const safeId = isNaN(id) ? 0 : id;
-  const isHt = trayCount === 1;
-  // AMS-HT uses IDs starting at 128, regular AMS uses 0-3
-  const normalizedId = safeId >= 128 ? safeId - 128 : safeId;
-  const letter = String.fromCharCode(65 + normalizedId); // 0=A, 1=B, 2=C, 3=D
-  return isHt ? `HT-${letter}` : `AMS-${letter}`;
-}
 
 // Get fill bar color based on spool fill level
 function getFillBarColor(fillLevel: number): string {
@@ -1009,7 +812,7 @@ function getSpoolmanFillLevel(
   linkedSpool: LinkedSpoolInfo | undefined
 ): number | null {
   if (!linkedSpool?.remaining_weight || !linkedSpool?.filament_weight
-      || linkedSpool.filament_weight <= 0) return null;
+    || linkedSpool.filament_weight <= 0) return null;
   return Math.min(100, Math.round(
     (linkedSpool.remaining_weight / linkedSpool.filament_weight) * 100
   ));
@@ -1692,6 +1495,7 @@ function PrinterCard({
     queryKey: ['slotPresets', printer.id],
     queryFn: () => api.getSlotPresets(printer.id),
     staleTime: 2 * 60 * 1000, // 2 minutes
+    enabled: !!printer.id,
   });
 
   // Fetch user-defined AMS friendly names from the database
@@ -1699,6 +1503,7 @@ function PrinterCard({
     queryKey: ['amsLabels', printer.id],
     queryFn: () => api.getAmsLabels(printer.id),
     staleTime: 5 * 60 * 1000, // 5 minutes
+    enabled: !!printer.id,
   });
 
   // Cache WiFi signal to prevent it disappearing on updates
@@ -2188,11 +1993,11 @@ function PrinterCard({
   // Size-based styling helpers
   const getImageSize = () => {
     switch (cardSize) {
-      case 1: return 'w-10 h-10';
-      case 2: return 'w-14 h-14';
-      case 3: return 'w-16 h-16';
-      case 4: return 'w-20 h-20';
-      default: return 'w-14 h-14';
+      case 1: return 'w-12 h-12';
+      case 2: return 'w-16 h-16';
+      case 3: return 'w-20 h-20';
+      case 4: return 'w-24 h-24';
+      default: return 'w-16 h-16';
     }
   };
   const getTitleSize = () => {
@@ -2204,15 +2009,7 @@ function PrinterCard({
       default: return 'text-lg';
     }
   };
-  const getSpacing = () => {
-    switch (cardSize) {
-      case 1: return 'mb-2';
-      case 2: return 'mb-4';
-      case 3: return 'mb-5';
-      case 4: return 'mb-6';
-      default: return 'mb-4';
-    }
-  };
+
 
   const canDrop = isConnected && status?.state !== 'RUNNING' && status?.state !== 'PAUSE' && hasPermission('printers:control');
 
@@ -2277,7 +2074,7 @@ function PrinterCard({
 
   return (
     <Card
-      className="relative"
+      className="relative flex flex-col h-full"
       onDragEnter={handleCardDragEnter}
       onDragOver={handleCardDragOver}
       onDragLeave={handleCardDragLeave}
@@ -2314,9 +2111,9 @@ function PrinterCard({
           </div>
         </div>
       )}
-      <CardContent className={cardSize >= 3 ? 'p-5' : ''}>
+      <CardContent className={cardSize >= 3 ? 'p-5 flex flex-col gap-2 flex-1' : 'flex flex-col gap-2 flex-1'}>
         {/* Header */}
-        <div className={getSpacing()}>
+        <div>
           {/* Top row: Image, Name, Menu */}
           <div className="flex items-start justify-between gap-2">
             <div className="flex items-center gap-3 min-w-0 flex-1">
@@ -2324,7 +2121,7 @@ function PrinterCard({
               <img
                 src={getPrinterImage(printer.model)}
                 alt={printer.model || t('common.printer')}
-                className={`object-contain rounded-lg bg-bambu-dark flex-shrink-0 ${getImageSize()}`}
+                className={`p-1 object-contain rounded-lg bg-bambu-dark flex-shrink-0 ${getImageSize()}`}
               />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
@@ -2332,9 +2129,8 @@ function PrinterCard({
                   {/* Connection indicator dot for compact mode */}
                   {viewMode === 'compact' && (
                     <div
-                      className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                        status?.connected ? 'bg-status-ok' : 'bg-status-error'
-                      }`}
+                      className={`w-2 h-2 rounded-full flex-shrink-0 ${status?.connected ? 'bg-status-ok' : 'bg-status-error'
+                        }`}
                       title={status?.connected ? t('printers.connection.connected') : t('printers.connection.offline')}
                     />
                   )}
@@ -2368,11 +2164,10 @@ function PrinterCard({
               {showMenu && (
                 <div className="absolute right-0 mt-2 w-48 bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-lg shadow-lg z-20">
                   <button
-                    className={`w-full px-4 py-2 text-left text-sm flex items-center gap-2 ${
-                      hasPermission('printers:update')
-                        ? 'hover:bg-bambu-dark-tertiary'
-                        : 'opacity-50 cursor-not-allowed'
-                    }`}
+                    className={`w-full px-4 py-2 text-left text-sm flex items-center gap-2 ${hasPermission('printers:update')
+                      ? 'hover:bg-bambu-dark-tertiary'
+                      : 'opacity-50 cursor-not-allowed'
+                      }`}
                     onClick={() => {
                       if (!hasPermission('printers:update')) return;
                       setShowEditModal(true);
@@ -2414,11 +2209,10 @@ function PrinterCard({
                     {t('printers.mqttDebug')}
                   </button>
                   <button
-                    className={`w-full px-4 py-2 text-left text-sm flex items-center gap-2 ${
-                      hasPermission('printers:delete')
-                        ? 'text-red-400 hover:bg-bambu-dark-tertiary'
-                        : 'text-red-400/50 cursor-not-allowed'
-                    }`}
+                    className={`w-full px-4 py-2 text-left text-sm flex items-center gap-2 ${hasPermission('printers:delete')
+                      ? 'text-red-400 hover:bg-bambu-dark-tertiary'
+                      : 'text-red-400/50 cursor-not-allowed'
+                      }`}
                     onClick={() => {
                       if (!hasPermission('printers:delete')) return;
                       setShowDeleteConfirm(true);
@@ -2439,11 +2233,10 @@ function PrinterCard({
             <div className="flex flex-wrap items-center gap-2 mt-2">
               {/* Connection status badge */}
               <span
-                className={`flex items-center gap-1.5 px-2 py-1 rounded-full text-xs ${
-                  status?.connected
-                    ? 'bg-status-ok/20 text-status-ok'
-                    : 'bg-status-error/20 text-status-error'
-                }`}
+                className={`flex items-center gap-1.5 px-2 py-1 rounded-full text-xs ${status?.connected
+                  ? 'bg-status-ok/20 text-status-ok'
+                  : 'bg-status-error/20 text-status-error'
+                  }`}
               >
                 {status?.connected ? (
                   <Link className="w-3 h-3" />
@@ -2467,14 +2260,12 @@ function PrinterCard({
                   className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs ${
                     wifiSignal >= -50
                       ? 'bg-status-ok/20 text-status-ok'
-                      : wifiSignal >= -60
-                      ? 'bg-status-ok/20 text-status-ok'
                       : wifiSignal >= -70
-                      ? 'bg-status-warning/20 text-status-warning'
-                      : wifiSignal >= -80
-                      ? 'bg-orange-500/20 text-orange-600'
-                      : 'bg-status-error/20 text-status-error'
-                  }`}
+                        ? 'bg-status-warning/20 text-status-warning'
+                        : wifiSignal >= -80
+                          ? 'bg-orange-500/20 text-orange-600'
+                          : 'bg-status-error/20 text-status-error'
+                    }`}
                   title={`WiFi: ${wifiSignal} dBm - ${t(getWifiStrength(wifiSignal).labelKey)}`}
                 >
                   <Signal className="w-3 h-3" />
@@ -2487,13 +2278,12 @@ function PrinterCard({
                 return (
                   <button
                     onClick={() => setShowHMSModal(true)}
-                    className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs cursor-pointer hover:opacity-80 transition-opacity ${
-                      knownErrors.length > 0
-                        ? knownErrors.some(e => e.severity <= 2)
-                          ? 'bg-status-error/20 text-status-error'
-                          : 'bg-status-warning/20 text-status-warning'
-                        : 'bg-status-ok/20 text-status-ok'
-                    }`}
+                    className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs cursor-pointer hover:opacity-80 transition-opacity ${knownErrors.length > 0
+                      ? knownErrors.some(e => e.severity <= 2)
+                        ? 'bg-status-error/20 text-status-error'
+                        : 'bg-status-warning/20 text-status-warning'
+                      : 'bg-status-ok/20 text-status-ok'
+                      }`}
                     title={t('printers.clickToViewHmsErrors')}
                   >
                     <AlertTriangle className="w-3 h-3" />
@@ -2505,13 +2295,12 @@ function PrinterCard({
               {maintenanceInfo && (
                 <button
                   onClick={() => navigate('/maintenance')}
-                  className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs cursor-pointer hover:opacity-80 transition-opacity ${
-                    maintenanceInfo.due_count > 0
-                      ? 'bg-status-error/20 text-status-error'
-                      : maintenanceInfo.warning_count > 0
+                  className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs cursor-pointer hover:opacity-80 transition-opacity ${maintenanceInfo.due_count > 0
+                    ? 'bg-status-error/20 text-status-error'
+                    : maintenanceInfo.warning_count > 0
                       ? 'bg-status-warning/20 text-status-warning'
                       : 'bg-status-ok/20 text-status-ok'
-                  }`}
+                    }`}
                   title={
                     maintenanceInfo.due_count > 0 || maintenanceInfo.warning_count > 0
                       ? `${maintenanceInfo.due_count > 0 ? `${maintenanceInfo.due_count} maintenance due` : ''}${maintenanceInfo.due_count > 0 && maintenanceInfo.warning_count > 0 ? ', ' : ''}${maintenanceInfo.warning_count > 0 ? `${maintenanceInfo.warning_count} due soon` : ''} - Click to view`
@@ -2539,11 +2328,10 @@ function PrinterCard({
               {checkPrinterFirmware && firmwareInfo?.current_version && firmwareInfo?.latest_version ? (
                 <button
                   onClick={() => setShowFirmwareModal(true)}
-                  className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs hover:opacity-80 transition-opacity ${
-                    firmwareInfo.update_available
-                      ? 'bg-orange-500/20 text-orange-400'
-                      : 'bg-status-ok/20 text-status-ok'
-                  }`}
+                  className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs hover:opacity-80 transition-opacity ${firmwareInfo.update_available
+                    ? 'bg-orange-500/20 text-orange-400'
+                    : 'bg-status-ok/20 text-status-ok'
+                    }`}
                   title={
                     firmwareInfo.update_available
                       ? t('printers.firmwareUpdateAvailable', { current: firmwareInfo.current_version, latest: firmwareInfo.latest_version })
@@ -2648,7 +2436,7 @@ function PrinterCard({
               /* Expanded: Full status section */
               <>
                 {/* Current Print or Idle Placeholder */}
-                <div className="mb-4 p-3 bg-bambu-dark rounded-lg relative">
+                <div className="p-3 bg-bambu-dark rounded-lg relative">
                   {/* Skip Objects button - top right corner, always visible */}
                   <button
                     onClick={() => setShowSkipObjectsModal(true)}
@@ -2866,7 +2654,7 @@ function PrinterCard({
               const chamberFan = status.big_fan2_speed;
 
               return (
-                <div className="mt-3">
+                <div>
                   {/* Section Header */}
                   <div className="flex items-center gap-2 mb-2">
                     <span className="text-[10px] uppercase tracking-wider text-bambu-gray font-medium">
@@ -2958,15 +2746,11 @@ function PrinterCard({
               );
             })()}
 
-            {/* AMS Units - 2-Column Grid Layout */}
+            {/* AMS Units */}
             {(amsData?.length > 0 || status.vt_tray.length > 0) && viewMode === 'expanded' && (() => {
-              // Separate regular AMS (4-tray) from HT AMS (1-tray)
-              const regularAms = amsData.filter(ams => ams.tray.length > 1);
-              const htAms = amsData.filter(ams => ams.tray.length === 1);
               const isDualNozzle = printer.nozzle_count === 2 || status?.temperatures?.nozzle_2 !== undefined;
-
               return (
-                <div className="mt-3">
+                <div className='@container'>
                   {/* Section Header */}
                   <div className="flex items-center gap-2 mb-2">
                     <span className="text-[10px] uppercase tracking-wider text-bambu-gray font-medium">
@@ -2976,564 +2760,56 @@ function PrinterCard({
                   </div>
 
                   {/* AMS Content */}
-                  <div className="space-y-3">
-                    {/* Row 1-2: Regular AMS (4-tray) in 2-column grid */}
-                    {regularAms.length > 0 && (
-                      <div className="grid grid-cols-2 gap-3">
-                        {regularAms.map((ams) => {
-                        const mappedExtruderId = amsExtruderMap[String(ams.id)];
-                        const normalizedId = ams.id >= 128 ? ams.id - 128 : ams.id;
-                        const extruderId = mappedExtruderId !== undefined ? mappedExtruderId : normalizedId;
-                        const isLeftNozzle = extruderId === 1;
-                        const isRightNozzle = extruderId === 0;
-
-                        return (
-                          <div key={ams.id} className="p-2.5 bg-bambu-dark rounded-lg border border-bambu-dark-tertiary/30">
-                            {/* Header: Label + Stats (no icon) */}
-                            <div className="flex items-center justify-between mb-2">
-                              <div className="flex items-center gap-1.5">
-                                {/* AMS name — hover to see serial, firmware, and edit friendly name */}
-                                <AmsNameHoverCard
-                                  ams={ams}
-                                  printerId={printer.id}
-                                  label={getAmsLabel(ams.id, ams.tray.length)}
-                                  amsLabels={amsLabels}
-                                  canEdit={hasPermission('printers:update')}
-                                  onSaved={refetchAmsLabels}
-                                >
-                                  <span className="text-[10px] text-white font-medium cursor-default select-none">
-                                    {amsLabels?.[ams.id] || getAmsLabel(ams.id, ams.tray.length)}
-                                  </span>
-                                </AmsNameHoverCard>
-                                {isDualNozzle && (isLeftNozzle || isRightNozzle) && (
-                                  <NozzleBadge side={isLeftNozzle ? 'L' : 'R'} />
-                                )}
-                              </div>
-                              {(ams.humidity != null || ams.temp != null) && (
-                                <div className="flex items-center gap-1.5 max-[550px]:flex-col max-[550px]:items-start">
-                                  {ams.humidity != null && (
-                                    <HumidityIndicator
-                                      humidity={ams.humidity}
-                                      goodThreshold={amsThresholds?.humidityGood}
-                                      fairThreshold={amsThresholds?.humidityFair}
-                                      onClick={() => setAmsHistoryModal({
-                                        amsId: ams.id,
-                                        amsLabel: getAmsLabel(ams.id, ams.tray.length),
-                                        mode: 'humidity',
-                                      })}
-                                      compact
-                                    />
-                                  )}
-                                  {ams.temp != null && (
-                                    <TemperatureIndicator
-                                      temp={ams.temp}
-                                      goodThreshold={amsThresholds?.tempGood}
-                                      fairThreshold={amsThresholds?.tempFair}
-                                      onClick={() => setAmsHistoryModal({
-                                        amsId: ams.id,
-                                        amsLabel: getAmsLabel(ams.id, ams.tray.length),
-                                        mode: 'temperature',
-                                      })}
-                                      compact
-                                    />
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                            {/* Slots grid: 4 columns - always render 4 slots */}
-                            <div className="grid grid-cols-4 gap-1.5">
-                              {[0, 1, 2, 3].map((slotIdx) => {
-                                // Find tray data for this slot (may be undefined if data incomplete)
-                                // Use array index if available, as tray.id may not always be set
-                                const tray = ams.tray[slotIdx] || ams.tray.find(t => t.id === slotIdx);
-                                const hasFillLevel = tray?.tray_type && tray.remain >= 0;
-                                const isEmpty = !tray?.tray_type;
-                                // Check if this is the currently loaded tray
-                                // Global tray ID = ams.id * 4 + slot index (for standard AMS)
-                                const globalTrayId = ams.id * 4 + slotIdx;
-                                const isActive = effectiveTrayNow === globalTrayId;
-                                // Get cloud preset info if available
-                                const cloudInfo = tray?.tray_info_idx ? filamentInfo?.[tray.tray_info_idx] : null;
-                                // Get saved slot preset mapping (for user-configured slots)
-                                const slotPreset = slotPresets?.[globalTrayId];
-
-                                // Fill level fallback chain: Spoolman → Inventory → AMS remain
-                                const trayTag = tray?.tray_uuid?.toUpperCase();
-                                const linkedSpool = trayTag ? linkedSpools?.[trayTag] : undefined;
-                                const spoolmanFill = getSpoolmanFillLevel(linkedSpool);
-                                const inventoryAssignment = onGetAssignment?.(printer.id, ams.id, slotIdx);
-                                const inventoryFill = (() => {
-                                  const sp = inventoryAssignment?.spool;
-                                  if (sp && sp.label_weight > 0 && sp.weight_used != null) {
-                                    return Math.round(Math.max(0, sp.label_weight - sp.weight_used) / sp.label_weight * 100);
-                                  }
-                                  return null;
-                                })();
-                                const effectiveFill = spoolmanFill ?? inventoryFill ?? (hasFillLevel ? tray.remain : null);
-                                const fillSource = spoolmanFill !== null ? 'spoolman' as const
-                                  : inventoryFill !== null ? 'inventory' as const
-                                  : hasFillLevel ? 'ams' as const
-                                  : undefined;
-
-                                // Build filament data for hover card
-                                const filamentData = tray?.tray_type ? {
-                                  vendor: (isBambuLabSpool(tray) ? 'Bambu Lab' : 'Generic') as 'Bambu Lab' | 'Generic',
-                                  profile: cloudInfo?.name || slotPreset?.preset_name || tray.tray_sub_brands || tray.tray_type,
-                                  colorName: getBambuColorName(tray.tray_id_name) || hexToColorName(tray.tray_color),
-                                  colorHex: tray.tray_color || null,
-                                  kFactor: formatKValue(tray.k),
-                                  fillLevel: effectiveFill,
-                                  trayUuid: tray.tray_uuid || null,
-                                  tagUid: tray.tag_uid || null,
-                                  fillSource,
-                                } : null;
-
-                                // Check if this specific slot is being refreshed
-                                const isRefreshing = refreshingSlot?.amsId === ams.id &&
-                                  refreshingSlot?.slotId === slotIdx;
-
-                                // Slot visual content (goes inside hover card)
-                                const slotVisual = (
-                                  <div
-                                    className={`bg-bambu-dark-tertiary rounded p-1 text-center ${isEmpty ? 'opacity-50' : ''} ${isActive ? 'ring-2 ring-bambu-green ring-offset-1 ring-offset-bambu-dark' : ''}`}
-                                  >
-                                    {/* Filament color circle with 1-based slot number centered inside */}
-                                    <FilamentSlotCircle
-                                      trayColor={tray?.tray_color}
-                                      trayType={tray?.tray_type}
-                                      isEmpty={isEmpty}
-                                      slotNumber={slotIdx + 1}
-                                    />
-                                    <div className="text-[9px] text-white font-bold truncate">
-                                      {tray?.tray_type || '—'}
-                                    </div>
-                                    {/* Fill bar */}
-                                    <div className="mt-1 h-1.5 bg-black/30 rounded-full overflow-hidden">
-                                      {effectiveFill !== null && effectiveFill >= 0 && tray && (
-                                        <div
-                                          className="h-full rounded-full transition-all"
-                                          style={{
-                                            width: `${effectiveFill}%`,
-                                            backgroundColor: getFillBarColor(effectiveFill),
-                                          }}
-                                        />
-                                      )}
-                                    </div>
-                                  </div>
-                                );
-
-                                // Wrapper with menu button, dropdown, and loading overlay (outside hover card)
-                                return (
-                                  <div key={slotIdx} className="relative group">
-                                    {/* Loading overlay during RFID re-read */}
-                                    {isRefreshing && (
-                                      <div className="absolute inset-0 bg-bambu-dark-tertiary/80 rounded flex items-center justify-center z-20">
-                                        <RefreshCw className="w-4 h-4 text-bambu-green animate-spin" />
-                                      </div>
-                                    )}
-                                    {/* Menu button - appears on hover, hidden when printer busy */}
-                                    {status?.state !== 'RUNNING' && (
-                                      <button
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          setAmsSlotMenu(
-                                            amsSlotMenu?.amsId === ams.id && amsSlotMenu?.slotId === slotIdx
-                                              ? null
-                                              : { amsId: ams.id, slotId: slotIdx }
-                                          );
-                                        }}
-                                        className="absolute -top-1 -right-1 w-4 h-4 bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10 hover:bg-bambu-dark-tertiary"
-                                        title={t('printers.slotOptions')}
-                                      >
-                                        <MoreVertical className="w-2.5 h-2.5 text-bambu-gray" />
-                                      </button>
-                                    )}
-                                    {/* Dropdown menu */}
-                                    {status?.state !== 'RUNNING' && amsSlotMenu?.amsId === ams.id && amsSlotMenu?.slotId === slotIdx && (
-                                      <div className="absolute top-full left-0 mt-1 z-50 bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-lg shadow-xl py-1 min-w-[120px]">
-                                        <button
-                                          className={`w-full px-3 py-1.5 text-left text-xs flex items-center gap-2 ${
-                                            hasPermission('printers:ams_rfid')
-                                              ? 'text-white hover:bg-bambu-dark-tertiary'
-                                              : 'text-bambu-gray/50 cursor-not-allowed'
-                                          }`}
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            if (!hasPermission('printers:ams_rfid')) return;
-                                            refreshAmsSlotMutation.mutate({ amsId: ams.id, slotId: slotIdx });
-                                            setAmsSlotMenu(null);
-                                          }}
-                                          disabled={isRefreshing || !hasPermission('printers:ams_rfid')}
-                                          title={!hasPermission('printers:ams_rfid') ? t('printers.permission.noAmsRfid') : undefined}
-                                        >
-                                          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
-                                          {t('printers.rfid.reread')}
-                                        </button>
-                                      </div>
-                                    )}
-                                    {/* Hover card wraps only the visual content */}
-                                    {filamentData ? (
-                                      <FilamentHoverCard
-                                        data={filamentData}
-                                        spoolman={{
-                                          enabled: spoolmanEnabled,
-                                          hasUnlinkedSpools,
-                                          linkedSpoolId: filamentData.trayUuid ? linkedSpools?.[filamentData.trayUuid.toUpperCase()]?.id : undefined,
-                                          spoolmanUrl,
-                                          onLinkSpool: spoolmanEnabled && filamentData.trayUuid ? (uuid) => {
-                                            setLinkSpoolModal({
-                                              tagUid: filamentData.tagUid || '',
-                                              trayUuid: uuid,
-                                              printerId: printer.id,
-                                              amsId: ams.id,
-                                              trayId: slotIdx,
-                                            });
-                                          } : undefined,
-                                        }}
-                                        inventory={spoolmanEnabled ? undefined : (() => {
-                                          const assignment = onGetAssignment?.(printer.id, ams.id, slotIdx);
-                                          return {
-                                            assignedSpool: assignment?.spool ? {
-                                              id: assignment.spool.id,
-                                              material: assignment.spool.material,
-                                              brand: assignment.spool.brand,
-                                              color_name: assignment.spool.color_name,
-                                              remainingWeightGrams: Math.max(0, Math.round(assignment.spool.label_weight - assignment.spool.weight_used)),
-                                            } : null,
-                                            onAssignSpool: filamentData.vendor !== 'Bambu Lab' ? () => setAssignSpoolModal({
-                                              printerId: printer.id,
-                                              amsId: ams.id,
-                                              trayId: slotIdx,
-                                              trayInfo: {
-                                                type: filamentData.profile,
-                                                color: filamentData.colorHex || '',
-                                                location: `${getAmsLabel(ams.id, ams.tray.length)} Slot ${slotIdx + 1}`,
-                                              },
-                                            }) : undefined,
-                                            onUnassignSpool: assignment && filamentData.vendor !== 'Bambu Lab' ? () => onUnassignSpool?.(printer.id, ams.id, slotIdx) : undefined,
-                                          };
-                                        })()}
-                                        configureSlot={{
-                                          enabled: hasPermission('printers:control'),
-                                          onConfigure: () => setConfigureSlotModal({
-                                            amsId: ams.id,
-                                            trayId: slotIdx,
-                                            trayCount: ams.tray.length,
-                                            trayType: tray?.tray_type || undefined,
-                                            trayColor: tray?.tray_color || undefined,
-                                            traySubBrands: tray?.tray_sub_brands || undefined,
-                                            trayInfoIdx: tray?.tray_info_idx || undefined,
-                                            extruderId: mappedExtruderId,
-                                            caliIdx: tray?.cali_idx,
-                                            savedPresetId: slotPreset?.preset_id,
-                                          }),
-                                        }}
-                                      >
-                                        {slotVisual}
-                                      </FilamentHoverCard>
-                                    ) : (
-                                      <EmptySlotHoverCard
-                                        configureSlot={{
-                                          enabled: hasPermission('printers:control'),
-                                          onConfigure: () => setConfigureSlotModal({
-                                            amsId: ams.id,
-                                            trayId: slotIdx,
-                                            trayCount: ams.tray.length,
-                                            extruderId: mappedExtruderId,
-                                          }),
-                                        }}
-                                      >
-                                        {slotVisual}
-                                      </EmptySlotHoverCard>
-                                    )}
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-
-                    {/* Row 3: HT AMS + External spools (same style as regular AMS, 4 across) */}
-                    {(htAms.length > 0 || status.vt_tray.length > 0) && (
-                      <div className="grid grid-cols-4 gap-3">
-                      {/* HT AMS units - name/badge top, slot left, stats right */}
-                      {htAms.map((ams) => {
-                        const mappedExtruderId = amsExtruderMap[String(ams.id)];
-                        const normalizedId = ams.id >= 128 ? ams.id - 128 : ams.id;
-                        const extruderId = mappedExtruderId !== undefined ? mappedExtruderId : normalizedId;
-                        const isLeftNozzle = extruderId === 1;
-                        const isRightNozzle = extruderId === 0;
-                        const tray = ams.tray[0];
-                        const hasFillLevel = tray?.tray_type && tray.remain >= 0;
-                        const isEmpty = !tray?.tray_type;
-                        // Check if this is the currently loaded tray
-                        const globalTrayId = getGlobalTrayId(ams.id, tray?.id ?? 0, false);
-                        const isActive = effectiveTrayNow === globalTrayId;
-                        // Get cloud preset info if available
-                        const cloudInfo = tray?.tray_info_idx ? filamentInfo?.[tray.tray_info_idx] : null;
-                        // Get saved slot preset mapping (for user-configured slots)
-                        const slotPreset = slotPresets?.[globalTrayId];
-
-                        // Fill level fallback chain: Spoolman → Inventory → AMS remain
-                        const htTrayTag = tray?.tray_uuid?.toUpperCase();
-                        const htLinkedSpool = htTrayTag ? linkedSpools?.[htTrayTag] : undefined;
-                        const htSpoolmanFill = getSpoolmanFillLevel(htLinkedSpool);
-                        const htTraySlotId = tray?.id ?? 0;
-                        const htInventoryAssignment = onGetAssignment?.(printer.id, ams.id, htTraySlotId);
-                        const htInventoryFill = (() => {
-                          const sp = htInventoryAssignment?.spool;
-                          if (sp && sp.label_weight > 0 && sp.weight_used != null) {
-                            return Math.round(Math.max(0, sp.label_weight - sp.weight_used) / sp.label_weight * 100);
-                          }
-                          return null;
-                        })();
-                        const htEffectiveFill = htSpoolmanFill ?? htInventoryFill ?? (hasFillLevel ? tray.remain : null);
-                        const htFillSource = htSpoolmanFill !== null ? 'spoolman' as const
-                          : htInventoryFill !== null ? 'inventory' as const
-                          : hasFillLevel ? 'ams' as const
-                          : undefined;
-
-                        // Build filament data for hover card
-                        const filamentData = tray?.tray_type ? {
-                          vendor: (isBambuLabSpool(tray) ? 'Bambu Lab' : 'Generic') as 'Bambu Lab' | 'Generic',
-                          profile: cloudInfo?.name || slotPreset?.preset_name || tray.tray_sub_brands || tray.tray_type,
-                          colorName: getBambuColorName(tray.tray_id_name) || hexToColorName(tray.tray_color),
-                          colorHex: tray.tray_color || null,
-                          kFactor: formatKValue(tray.k),
-                          fillLevel: htEffectiveFill,
-                          trayUuid: tray.tray_uuid || null,
-                          tagUid: tray.tag_uid || null,
-                          fillSource: htFillSource,
-                        } : null;
-
-                        const htSlotId = tray?.id ?? 0;
-                        // Check if this specific slot is being refreshed
-                        const isHtRefreshing = refreshingSlot?.amsId === ams.id &&
-                          refreshingSlot?.slotId === htSlotId;
-
-                        // Slot visual content (goes inside hover card)
-                        const slotVisual = (
-                          <div
-                            className={`bg-bambu-dark-tertiary rounded p-1 text-center ${isEmpty ? 'opacity-50' : ''} ${isActive ? 'ring-2 ring-bambu-green ring-offset-1 ring-offset-bambu-dark' : ''}`}
-                          >
-                            {/* Filament color circle with 1-based slot number centered inside */}
-                            <FilamentSlotCircle
-                              trayColor={tray?.tray_color}
-                              trayType={tray?.tray_type}
-                              isEmpty={isEmpty}
-                              slotNumber={1}
+                  <div className={`space-y-1.5 ${isDualNozzle && '@sm:items-start grid grid-cols-1 @sm:grid-cols-[1fr_1px_1fr] gap-1.5'}`}>
+                    {Array.from({ length: printer.nozzle_count }, (_, i) => i).reverse().map((extruderIndex, i) => (
+                      <React.Fragment key={extruderIndex}>
+                        {i > 0 && <div className="bg-bambu-dark-tertiary @sm:h-full h-px @sm:w-auto w-full"></div>}
+                        <div className="flex flex-wrap gap-1.5">
+                          {/* AMS */}
+                          {amsData.sort((a, b) => (b.tray.length - a.tray.length)).filter((ams) => (amsExtruderMap[String(ams.id)] !== undefined ? amsExtruderMap[String(ams.id)] : ams.id >= 128 ? ams.id - 128 : ams.id) === extruderIndex).map((ams) => (
+                            <AMSUnitCard
+                              key={ams.id}
+                              ams={ams}
+                              isDualNozzle={isDualNozzle}
+                              amsExtruderMap={amsExtruderMap}
+                              effectiveTrayNow={effectiveTrayNow}
+                              filamentInfo={filamentInfo}
+                              slotPresets={slotPresets}
+                              amsThresholds={amsThresholds}
+                              printerId={printer.id}
+                              printerState={status?.state}
+                              spoolmanEnabled={spoolmanEnabled}
+                              hasUnlinkedSpools={hasUnlinkedSpools}
+                              linkedSpools={linkedSpools}
+                              spoolmanUrl={spoolmanUrl}
+                              onGetAssignment={onGetAssignment}
+                              onUnassignSpool={onUnassignSpool}
+                              amsSlotMenu={amsSlotMenu}
+                              setAmsSlotMenu={setAmsSlotMenu}
+                              refreshingSlot={refreshingSlot}
+                              onRefreshSlot={(amsId, slotId) => refreshAmsSlotMutation.mutate({ amsId, slotId })}
+                              hasPermission={hasPermission}
+                              onOpenAmsHistory={(amsId, amsLabel, mode) => setAmsHistoryModal({ amsId, amsLabel, mode })}
+                              onOpenLinkSpool={(tagUid, trayUuid, pId, aId, tId) => setLinkSpoolModal({ tagUid, trayUuid, printerId: pId, amsId: aId, trayId: tId })}
+                              onOpenAssignSpool={(pId, aId, tId, trayInfo) => setAssignSpoolModal({ printerId: pId, amsId: aId, trayId: tId, trayInfo })}
+                              onOpenConfigureSlot={(config) => setConfigureSlotModal(config)}
+                              amsLabels={amsLabels}
+                              onAmsLabelSaved={() => refetchAmsLabels()}
                             />
-                            <div className="text-[9px] text-white font-bold truncate">
-                              {tray?.tray_type || '—'}
-                            </div>
-                            {/* Fill bar */}
-                            <div className="mt-1 h-1.5 bg-black/30 rounded-full overflow-hidden">
-                              {htEffectiveFill !== null && htEffectiveFill >= 0 && (
-                                <div
-                                  className="h-full rounded-full transition-all"
-                                  style={{
-                                    width: `${htEffectiveFill}%`,
-                                    backgroundColor: getFillBarColor(htEffectiveFill),
-                                  }}
-                                />
-                              )}
-                            </div>
-                          </div>
-                        );
-
-                        return (
-                          <div key={ams.id} className="p-2.5 bg-bambu-dark rounded-lg border border-bambu-dark-tertiary/30">
-                            {/* Row 1: Label + Nozzle */}
-                            <div className="flex items-center gap-1 mb-2">
-                              {/* AMS name — hover to see serial, firmware, and edit friendly name */}
-                              <AmsNameHoverCard
-                                ams={ams}
-                                printerId={printer.id}
-                                label={getAmsLabel(ams.id, ams.tray.length)}
-                                amsLabels={amsLabels}
-                                canEdit={hasPermission('printers:update')}
-                                onSaved={refetchAmsLabels}
-                              >
-                                <span className="text-[10px] text-white font-medium cursor-default select-none">
-                                  {amsLabels?.[ams.id] || getAmsLabel(ams.id, ams.tray.length)}
-                                </span>
-                              </AmsNameHoverCard>
-                              {isDualNozzle && (isLeftNozzle || isRightNozzle) && (
-                                <NozzleBadge side={isLeftNozzle ? 'L' : 'R'} />
-                              )}
-                            </div>
-                            {/* Row 2: Slot (left) + Stats (right stacked) */}
-                            <div className="flex gap-1.5 max-[550px]:flex-col max-[550px]:items-start">
-                              {/* Slot wrapper with menu button, dropdown, and loading overlay */}
-                              <div className="relative group flex-1 max-[550px]:w-full">
-                                {/* Loading overlay during RFID re-read */}
-                                {isHtRefreshing && (
-                                  <div className="absolute inset-0 bg-bambu-dark-tertiary/80 rounded flex items-center justify-center z-20">
-                                    <RefreshCw className="w-4 h-4 text-bambu-green animate-spin" />
-                                  </div>
-                                )}
-                                {/* Menu button - appears on hover, hidden when printer busy */}
-                                {status?.state !== 'RUNNING' && (
-                                  <button
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      setAmsSlotMenu(
-                                        amsSlotMenu?.amsId === ams.id && amsSlotMenu?.slotId === htSlotId
-                                          ? null
-                                          : { amsId: ams.id, slotId: htSlotId }
-                                      );
-                                    }}
-                                    className="absolute -top-1 -right-1 w-4 h-4 bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10 hover:bg-bambu-dark-tertiary"
-                                    title={t('printers.slotOptions')}
-                                  >
-                                    <MoreVertical className="w-2.5 h-2.5 text-bambu-gray" />
-                                  </button>
-                                )}
-                                {/* Dropdown menu */}
-                                {status?.state !== 'RUNNING' && amsSlotMenu?.amsId === ams.id && amsSlotMenu?.slotId === htSlotId && (
-                                  <div className="absolute top-full left-0 mt-1 z-50 bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-lg shadow-xl py-1 min-w-[120px]">
-                                    <button
-                                      className={`w-full px-3 py-1.5 text-left text-xs flex items-center gap-2 ${
-                                        hasPermission('printers:ams_rfid')
-                                          ? 'text-white hover:bg-bambu-dark-tertiary'
-                                          : 'text-bambu-gray/50 cursor-not-allowed'
-                                      }`}
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        if (!hasPermission('printers:ams_rfid')) return;
-                                        refreshAmsSlotMutation.mutate({ amsId: ams.id, slotId: htSlotId });
-                                        setAmsSlotMenu(null);
-                                      }}
-                                      disabled={isHtRefreshing || !hasPermission('printers:ams_rfid')}
-                                      title={!hasPermission('printers:ams_rfid') ? t('printers.permission.noAmsRfid') : undefined}
-                                    >
-                                      <RefreshCw className={`w-3 h-3 ${isHtRefreshing ? 'animate-spin' : ''}`} />
-                                      {t('printers.rfid.reread')}
-                                    </button>
-                                  </div>
-                                )}
-                                {/* Hover card wraps only the visual content */}
-                                {filamentData ? (
-                                  <FilamentHoverCard
-                                    data={filamentData}
-                                    spoolman={{
-                                      enabled: spoolmanEnabled,
-                                      hasUnlinkedSpools,
-                                      linkedSpoolId: filamentData.trayUuid ? linkedSpools?.[filamentData.trayUuid.toUpperCase()]?.id : undefined,
-                                      spoolmanUrl,
-                                      onLinkSpool: spoolmanEnabled && filamentData.trayUuid ? (uuid) => {
-                                        setLinkSpoolModal({
-                                          tagUid: filamentData.tagUid || '',
-                                          trayUuid: uuid,
-                                          printerId: printer.id,
-                                          amsId: ams.id,
-                                          trayId: htSlotId,
-                                        });
-                                      } : undefined,
-                                    }}
-                                    inventory={spoolmanEnabled ? undefined : (() => {
-                                      const assignment = onGetAssignment?.(printer.id, ams.id, htSlotId);
-                                      return {
-                                        assignedSpool: assignment?.spool ? {
-                                          id: assignment.spool.id,
-                                          material: assignment.spool.material,
-                                          brand: assignment.spool.brand,
-                                          color_name: assignment.spool.color_name,
-                                          remainingWeightGrams: Math.max(0, Math.round(assignment.spool.label_weight - assignment.spool.weight_used)),
-                                        } : null,
-                                        onAssignSpool: filamentData.vendor !== 'Bambu Lab' ? () => setAssignSpoolModal({
-                                          printerId: printer.id,
-                                          amsId: ams.id,
-                                          trayId: htSlotId,
-                                          trayInfo: {
-                                            type: filamentData.profile,
-                                            color: filamentData.colorHex || '',
-                                            location: getAmsLabel(ams.id, ams.tray.length),
-                                          },
-                                        }) : undefined,
-                                        onUnassignSpool: assignment && filamentData.vendor !== 'Bambu Lab' ? () => onUnassignSpool?.(printer.id, ams.id, htSlotId) : undefined,
-                                      };
-                                    })()}
-                                    configureSlot={{
-                                      enabled: hasPermission('printers:control'),
-                                      onConfigure: () => setConfigureSlotModal({
-                                        amsId: ams.id,
-                                        trayId: htSlotId,
-                                        trayCount: ams.tray.length,
-                                        trayType: tray?.tray_type || undefined,
-                                        trayColor: tray?.tray_color || undefined,
-                                        traySubBrands: tray?.tray_sub_brands || undefined,
-                                        trayInfoIdx: tray?.tray_info_idx || undefined,
-                                        extruderId: mappedExtruderId,
-                                        caliIdx: tray?.cali_idx,
-                                        savedPresetId: slotPreset?.preset_id,
-                                      }),
-                                    }}
-                                  >
-                                    {slotVisual}
-                                  </FilamentHoverCard>
-                                ) : (
-                                  <EmptySlotHoverCard
-                                    configureSlot={{
-                                      enabled: hasPermission('printers:control'),
-                                      onConfigure: () => setConfigureSlotModal({
-                                        amsId: ams.id,
-                                        trayId: htSlotId,
-                                        trayCount: ams.tray.length,
-                                        extruderId: mappedExtruderId,
-                                      }),
-                                    }}
-                                  >
-                                    {slotVisual}
-                                  </EmptySlotHoverCard>
-                                )}
-                              </div>
-                              {/* Stats stacked vertically: Temp on top, Humidity below */}
-                              {(ams.humidity != null || ams.temp != null) && (
-                                <div className="flex flex-col justify-center gap-1 shrink-0 max-[550px]:w-full">
-                                  {ams.temp != null && (
-                                    <TemperatureIndicator
-                                      temp={ams.temp}
-                                      goodThreshold={amsThresholds?.tempGood}
-                                      fairThreshold={amsThresholds?.tempFair}
-                                      onClick={() => setAmsHistoryModal({
-                                        amsId: ams.id,
-                                        amsLabel: getAmsLabel(ams.id, ams.tray.length),
-                                        mode: 'temperature',
-                                      })}
-                                      compact
-                                    />
-                                  )}
-                                  {ams.humidity != null && (
-                                    <HumidityIndicator
-                                      humidity={ams.humidity}
-                                      goodThreshold={amsThresholds?.humidityGood}
-                                      fairThreshold={amsThresholds?.humidityFair}
-                                      onClick={() => setAmsHistoryModal({
-                                        amsId: ams.id,
-                                        amsLabel: getAmsLabel(ams.id, ams.tray.length),
-                                        mode: 'humidity',
-                                      })}
-                                      compact
-                                    />
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        );
-                      })}
+                          ))}
                       {/* External spool(s) - grouped in one card like regular AMS */}
-                      {status.vt_tray.length > 0 && (
-                        <div className={`p-2.5 bg-bambu-dark rounded-lg border border-bambu-dark-tertiary/30 ${status.vt_tray.length === 1 ? 'max-w-[50%]' : ''}`}>
+                      {(() => {
+                        // For dual-nozzle, filter external spools by extruder: id 254 → extruder 1 (left), id 255 → extruder 0 (right)
+                        const filteredVtTray = isDualNozzle
+                          ? status.vt_tray.filter((t) => ((t.id ?? 254) === 254 ? 1 : 0) === extruderIndex)
+                          : status.vt_tray;
+                        return filteredVtTray.length > 0 && (
+                        <div className={`p-2.5 bg-bambu-dark rounded-lg border border-bambu-dark-tertiary/30 ${filteredVtTray.length === 1 ? 'flex-[1] min-w-[50px] max-w-[80px]' : 'flex-[2] min-w-[100px] max-w-[150px]'}`}>
                           <div className="flex items-center gap-1 mb-2">
                             <span className="text-[10px] text-white font-medium">{t('printers.external')}</span>
                           </div>
-                          <div className={`grid ${status.vt_tray.length > 1 ? 'grid-cols-2' : 'grid-cols-1'} gap-1.5`}>
-                            {[...status.vt_tray].sort((a, b) => (a.id ?? 254) - (b.id ?? 254)).map((extTray) => {
+                          <div className={`grid ${filteredVtTray.length > 1 ? 'grid-cols-2' : 'grid-cols-1'} gap-1.5`}>
+                            {[...filteredVtTray].sort((a, b) => (a.id ?? 254) - (b.id ?? 254)).map((extTray) => {
                               const extTrayId = extTray.id ?? 254;
                               // On dual-nozzle (H2C/H2D), tray_now=254 means "external spool"
                               // generically — use active_extruder to determine L vs R:
@@ -3688,9 +2964,11 @@ function PrinterCard({
                             })}
                           </div>
                         </div>
-                      )}
+                        );
+                      })()}
                       </div>
-                    )}
+                      </React.Fragment>
+                    ))}
                   </div>
                 </div>
               );
@@ -3708,13 +2986,12 @@ function PrinterCard({
                 <span className="text-sm text-white truncate">{smartPlug.name}</span>
                 {plugStatus && (
                   <span
-                    className={`text-xs px-1.5 py-0.5 rounded flex-shrink-0 ${
-                      plugStatus.state === 'ON'
-                        ? 'bg-bambu-green/20 text-bambu-green'
-                        : plugStatus.state === 'OFF'
+                    className={`text-xs px-1.5 py-0.5 rounded flex-shrink-0 ${plugStatus.state === 'ON'
+                      ? 'bg-bambu-green/20 text-bambu-green'
+                      : plugStatus.state === 'OFF'
                         ? 'bg-red-500/20 text-red-400'
                         : 'bg-bambu-gray/20 text-bambu-gray'
-                    }`}
+                      }`}
                   >
                     {plugStatus.state || '?'}
                     {plugStatus.state === 'ON' && plugStatus.energy?.power != null && (
@@ -3732,13 +3009,12 @@ function PrinterCard({
                 <button
                   onClick={() => setShowPowerOnConfirm(true)}
                   disabled={powerControlMutation.isPending || plugStatus?.state === 'ON' || !hasPermission('smart_plugs:control')}
-                  className={`px-2 py-1 text-xs rounded transition-colors flex items-center gap-1 ${
-                    !hasPermission('smart_plugs:control')
-                      ? 'bg-bambu-dark text-bambu-gray/50 cursor-not-allowed'
-                      : plugStatus?.state === 'ON'
-                        ? 'bg-bambu-green text-white'
-                        : 'bg-bambu-dark text-bambu-gray hover:text-white hover:bg-bambu-dark-tertiary'
-                  }`}
+                  className={`px-2 py-1 text-xs rounded transition-colors flex items-center gap-1 ${!hasPermission('smart_plugs:control')
+                    ? 'bg-bambu-dark text-bambu-gray/50 cursor-not-allowed'
+                    : plugStatus?.state === 'ON'
+                      ? 'bg-bambu-green text-white'
+                      : 'bg-bambu-dark text-bambu-gray hover:text-white hover:bg-bambu-dark-tertiary'
+                    }`}
                   title={!hasPermission('smart_plugs:control') ? t('printers.permission.noSmartPlugControl') : undefined}
                 >
                   <Power className="w-3 h-3" />
@@ -3747,13 +3023,12 @@ function PrinterCard({
                 <button
                   onClick={() => setShowPowerOffConfirm(true)}
                   disabled={powerControlMutation.isPending || plugStatus?.state === 'OFF' || !hasPermission('smart_plugs:control')}
-                  className={`px-2 py-1 text-xs rounded transition-colors flex items-center gap-1 ${
-                    !hasPermission('smart_plugs:control')
-                      ? 'bg-bambu-dark text-bambu-gray/50 cursor-not-allowed'
-                      : plugStatus?.state === 'OFF'
-                        ? 'bg-red-500/30 text-red-400'
-                        : 'bg-bambu-dark text-bambu-gray hover:text-white hover:bg-bambu-dark-tertiary'
-                  }`}
+                  className={`px-2 py-1 text-xs rounded transition-colors flex items-center gap-1 ${!hasPermission('smart_plugs:control')
+                    ? 'bg-bambu-dark text-bambu-gray/50 cursor-not-allowed'
+                    : plugStatus?.state === 'OFF'
+                      ? 'bg-red-500/30 text-red-400'
+                      : 'bg-bambu-dark text-bambu-gray hover:text-white hover:bg-bambu-dark-tertiary'
+                    }`}
                   title={!hasPermission('smart_plugs:control') ? t('printers.permission.noSmartPlugControl') : undefined}
                 >
                   <PowerOff className="w-3 h-3" />
@@ -3770,18 +3045,16 @@ function PrinterCard({
                   onClick={() => toggleAutoOffMutation.mutate(!smartPlug.auto_off)}
                   disabled={toggleAutoOffMutation.isPending || smartPlug.auto_off_executed || !hasPermission('smart_plugs:control')}
                   title={!hasPermission('smart_plugs:control') ? t('printers.permission.noSmartPlugControl') : (smartPlug.auto_off_executed ? t('printers.autoOffExecuted') : t('printers.autoOffAfterPrint'))}
-                  className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${
-                    !hasPermission('smart_plugs:control')
-                      ? 'bg-bambu-dark-tertiary/50 cursor-not-allowed'
-                      : smartPlug.auto_off_executed
-                        ? 'bg-bambu-green/50 cursor-not-allowed'
-                        : smartPlug.auto_off ? 'bg-bambu-green' : 'bg-bambu-dark-tertiary'
-                  }`}
+                  className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${!hasPermission('smart_plugs:control')
+                    ? 'bg-bambu-dark-tertiary/50 cursor-not-allowed'
+                    : smartPlug.auto_off_executed
+                      ? 'bg-bambu-green/50 cursor-not-allowed'
+                      : smartPlug.auto_off ? 'bg-bambu-green' : 'bg-bambu-dark-tertiary'
+                    }`}
                 >
                   <span
-                    className={`absolute top-[2px] left-[2px] w-4 h-4 bg-white rounded-full transition-transform ${
-                      smartPlug.auto_off || smartPlug.auto_off_executed ? 'translate-x-4' : 'translate-x-0'
-                    }`}
+                    className={`absolute top-[2px] left-[2px] w-4 h-4 bg-white rounded-full transition-transform ${smartPlug.auto_off || smartPlug.auto_off_executed ? 'translate-x-4' : 'translate-x-0'
+                      }`}
                   />
                 </button>
               </div>
@@ -3813,7 +3086,7 @@ function PrinterCard({
 
         {/* Connection Info & Actions - hidden in compact mode */}
         {viewMode === 'expanded' && (
-          <div className="mt-4 pt-4 border-t border-bambu-dark-tertiary flex items-center justify-end gap-2 flex-wrap">
+          <div className="mt-auto pt-4 border-t border-bambu-dark-tertiary flex items-center justify-end gap-2 flex-wrap">
               {/* Chamber Light */}
               <Button
                 variant="secondary"
@@ -4557,8 +3830,8 @@ function AddPrinterModal({
   // Cleanup discovery on unmount
   useEffect(() => {
     return () => {
-      discoveryApi.stopDiscovery().catch(() => {});
-      discoveryApi.stopSubnetScan().catch(() => {});
+      discoveryApi.stopDiscovery().catch(() => { });
+      discoveryApi.stopSubnetScan().catch(() => { });
     };
   }, []);
 
@@ -4953,10 +4226,9 @@ function FirmwareUpdateModal({
               </div>
               <div className="w-full bg-bambu-dark-tertiary rounded-full h-2">
                 <div
-                  className={`h-2 rounded-full transition-all ${
-                    uploadStatus.status === 'error' ? 'bg-status-error' :
+                  className={`h-2 rounded-full transition-all ${uploadStatus.status === 'error' ? 'bg-status-error' :
                     uploadStatus.status === 'complete' ? 'bg-status-ok' : 'bg-orange-500'
-                  } ${uploadStatus.status === 'uploading' ? 'animate-pulse' : ''}`}
+                    } ${uploadStatus.status === 'uploading' ? 'animate-pulse' : ''}`}
                   style={{ width: `${uploadStatus.progress}%` }}
                 />
               </div>
@@ -5231,11 +4503,10 @@ function PowerDropdownItem({
         <span className="text-sm text-gray-900 dark:text-white truncate">{printer.name}</span>
         {plugStatus && (
           <span
-            className={`text-xs px-1.5 py-0.5 rounded ${
-              plugStatus.state === 'ON'
-                ? 'bg-bambu-green/20 text-bambu-green'
-                : 'bg-red-500/20 text-red-400'
-            }`}
+            className={`text-xs px-1.5 py-0.5 rounded ${plugStatus.state === 'ON'
+              ? 'bg-bambu-green/20 text-bambu-green'
+              : 'bg-red-500/20 text-red-400'
+              }`}
           >
             {plugStatus.state || '?'}
           </span>
@@ -5244,11 +4515,10 @@ function PowerDropdownItem({
       <button
         onClick={() => onPowerOn(plug.id)}
         disabled={isPowering || plugStatus?.state === 'ON'}
-        className={`px-2 py-1 text-xs rounded transition-colors flex items-center gap-1 ${
-          plugStatus?.state === 'ON'
-            ? 'bg-bambu-green/20 text-bambu-green cursor-default'
-            : 'bg-bambu-green/20 text-bambu-green hover:bg-bambu-green hover:text-white'
-        }`}
+        className={`px-2 py-1 text-xs rounded transition-colors flex items-center gap-1 ${plugStatus?.state === 'ON'
+          ? 'bg-bambu-green/20 text-bambu-green cursor-default'
+          : 'bg-bambu-green/20 text-bambu-green hover:bg-bambu-green hover:text-white'
+          }`}
       >
         <Power className="w-3 h-3" />
         {isPowering ? '...' : 'On'}
@@ -5276,6 +4546,24 @@ export function PrintersPage() {
     const saved = localStorage.getItem('printerCardSize');
     return saved ? parseInt(saved, 10) : 2; // Default to medium
   });
+  // On small screens, clamp cardSize to max 2 (M) since L/XL are hidden
+  useEffect(() => {
+    const mql = window.matchMedia('(min-width: 1024px)');
+    const handler = () => {
+      if (!mql.matches) {
+        setCardSize(prev => {
+          if (prev > 2) {
+            localStorage.setItem('printerCardSize', '2');
+            return 2;
+          }
+          return prev;
+        });
+      }
+    };
+    handler();
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
   // Derive viewMode from cardSize: S=compact, M/L/XL=expanded
   const viewMode: ViewMode = cardSize === 1 ? 'compact' : 'expanded';
   const queryClient = useQueryClient();
@@ -5567,15 +4855,13 @@ export function PrintersPage() {
                     setCardSize(size);
                     localStorage.setItem('printerCardSize', String(size));
                   }}
-                  className={`px-2 py-1.5 text-xs font-medium transition-colors ${
-                    index === 0 ? 'rounded-l-lg' : ''
-                  } ${
-                    index === cardSizeLabels.length - 1 ? 'rounded-r-lg' : ''
-                  } ${
-                    isSelected
+                  className={`px-2 py-1.5 text-xs font-medium transition-colors ${label === 'L' || label === 'XL' ? 'hidden lg:block' : ''} ${index === 0 ? 'rounded-l-lg' : ''
+                    } ${index === cardSizeLabels.length - 1 ? 'rounded-r-lg' : ''
+                    } ${label === 'M' ? 'rounded-r-lg lg:rounded-r-none' : ''
+                    } ${isSelected
                       ? 'bg-bambu-green text-white'
                       : 'text-bambu-gray hover:bg-bambu-dark-tertiary hover:text-white'
-                  }`}
+                    }`}
                   title={label === 'S' ? t('printers.cardSize.small') : label === 'M' ? t('printers.cardSize.medium') : label === 'L' ? t('printers.cardSize.large') : t('printers.cardSize.extraLarge')}
                 >
                   {label}
@@ -5676,7 +4962,7 @@ export function PrintersPage() {
                 {location}
                 <span className="text-sm font-normal text-bambu-gray">({locationPrinters.length})</span>
               </h2>
-              <div className={`grid gap-4 ${cardSize >= 3 ? 'gap-6' : ''} ${getGridClasses()}`}>
+              <div className={`grid gap-4 ${getGridClasses()}`}>
                 {locationPrinters.map((printer) => (
                   <PrinterCard
                     key={printer.id}
@@ -5709,7 +4995,7 @@ export function PrintersPage() {
         </div>
       ) : (
         /* Regular grid view */
-        <div className={`grid gap-4 ${cardSize >= 3 ? 'gap-6' : ''} ${getGridClasses()}`}>
+        <div className={`grid gap-4 ${getGridClasses()}`}>
           {sortedPrinters.map((printer) => (
             <PrinterCard
               key={printer.id}


### PR DESCRIPTION
## Description

Refactor printer card UI: extract AMSUnitCard into a standalone component, fix dual-nozzle external spool display, and improve card layout responsiveness.

FIx #610 #611 #612 #402

<img width="475" height="744" alt="image" src="https://github.com/user-attachments/assets/129283e4-8476-470a-9465-2238580743f5" />
<img width="474" height="909" alt="image" src="https://github.com/user-attachments/assets/0aa69ad1-0a6b-4376-a41a-30fb28d39ad1" />
<img width="390" height="781" alt="image" src="https://github.com/user-attachments/assets/ed474d78-b8e6-420d-bb4c-38dc8872240c" />

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Changes Made

- **AMSUnitCard extraction**: Moved AMS unit rendering (~995 lines) into `frontend/src/components/AMSUnitCard.tsx`, removing ~870 lines of dead inline AMS/HT-AMS code and unused SVG helpers (`NozzleBadge`, `HumidityIndicator`, `TemperatureIndicator`, `WaterDrop*`, `Thermometer*`) from `PrintersPage.tsx`
- **Dual-nozzle external spool fix**: Filter `vt_tray` by extruder index so the left column only shows Ext-L (id 254) and the right column only shows Ext-R (id 255) — previously both spools appeared in both columns
- **Card layout**: `flex flex-col h-full` on Card, `flex flex-col gap-2 flex-1` on CardContent, `mt-auto` on bottom buttons so they always pin to the card bottom
- **Responsive padding**: `CardContent` now uses `p-3 lg:p-6` instead of `p-6`
- **Small screen card size**: Clamp card size to max M on screens < 1024px, hide L/XL size buttons
- **Spacing cleanup**: Remove redundant `mb-3` from `PrinterQueueWidget` (parent `gap-2` handles spacing)
- **Gitignore**: Add `.planning/` to prevent GSD planning artifacts from being committed

## Testing

- [x] I have tested this on my local machine
- [x] All 1038 frontend tests pass (69 test files)
- [x] `npm run build` (tsc -b + Vite) compiles cleanly
- [x] Card.test.tsx updated for new responsive padding classes

## Checklist

- [x] My code follows the project's coding style
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes
