### PR TITLE
feat: expose storage_location in internal spool inventory

### DIFF
--- a/backend/app/schemas/spool.py
+++ b/backend/app/schemas/spool.py
@@ -116,6 +116,7 @@ class SpoolBase(BaseModel):
     # User-defined category + per-spool low-stock threshold override (#729).
     category: str | None = Field(default=None, max_length=50)
     low_stock_threshold_pct: int | None = Field(default=None, ge=1, le=99)
+    storage_location: str | None = Field(default=None, max_length=255)
 
 
 class SpoolCreate(SpoolBase):
@@ -164,6 +165,7 @@ class SpoolUpdate(BaseModel):
     # User-defined category + per-spool low-stock threshold override (#729).
     category: str | None = Field(default=None, max_length=50)
     low_stock_threshold_pct: int | None = Field(default=None, ge=1, le=99)
+    storage_location: str | None = Field(default=None, max_length=255)
 
 
 class SpoolKProfileBase(BaseModel):

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -231,7 +231,16 @@ const columnCells: Record<string, (ctx: CellCtx) => ReactNode> = {
   ),
   location: ({ spool, assignmentMap }) => {
     const assignment = assignmentMap[spool.id];
-    if (!assignment) return <span className="text-sm text-bambu-gray">-</span>;
+    if (!assignment) {
+      if (spool.storage_location) {
+        return (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-blue-500/20 text-blue-400">
+            {spool.storage_location}
+          </span>
+        );
+      }
+      return <span className="text-sm text-bambu-gray">-</span>;
+    }
     const printerLabel = assignment.printer_name || `Printer ${assignment.printer_id}`;
     const isExternal = assignment.ams_id === 254 || assignment.ams_id === 255;
     const isHt = !isExternal && assignment.ams_id >= 128;

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
 
     <!-- Splash screens for iOS -->
     <link rel="apple-touch-startup-image" href="/img/android-chrome-512x512.png" />
-    <script type="module" crossorigin src="/assets/index-V-aY7Bt-.js"></script>
+    <script type="module" crossorigin src="/assets/index-DZbG7Ycs.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DdYV-omj.css">
   </head>
   <body>


### PR DESCRIPTION
Add storage_location field to SpoolBase and SpoolUpdate schemas so the internal inventory API accepts and returns it. Display the value in the inventory table Location column when set and no AMS slot is assigned.

## Description

This makes it so the user can specify a location for each filament roll when using the internal filament database. This also exposes the storage_location to the API for updates. This allows users to update the storage locations when using NFC/QR codes by using the API.

**Pick one**:
- [ ] Docs PR(s) linked above
- [X] No docs update required — reason: This exposed an API field. The API update docs look to be generated automatically.

## Type of Change

- [X] New feature (non-breaking change that adds functionality)

## Changes Made

- Added `storage_location` field to `SpoolBase` and `SpoolUpdate` schemas so the internal inventory API accepts writes and returns the value on reads
- The `PATCH /api/v1/inventory/spools/{id}` endpoint now persists `storage_location` (free-text, max 255 chars) — no route changes needed, flows through existing `setattr` loop
- Inventory table Location column now displays `storage_location` as a badge when set and no AMS slot is assigned; falls back to `-` when neither is set

## Screenshots

<img width="1263" height="496" alt="Screenshot 2026-05-11 at 3 48 10 PM" src="https://github.com/user-attachments/assets/3e2d4454-9e6d-455c-a34c-39bf9b07c814" />

## Testing

- [X] I have tested this on my local machine

## Checklist

- [X] My code follows the project's coding style
- [X] I have commented my code where necessary
- [X] My changes generate no new warnings
- [X] I have tested my changes thoroughly
