### PR TITLE
Add setting to disable developer LAN mode warning banner

### DIFF
--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -186,6 +186,11 @@ class AppSettings(BaseModel):
         description="Enable user email notifications for print job events (requires Advanced Authentication)",
     )
 
+    # Developer mode warning banner
+    disable_developer_mode_warning: bool = Field(
+        default=False, description="Disable the developer LAN mode warning banner"
+    )
+
     # Default sidebar order (admin-set for all users)
     default_sidebar_order: str = Field(
         default="",
@@ -260,6 +265,7 @@ class AppSettingsUpdate(BaseModel):
     prometheus_token: str | None = None
     low_stock_threshold: float | None = Field(default=None, ge=0.1, le=99.9)
     user_notifications_enabled: bool | None = None
+    disable_developer_mode_warning: bool | None = None
     default_sidebar_order: str | None = None
 
     @field_validator("default_sidebar_order")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -819,6 +819,8 @@ export interface AppSettings {
   time_format: 'system' | '12h' | '24h';
   // Filament tracking
   disable_filament_warnings: boolean;  // Disable filament warnings (print insufficiency and assignment mismatch)
+  // Developer mode warning
+  disable_developer_mode_warning: boolean;  // Disable the developer LAN mode warning banner
   // Default printer
   default_printer_id: number | null;
   // Dark mode theme settings

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -897,8 +897,8 @@ export function Layout() {
             </div>
           </div>
         )}
-        {devModeWarnings && devModeWarnings.length > 0 && (
-          <div className="bg-orange-500/20 border-b border-orange-500/30 px-4 py-2 flex items-center justify-between">
+        {devModeWarnings && devModeWarnings.length > 0 && !settings?.disable_developer_mode_warning && (
+          <div className="bg-orange-500/20 border-b border-orange-500/30 px-4 py-2">
             <div className="flex items-center gap-2 text-sm">
               <ShieldAlert className="w-4 h-4 text-orange-500" />
               <span className="text-orange-200">

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1406,6 +1406,8 @@ export default {
     // Updates
     checkForUpdatesLabel: 'Check for updates',
     checkPrinterFirmware: 'Check printer firmware',
+    disableDeveloperModeWarning: 'Disable developer mode warning',
+    disableDeveloperModeWarningDesc: 'Hide the banner warning about printers without LAN developer mode enabled',
     includeBetaUpdates: 'Include beta versions',
     includeBetaUpdatesDesc: 'Notify about beta and prerelease versions when checking for updates',
     // Queue

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -1406,6 +1406,8 @@ export default {
     // Updates
     checkForUpdatesLabel: 'Vérifier les mises à jour',
     checkPrinterFirmware: 'Vérifier le firmware imprimante',
+    disableDeveloperModeWarning: 'Désactiver l\'avertissement du mode développeur',
+    disableDeveloperModeWarningDesc: 'Masquer la bannière d\'avertissement pour les imprimantes sans le mode développeur LAN activé',
     includeBetaUpdates: 'Inclure les versions bêta',
     includeBetaUpdatesDesc: 'Notifier des versions bêta et préliminaires lors de la vérification des mises à jour',
     // Queue

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -732,6 +732,7 @@ export function SettingsPage() {
       settings.energy_tracking_mode !== localSettings.energy_tracking_mode ||
       settings.check_updates !== localSettings.check_updates ||
       (settings.check_printer_firmware ?? true) !== (localSettings.check_printer_firmware ?? true) ||
+      (settings.disable_developer_mode_warning ?? false) !== (localSettings.disable_developer_mode_warning ?? false) ||
       (settings.include_beta_updates ?? false) !== (localSettings.include_beta_updates ?? false) ||
       settings.notification_language !== localSettings.notification_language ||
       (settings.bed_cooled_threshold ?? 35) !== (localSettings.bed_cooled_threshold ?? 35) ||
@@ -804,6 +805,7 @@ export function SettingsPage() {
         energy_tracking_mode: localSettings.energy_tracking_mode,
         check_updates: localSettings.check_updates,
         check_printer_firmware: localSettings.check_printer_firmware,
+        disable_developer_mode_warning: localSettings.disable_developer_mode_warning,
         include_beta_updates: localSettings.include_beta_updates,
         notification_language: localSettings.notification_language,
         bed_cooled_threshold: localSettings.bed_cooled_threshold,
@@ -1228,6 +1230,23 @@ export function SettingsPage() {
                     </div>
                   )}
                 </div>
+              </div>
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-white">{t('settings.disableDeveloperModeWarning')}</p>
+                  <p className="text-sm text-bambu-gray">
+                    {t('settings.disableDeveloperModeWarningDesc')}
+                  </p>
+                </div>
+                <label className="relative inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={localSettings.disable_developer_mode_warning ?? false}
+                    onChange={(e) => updateSetting('disable_developer_mode_warning', e.target.checked)}
+                    className="sr-only peer"
+                  />
+                  <div className="w-11 h-6 bg-bambu-dark-tertiary peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-bambu-green"></div>
+                </label>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Description

Allow users to dismiss the developer LAN mode warning banner via a toggle in Settings > General. The setting is persisted server-side and resets with "Reset Settings". This is useful for users running a limited setup where the banner becomes repetitive and distracting on every page load (e.g. for monitoring and filament tracking only)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

- Add `disable_developer_mode_warning` backend setting, resets with "Reset Settings"
- Add English and French translations

## Screenshots

<img width="539" height="764" alt="CleanShot 2026-04-06 at 20 53 27@2x" src="https://github.com/user-attachments/assets/1861f0f9-0874-41a5-b370-de22648a9214" />

## Testing

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: H2C, P2S

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly