### PR TITLE
feat(metrics): add bambuddy_build_info metric

### DIFF
--- a/backend/app/api/routes/metrics.py
+++ b/backend/app/api/routes/metrics.py
@@ -1,9 +1,12 @@
 """Prometheus metrics endpoint for external monitoring."""
 
+import platform
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.app.core.config import APP_VERSION
 from backend.app.core.database import get_db
 from backend.app.models.archive import PrintArchive
 from backend.app.models.print_queue import PrintQueueItem
@@ -76,6 +79,20 @@ async def get_metrics(
             raise HTTPException(status_code=401, detail="Invalid token")
 
     lines: list[str] = []
+
+    # =========================================================================
+    # Build info
+    # =========================================================================
+
+    lines.append("# HELP bambuddy_build_info Build and version information")
+    lines.append("# TYPE bambuddy_build_info gauge")
+    build_labels = format_labels(
+        version=APP_VERSION,
+        python_version=platform.python_version(),
+        platform=platform.system(),
+        architecture=platform.machine(),
+    )
+    lines.append(f"bambuddy_build_info{build_labels} 1")
 
     # =========================================================================
     # Printer metrics


### PR DESCRIPTION
## Description

Add a `bambuddy_build_info` gauge metric to the Prometheus metrics endpoint that exposes build and version information, including the application version, Python version, platform, and architecture.

## Related Issue

<!-- No specific issue -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

- Added `bambuddy_build_info` gauge metric to `backend/app/api/routes/metrics.py`
- Metric labels include: `version`, `python_version`, `platform`, `architecture`
- Uses existing `APP_VERSION` from config and Python's `platform` module

## Screenshots

Example metric output:
```
# HELP bambuddy_build_info Build and version information
# TYPE bambuddy_build_info gauge
bambuddy_build_info{version="0.2.2",python_version="3.12.0",platform="Linux",architecture="x86_64"} 1
```

## Testing

- [x] I have tested this on my local machine
- [ ] I have tested with my printer model: <!-- N/A - metrics endpoint only -->

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

This follows the standard Prometheus `_build_info` convention (similar to `prometheus_build_info`). The metric always has value `1` and carries version/environment details as labels, making it useful for dashboards and alerting on version changes.