### PR TITLE
Add ai detection box drawing support to notifications

### DIFF
--- a/backend/app/services/obico_actions.py
+++ b/backend/app/services/obico_actions.py
@@ -4,6 +4,9 @@ Separated from the detection loop so actions can be unit-tested and swapped.
 """
 
 import logging
+from io import BytesIO
+
+from PIL import Image, ImageDraw
 
 from sqlalchemy import select
 
@@ -13,7 +16,14 @@ from backend.app.models.printer import Printer
 logger = logging.getLogger(__name__)
 
 
-async def execute_action(printer_id: int, action: str, task_name: str, score: float) -> None:
+async def execute_action(
+    printer_id: int,
+    action: str,
+    task_name: str,
+    score: float,
+    frame: bytes | None = None,
+    detections: list | None = None,
+) -> None:
     """Run the configured action for a detected print failure.
 
     action: 'notify' | 'pause' | 'pause_and_off'
@@ -26,7 +36,15 @@ async def execute_action(printer_id: int, action: str, task_name: str, score: fl
     if action == "pause_and_off":
         await _turn_off_linked_plugs(printer_id)
 
-    await _notify(printer_id, printer_name, task_name, score, action)
+    await _notify(
+        printer_id=printer_id,
+        printer_name=printer_name,
+        task_name=task_name,
+        score=score,
+        action=action,
+        frame=frame,
+        detections=detections,
+    )
 
 
 async def _get_printer_name(printer_id: int) -> str:
@@ -63,13 +81,62 @@ async def _turn_off_linked_plugs(printer_id: int) -> None:
                 logger.error("Obico action: failed to turn off plug %s: %s", plug.name, e)
 
 
-async def _notify(printer_id: int, printer_name: str, task_name: str, score: float, action: str) -> None:
+def _draw_detection_boxes(frame: bytes | None, detections: list | None) -> bytes | None:
+    """Draw Obico detection boxes on frame when possible.
+
+    Supports boxes as normalized coordinates (0..1) or absolute pixel values.
+    Expected item shape: [label, confidence, [x1, y1, x2, y2]].
+    """
+    if not frame:
+        return None
+    if not detections:
+        return frame
+
+    try:
+        image = Image.open(BytesIO(frame)).convert("RGB")
+        draw = ImageDraw.Draw(image)
+        width, height = image.size
+
+        for det in detections:
+            if not isinstance(det, (list, tuple)) or len(det) < 3:
+                continue
+            bbox = det[2]
+            if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+                continue
+
+            x1, y1, x2, y2 = bbox
+            if all(isinstance(v, (int, float)) for v in (x1, y1, x2, y2)):
+                # Many detectors return normalized coordinates.
+                if 0.0 <= x1 <= 1.0 and 0.0 <= y1 <= 1.0 and 0.0 <= x2 <= 1.0 and 0.0 <= y2 <= 1.0:
+                    x1, x2 = x1 * width, x2 * width
+                    y1, y2 = y1 * height, y2 * height
+
+                draw.rectangle([(x1, y1), (x2, y2)], outline=(255, 64, 64), width=4)
+
+        output = BytesIO()
+        image.save(output, format="JPEG", quality=90)
+        return output.getvalue()
+    except Exception:
+        logger.error("Failed to draw Obico detection boxes", exc_info=True)
+        return frame
+
+
+async def _notify(
+    printer_id: int,
+    printer_name: str,
+    task_name: str,
+    score: float,
+    action: str,
+    frame: bytes | None = None,
+    detections: list | None = None,
+) -> None:
     from backend.app.services.notification_service import notification_service
 
     detail = (
         f"Possible print failure detected on '{task_name or 'current job'}' "
         f"(confidence {score:.2f}). Action taken: {action}."
     )
+    image_data = _draw_detection_boxes(frame, detections)
     async with async_session() as db:
         try:
             await notification_service.on_printer_error(
@@ -78,6 +145,7 @@ async def _notify(printer_id: int, printer_name: str, task_name: str, score: flo
                 error_type="ai_failure_detection",
                 db=db,
                 error_detail=detail,
+                image_data=image_data,
             )
         except Exception as e:
             logger.error("Obico notify failed for printer %s: %s", printer_id, e)

--- a/backend/app/services/obico_detection.py
+++ b/backend/app/services/obico_detection.py
@@ -274,9 +274,17 @@ class ObicoDetectionService:
 
         if verdict == "failure" and not self._action_fired.get(printer_id):
             self._action_fired[printer_id] = True
-            await self._dispatch_action(printer_id, settings["action"], task_name, score)
+            await self._dispatch_action(printer_id, settings["action"], task_name, score, frame, detections)
 
-    async def _dispatch_action(self, printer_id: int, action: str, task_name: str, score: float):
+    async def _dispatch_action(
+        self,
+        printer_id: int,
+        action: str,
+        task_name: str,
+        score: float,
+        frame: bytes | None = None,
+        detections: list | None = None,
+    ):
         from backend.app.services.obico_actions import execute_action
 
         logger.warning(
@@ -287,7 +295,14 @@ class ObicoDetectionService:
             action,
         )
         try:
-            await execute_action(printer_id, action, task_name, score)
+            await execute_action(
+                printer_id=printer_id,
+                action=action,
+                task_name=task_name,
+                score=score,
+                frame=frame,
+                detections=detections,
+            )
         except Exception as e:
             self._last_error = f"Action dispatch failed: {e or type(e).__name__}"
             logger.error(self._last_error)


### PR DESCRIPTION
## Description

Fixes AI failure detection notifications so they include an image, and adds optional visual highlighting of detected failure regions.


## Documentation

- [x] No docs update required — reason: backend-only bug fix; no user-facing settings, URLs, ports, or install steps changed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

- Updated Obico failure dispatch flow to pass the captured frame and detections into action execution.
- Enhanced AI failure notification path to attach `image_data` for `ai_failure_detection` events.
- Added bounding-box rendering on the failure snapshot (supports normalized or absolute bbox coordinates) before sending notifications.

## Testing

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: A1

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

When detections are present, the outgoing image is annotated with red boxes.  
If detections are missing or malformed, notifications still include the original image (no overlay) to avoid dropping attachments.