### PR TITLE
feat(printer): add X2D printer support

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1250,6 +1250,7 @@ async def run_migrations(conn):
         "X1C": "BL-P001",
         "X1": "BL-P002",
         "X1E": "C13",
+        "X2D": "N6",
         "P1P": "C11",
         "P1S": "C12",
         "P2S": "N7",

--- a/backend/app/services/camera.py
+++ b/backend/app/services/camera.py
@@ -65,13 +65,14 @@ def get_ffmpeg_path() -> str | None:
 def supports_rtsp(model: str | None) -> bool:
     """Check if printer model supports RTSP camera streaming.
 
-    RTSP supported: X1, X1C, X1E, H2C, H2D, H2DPRO, H2S, P2S
+    RTSP supported: X1, X1C, X1E, X2D, H2C, H2D, H2DPRO, H2S, P2S
     Chamber image only: A1, A1MINI, P1P, P1S
 
     Note: Model can be either display name (e.g., "P2S") or internal code (e.g., "N7").
     Internal codes from MQTT/SSDP:
       - BL-P001: X1/X1C
       - C13: X1E
+      - N6: X2D
       - O1D: H2D
       - O1C, O1C2: H2C
       - O1S: H2S
@@ -80,11 +81,11 @@ def supports_rtsp(model: str | None) -> bool:
     """
     if model:
         model_upper = model.upper()
-        # Display names: X1, X1C, X1E, H2C, H2D, H2DPRO, H2S, P2S
-        if model_upper.startswith(("X1", "H2", "P2")):
+        # Display names: X1, X1C, X1E, X2D, H2C, H2D, H2DPRO, H2S, P2S
+        if model_upper.startswith(("X1", "X2", "H2", "P2")):
             return True
         # Internal codes for RTSP models
-        if model_upper in ("BL-P001", "C13", "O1D", "O1C", "O1C2", "O1S", "O1E", "O2D", "N7"):
+        if model_upper in ("BL-P001", "C13", "O1D", "O1C", "O1C2", "O1S", "O1E", "O2D", "N7", "N6"):
             return True
     # A1/P1 and unknown models use chamber image protocol
     return False

