### PR TITLE
[Fix]: Ensures AMS-HT devices are properly identified in Spoolman

### DIFF
--- a/backend/app/services/spoolman.py
+++ b/backend/app/services/spoolman.py
@@ -42,7 +42,7 @@ class SpoolmanFilament:
 class AMSTray:
     """Represents an AMS tray with filament data from Bambu printer."""
 
-    ams_id: int  # 0-3 for regular AMS, 128-135 for external spool
+    ams_id: int  # 0-3 for regular AMS, 128-135 for AMS-HT, 254+ for external spool
     tray_id: int  # 0-3
     tray_type: str  # PLA, PETG, ABS, etc.
     tray_sub_brands: str  # Full name like "PLA Basic", "PETG HF"
@@ -620,7 +620,7 @@ class SpoolmanClient:
         """Parse AMS tray data into AMSTray object.
 
         Args:
-            ams_id: The AMS unit ID (0-3 for regular, 128-135 for external)
+            ams_id: The AMS unit ID (0-3 for regular, 128-135 for AMS-HT, 254+ for external)
             tray_data: Raw tray data from MQTT
 
         Returns:


### PR DESCRIPTION
## Description

AMS-HT devices were being misidentified as External Spools in Spoolman. This fixes that and ensures they are properly identified as AMS-HT devices in Spoolman.

**COPILOT GENERATED SUMMARY**

This pull request updates the logic for converting AMS slot IDs to human-readable location strings in the `convert_ams_slot_to_location` function. The main improvement is the addition of support for AMS-HT units and a correction to the range for external spool IDs.

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #707 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

Enhancements to AMS slot location conversion:

* Added explicit handling for AMS-HT units by mapping AMS IDs 128–135 to the format `AMS-HT <Letter><TrayNumber>`.
* Updated the threshold for external spool IDs to `ams_id >= 254` (previously 128), ensuring AMS-HT units are not incorrectly labeled as external.

## Screenshots

<img width="349" height="225" alt="image" src="https://github.com/user-attachments/assets/8e26a8d0-cb50-4c62-83e0-a3277f218862" />

## Testing

<!-- Describe how you tested your changes -->

- [X] I have tested this on my local machine
- [X] I have tested with my printer model: P2S (ensured regular AMS slots are still identified properly)
 
## Checklist

- [X] My code follows the project's coding style
- [X] I have commented my code where necessary
- [X] I have updated the documentation (if needed)
- [X] My changes generate no new warnings
- [X] I have tested my changes thoroughly

## Additional Notes

<!-- Add any additional information that reviewers should know -->
