### PR TITLE
feat: Shows vendor name in Spoolman Link Modal

### DIFF
--- a/backend/app/api/routes/spoolman.py
+++ b/backend/app/api/routes/spoolman.py
@@ -571,6 +571,7 @@ class UnlinkedSpool(BaseModel):
 
     id: int
     filament_name: str | None
+    filament_vendor: str | None
     filament_material: str | None
     filament_color_hex: str | None
     remaining_weight: float | None
@@ -613,6 +614,7 @@ async def get_unlinked_spools(
                 UnlinkedSpool(
                     id=spool["id"],
                     filament_name=filament.get("name"),
+                    filament_vendor=(filament.get("vendor") or {}).get("name"),
                     filament_material=filament.get("material"),
                     filament_color_hex=filament.get("color_hex"),
                     remaining_weight=spool.get("remaining_weight"),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1981,6 +1981,7 @@ export interface SpoolmanSyncResult {
 export interface UnlinkedSpool {
   id: number;
   filament_name: string | null;
+  filament_vendor: string | null;
   filament_material: string | null;
   filament_color_hex: string | null;
   remaining_weight: number | null;

--- a/frontend/src/components/LinkSpoolModal.tsx
+++ b/frontend/src/components/LinkSpoolModal.tsx
@@ -38,6 +38,7 @@ export function LinkSpoolModal({ isOpen, onClose, tagUid, trayUuid, printerId, a
       const q = search.toLowerCase();
       return (
         (s.filament_name && s.filament_name.toLowerCase().includes(q)) ||
+        (s.filament_vendor && s.filament_vendor.toLowerCase().includes(q)) ||
         (s.filament_material && s.filament_material.toLowerCase().includes(q)) ||
         String(s.id).includes(q)
       );
@@ -131,6 +132,7 @@ export function LinkSpoolModal({ isOpen, onClose, tagUid, trayUuid, printerId, a
                     {spool.filament_name || t('spoolman.spoolId')}
                   </div>
                   <div className="text-xs text-bambu-gray truncate">
+                    {spool.filament_vendor ? `${spool.filament_vendor} · ` : ''}
                     {spool.filament_material || 'Unknown'} &middot; #{spool.id}
                   </div>
                 </div>


### PR DESCRIPTION
## Description

This pull request adds support for displaying and searching by filament vendor for unlinked spools throughout both the backend and frontend. The main changes update data models, API responses, UI display, and search functionality to include the new `filament_vendor` field.

## Related Issue

#926 

## Documentation

<!--
If this PR changes user-visible behavior, config keys, ports, CLI flags,
URLs, or installation steps, link matching PRs in the docs repos below.
Internal refactors, bug fixes with no observable change, and test-only
changes are exempt — just check the "not required" box and say why.

See CONTRIBUTING.md → Documentation Requirements for the full rules.
-->

**Pick one**:
- [ ] Docs PR(s) linked above
- [X] No docs update required — reason: UX enhancement

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

**Backend changes:**

* Added a new `filament_vendor` field to the `UnlinkedSpool` data model in `spoolman.py` to store the vendor name.
* Updated the `get_unlinked_spools` API endpoint to populate the new `filament_vendor` field from the filament data.

**Frontend changes:**

* Updated the `UnlinkedSpool` TypeScript interface to include the new `filament_vendor` field.

**UI/UX improvements:**

* Enhanced the search functionality in `LinkSpoolModal` to allow searching by filament vendor.
* Updated the spool display in `LinkSpoolModal` to show the filament vendor next to the material and spool ID.

## Screenshots

<img width="455" height="397" alt="image" src="https://github.com/user-attachments/assets/947d9e03-8381-4c4b-ae05-118f30aaefeb" />

<img width="460" height="333" alt="image" src="https://github.com/user-attachments/assets/4ea4a6bf-1c42-470e-91d8-8fa575d9a7a0" />

<img width="485" height="349" alt="image" src="https://github.com/user-attachments/assets/b36529b0-752c-4ae6-9e09-3284b0d86862" />


## Testing

<!-- Describe how you tested your changes -->

- [X] I have tested this on my local machine
- [X] I have tested with my printer model: P2S

## Checklist

- [X] My code follows the project's coding style
- [X] I have commented my code where necessary
- [X] My changes generate no new warnings
- [X] I have tested my changes thoroughly

## Additional Notes

N/A
