### PR TITLE
Fixes #1235 VP not using database defaults for workflow settings

### DIFF
--- a/backend/app/services/virtual_printer/manager.py
+++ b/backend/app/services/virtual_printer/manager.py
@@ -345,6 +345,16 @@ class VirtualPrinterInstance:
             async with self._session_factory() as db:
                 name_source = await get_setting(db, "virtual_printer_archive_name_source")
                 prefer_filename = name_source == "filename"
+
+                def _bool_setting(value: str | None, default: bool) -> bool:
+                    return value.lower() == "true" if value is not None else default
+
+                bed_levelling = _bool_setting(await get_setting(db, "default_bed_levelling"), True)
+                flow_cali = _bool_setting(await get_setting(db, "default_flow_cali"), False)
+                vibration_cali = _bool_setting(await get_setting(db, "default_vibration_cali"), True)
+                layer_inspect = _bool_setting(await get_setting(db, "default_layer_inspect"), False)
+                timelapse = _bool_setting(await get_setting(db, "default_timelapse"), False)
+
                 service = ArchiveService(db)
                 archive = await service.archive_print(
                     printer_id=None,
@@ -405,6 +415,11 @@ class VirtualPrinterInstance:
                         manual_start=not self.auto_dispatch,
                         required_filament_types=required_filament_types_json,
                         filament_overrides=filament_overrides_json,
+                        bed_levelling=bed_levelling,
+                        flow_cali=flow_cali,
+                        vibration_cali=vibration_cali,
+                        layer_inspect=layer_inspect,
+                        timelapse=timelapse,
                     )
                     db.add(queue_item)
                     await db.commit()


### PR DESCRIPTION
## Description

Root cause: manager.py:398-408 — when a file received via the virtual FTP server is added to the print queue, the PrintQueueItem was constructed without specifying bed_levelling, flow_cali, vibration_cali, layer_inspect, or timelapse. SQLAlchemy fell back to the column-level defaults (bed_levelling=True, vibration_cali=True, etc.), completely ignoring whatever the user configured in the workflow settings (default_bed_levelling, default_flow_cali, etc.).

## Related Issue

Fixes #1235 

## Documentation

**Pick one**:
- [ ] Docs PR(s) linked above
- [x] No docs update required — reason: this fixes a silent backend bug

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

Fix: Before creating the archive, the method now reads all five default_* print option settings from the database using the same get_setting() helper already in use for virtual_printer_archive_name_source, and passes those values explicitly to PrintQueueItem. A local _bool_setting() helper handles the None → schema-default fallback in the same way the settings route does (value.lower() == "true").

## Testing

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: P2S

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