--- a/backend/app/services/firmware_check.py
+++ b/backend/app/services/firmware_check.py
@@ -46,6 +46,7 @@ MODEL_TO_API_KEY = {
     "H2S": "h2s",
     "P2S": "p2s",
     "X1E": "x1e",
+    "X2D": "x2d",
     "H2D Pro": "h2d-pro",
     "H2D-Pro": "h2d-pro",
     "H2DPRO": "h2d-pro",
@@ -64,6 +65,7 @@ MODEL_TO_API_KEY = {
     "C13": "p2s",
     "N2S": "a1",
     "N1": "a1-mini",
+    "N6": "x2d",
     "N7": "p2s",
 }
 
@@ -78,6 +80,7 @@ API_KEY_TO_DEV_MODEL = {
     "h2s": "O1S",
     "p2s": "N7",
     "x1e": "C13",
+    "x2d": "N6",
     "h2d-pro": "O1E",
 }
 
@@ -85,6 +88,7 @@ API_KEY_TO_DEV_MODEL = {
 API_KEY_TO_WIKI_PATH = {
     "x1": "/en/x1/manual/X1-X1C-firmware-release-history",
     "x1e": "/en/x1/manual/X1E-firmware-release-history",
+    "x2d": "/en/x2d/manual/x2d-firmware-release-history",
     "p1": "/en/p1/manual/p1p-firmware-release-history",
     "a1": "/en/a1/manual/a1-firmware-release-history",
     "a1-mini": "/en/a1-mini/manual/a1-mini-firmware-release-history",

--- a/backend/app/services/printer_manager.py
+++ b/backend/app/services/printer_manager.py
@@ -21,6 +21,7 @@ CHAMBER_TEMP_SUPPORTED_MODELS = frozenset(
         "X1",
         "X1C",
         "X1E",  # X1 series
+        "X2D",  # X2 series
         "P2S",  # P2 series
         "H2C",
         "H2D",
@@ -29,6 +30,7 @@ CHAMBER_TEMP_SUPPORTED_MODELS = frozenset(
         # Internal codes (from MQTT/SSDP)
         "BL-P001",  # X1/X1C
         "C13",  # X1E
+        "N6",  # X2D
         "O1D",  # H2D
         "O1C",  # H2C
         "O1C2",  # H2C (dual nozzle variant)

--- a/backend/app/services/virtual_printer/manager.py
+++ b/backend/app/services/virtual_printer/manager.py
@@ -31,6 +31,8 @@ VIRTUAL_PRINTER_MODELS = {
     "BL-P001": "X1C",  # X1 Carbon
     "BL-P002": "X1",  # X1
     "C13": "X1E",  # X1E
+    # X2 Series
+    "N6": "X2D",  # X2D
     # P Series
     "C11": "P1P",  # P1P
     "C12": "P1S",  # P1S
@@ -59,6 +61,8 @@ MODEL_SERIAL_PREFIXES = {
     "BL-P001": "00M00A",  # X1C
     "BL-P002": "00M00A",  # X1
     "C13": "03W00A",  # X1E
+    # X2 Series
+    "N6": "04X00A",  # X2D
     # P Series
     "C11": "01S00A",  # P1P
     "C12": "01P00A",  # P1S

--- a/backend/app/services/virtual_printer/mqtt_server.py
+++ b/backend/app/services/virtual_printer/mqtt_server.py
@@ -21,6 +21,7 @@ MODEL_PRODUCT_NAMES = {
     "BL-P001": "X1 Carbon",
     "BL-P002": "X1",
     "C13": "X1E",
+    "N6": "X2D",
     "C11": "P1P",
     "C12": "P1S",
     "N7": "P2S",

--- a/backend/app/utils/printer_models.py
+++ b/backend/app/utils/printer_models.py
@@ -19,6 +19,7 @@ PRINTER_MODEL_MAP = {
     "Bambu Lab H2D Pro": "H2D Pro",
     "Bambu Lab H2C": "H2C",
     "Bambu Lab H2S": "H2S",
+    "Bambu Lab X2D": "X2D",
 }
 
 # Map from printer_model_id (internal codes in slice_info.config) to short names
@@ -28,6 +29,8 @@ PRINTER_MODEL_ID_MAP = {
     "C11": "X1C",
     "C12": "X1",
     "C13": "X1E",
+    # X2 series
+    "N6": "X2D",
     # P1 series
     "P1P": "P1P",
     "P1S": "P1S",
@@ -60,12 +63,14 @@ CARBON_ROD_MODELS = frozenset(
         "X1",
         "X1C",
         "X1E",
+        "X2D",
         "P1P",
         "P1S",
         # Internal codes
         "C11",  # X1C
         "C12",  # X1
         "C13",  # X1E
+        "N6",  # X2D
     ]
 )
 
@@ -110,6 +115,7 @@ ETHERNET_MODELS = frozenset(
         # Display names (uppercase, no spaces)
         "X1C",
         "X1E",
+        "X2D",
         "P1S",
         "P2S",
         "H2D",
@@ -119,6 +125,7 @@ ETHERNET_MODELS = frozenset(
         # Internal codes
         "C11",  # X1C
         "C13",  # X1E
+        "N6",  # X2D
         "P1S",  # P1S
         "O1D",  # H2D
         "O1E",  # H2D Pro

--- a/backend/tests/unit/test_printer_models.py
+++ b/backend/tests/unit/test_printer_models.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from backend.app.utils.printer_models import get_rod_type
+from backend.app.services.camera import get_camera_port, supports_rtsp
+from backend.app.utils.printer_models import (
+    get_rod_type,
+    has_ethernet,
+    normalize_printer_model,
+    normalize_printer_model_id,
+)
 
 
 class TestGetRodType:
@@ -46,3 +52,36 @@ class TestGetRodType:
     def test_strips_whitespace_and_dashes(self):
         assert get_rod_type(" P2S ") == "steel_rod"
         assert get_rod_type("A1-Mini") == "linear_rail"
+
+
+class TestX2DModel:
+    """Tests for X2D printer model support (issue #988)."""
+
+    def test_x2d_carbon_rod_display_name(self):
+        assert get_rod_type("X2D") == "carbon"
+
+    def test_x2d_carbon_rod_internal_code(self):
+        """N6 is the internal SSDP/MQTT code for the X2D."""
+        assert get_rod_type("N6") == "carbon"
+
+    def test_x2d_model_id_map(self):
+        assert normalize_printer_model_id("N6") == "X2D"
+
+    def test_x2d_model_map(self):
+        assert normalize_printer_model("Bambu Lab X2D") == "X2D"
+
+    def test_x2d_has_ethernet_display_name(self):
+        assert has_ethernet("X2D") is True
+
+    def test_x2d_has_ethernet_internal_code(self):
+        assert has_ethernet("N6") is True
+
+    def test_x2d_supports_rtsp_display_name(self):
+        assert supports_rtsp("X2D") is True
+
+    def test_x2d_supports_rtsp_internal_code(self):
+        assert supports_rtsp("N6") is True
+
+    def test_x2d_camera_port_is_rtsp(self):
+        assert get_camera_port("N6") == 322
+        assert get_camera_port("X2D") == 322

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -1059,6 +1059,8 @@ function mapModelCode(ssdpModel: string | null): string {
     'BL-P001': 'X1C',
     'BL-P002': 'X1',
     'BL-P003': 'X1E',
+    // X2 Series
+    'N6': 'X2D',
     // P Series
     'C11': 'P1S',
     'C12': 'P1P',
@@ -1070,6 +1072,7 @@ function mapModelCode(ssdpModel: string | null): string {
     'X1C': 'X1C',
     'X1': 'X1',
     'X1E': 'X1E',
+    'X2D': 'X2D',
     'P1S': 'P1S',
     'P1P': 'P1P',
     'P2S': 'P2S',

--- a/frontend/src/pages/spoolbuddy/SpoolBuddyAmsPage.tsx
+++ b/frontend/src/pages/spoolbuddy/SpoolBuddyAmsPage.tsx
@@ -25,9 +25,10 @@ function mapModelCode(ssdpModel: string | null): string {
   const modelMap: Record<string, string> = {
     'O1D': 'H2D', 'O1E': 'H2D Pro', 'O2D': 'H2D Pro', 'O1C': 'H2C', 'O1C2': 'H2C', 'O1S': 'H2S',
     'BL-P001': 'X1C', 'BL-P002': 'X1', 'BL-P003': 'X1E',
+    'N6': 'X2D',
     'C11': 'P1S', 'C12': 'P1P', 'C13': 'P2S',
     'N2S': 'A1', 'N1': 'A1 Mini',
-    'X1C': 'X1C', 'X1': 'X1', 'X1E': 'X1E', 'P1S': 'P1S', 'P1P': 'P1P', 'P2S': 'P2S',
+    'X1C': 'X1C', 'X1': 'X1', 'X1E': 'X1E', 'X2D': 'X2D', 'P1S': 'P1S', 'P1P': 'P1P', 'P2S': 'P2S',
     'A1': 'A1', 'A1 Mini': 'A1 Mini', 'H2D': 'H2D', 'H2D Pro': 'H2D Pro', 'H2C': 'H2C', 'H2S': 'H2S',
   };
   return modelMap[ssdpModel] || ssdpModel;


### PR DESCRIPTION
## Summary

Fixes #988 — Bambu Lab X2D camera not working.

**Root cause:** The X2D identifies itself as internal model code `N6` via SSDP/MQTT. Since `N6` was unknown to Bambuddy, the camera service fell back to the chamber-image protocol on port 6000 instead of RTSP on port 322, resulting in a failed connection.

- Diagnosed from the support logs attached to issue #988: `Chamber image: failed to connect to [IP]:6000` and `Unknown printer model: N6`
- The X2D was launched April 14, 2026; both reporters' support-info files confirm `model: N6`, firmware `01.01.00.00`, dual-nozzle

## Changes

| File | What changed |
|------|-------------|
| `printer_models.py` | `N6 → X2D` mapping; add to `CARBON_ROD_MODELS` and `ETHERNET_MODELS` |
| `camera.py` | `supports_rtsp()` now returns `True` for `X2` prefix and `N6` code → port 322 |
| `printer_manager.py` | Add `X2D`/`N6` to `CHAMBER_TEMP_SUPPORTED_MODELS` |
| `firmware_check.py` | Register `x2d` API key, dev model `N6`, and wiki path |
| `virtual_printer/manager.py` | Add `N6 → X2D` to model and serial prefix maps |
| `virtual_printer/mqtt_server.py` | Add `N6 → X2D` to `MODEL_PRODUCT_NAMES` |
| `database.py` | Add `X2D → N6` to VP migration fix dict |
| `PrintersPage.tsx` | Add `N6 → X2D` to `mapModelCode()` |
| `SpoolBuddyAmsPage.tsx` | Add `N6 → X2D` to `mapModelCode()` |
| `test_printer_models.py` | New `TestX2DModel` class — 9 tests, all passing |

## Test plan

- [x] All existing unit tests pass (`pytest backend/tests/unit/test_printer_models.py` — 39/39)
- [x] New `TestX2DModel` tests verify: rod type, model ID map, model name map, ethernet, RTSP support, camera port
- [ ] X2D printer connects and camera stream uses RTSP on port 322
- [ ] Firmware check no longer logs `Unknown printer model: N6`