### PR TITLE
fix(pwa): reliable Android Chrome install prompt + CSP hardening

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5653,7 +5653,11 @@ async def serve_manifest():
     """Serve PWA manifest."""
     manifest_file = app_settings.static_dir / "manifest.json"
     if manifest_file.exists():
-        return FileResponse(manifest_file, media_type="application/manifest+json")
+        return FileResponse(
+            manifest_file,
+            media_type="application/manifest+json",
+            headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
+        )
     return {"error": "Manifest not found"}
 
 
@@ -5679,7 +5683,11 @@ async def serve_sw_register():
     """
     reg_file = app_settings.static_dir / "sw-register.js"
     if reg_file.exists():
-        return FileResponse(reg_file, media_type="application/javascript")
+        return FileResponse(
+            reg_file,
+            media_type="application/javascript",
+            headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
+        )
     return {"error": "sw-register.js not found"}
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5307,13 +5307,14 @@ async def security_headers_middleware(request, call_next):
     #   - img-src data: / blob:: base64 thumbnails and Blob-URL timelapse previews.
     #   - media-src blob:: timelapse video player uses Blob URLs.
     #   - font-src data:: some icon fonts are embedded as data URIs.
+    #   - Inter font is self-hosted under /fonts/; no CDN references needed.
     if request.url.path.startswith("/gcode-viewer"):
         # The gcode viewer is embedded in an iframe served by this same origin,
         # so frame-ancestors must allow 'self'.  prettygcode.js also uses eval()
         # internally, so script-src needs 'unsafe-eval'.
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-eval'; "
+            f"script-src 'self' 'nonce-{csp_nonce}' 'unsafe-eval'; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data: blob:; "
             "media-src 'self' blob:; "

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5320,6 +5320,7 @@ async def security_headers_middleware(request, call_next):
             "media-src 'self' blob:; "
             "connect-src 'self' ws: wss:; "
             "font-src 'self' data:; "
+            "worker-src 'self'; "
             "object-src 'none'; "
             "base-uri 'self'; "
             "frame-src 'self' http: https:; " + _frame_ancestors("'self'")
@@ -5348,6 +5349,12 @@ async def security_headers_middleware(request, call_next):
             "media-src 'self' blob:; "
             "connect-src 'self' ws: wss:; "
             "font-src 'self' data:; "
+            # Explicit worker-src so Chrome's PWA installability check does not
+            # have to infer service-worker permission via the default-src fallback
+            # chain.  Chrome 128+ verifies that a same-origin SW can be created;
+            # without this directive some Chrome builds treat the absence of
+            # worker-src as ambiguous and refuse to offer installation.
+            "worker-src 'self'; "
             "object-src 'none'; "
             "base-uri 'self'; "
             "frame-src 'self' http: https:; " + _frame_ancestors("'none'")

--- a/frontend/src/components/InstallAppButton.tsx
+++ b/frontend/src/components/InstallAppButton.tsx
@@ -10,15 +10,21 @@ interface BeforeInstallPromptEvent extends Event {
   readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
 }
 
+// Matches the compact-sidebar breakpoint in useIsSidebarCompact.ts
+const SIDEBAR_COMPACT_BREAKPOINT = 1144;
+
 /**
  * Sidebar-footer button that installs Bambuddy as a PWA.
  *
- * Chrome for Android removed the automatic install banner in Chrome 108, so
- * without an in-app trigger the only install path on Android is a buried
- * browser-menu item (#1460). This button captures the `beforeinstallprompt`
- * event and re-fires it on click. It renders nothing when the browser has no
- * pending prompt - already installed, unsupported browser, or iOS Safari
- * (which has no programmatic install at all).
+ * On desktop (>= 1144px) this button is always visible in the sidebar, so we
+ * suppress Chrome's mini-infobar and use this as the single install entry point.
+ *
+ * On mobile (< 1144px) the button is buried inside the hamburger drawer, so we
+ * do NOT suppress the mini-infobar — Chrome's native install UI fires automatically
+ * and the drawer button remains available as a secondary path.
+ *
+ * Renders nothing when there is no pending prompt (already installed, unsupported
+ * browser, or iOS Safari which has no programmatic install API).
  */
 export function InstallAppButton() {
   const { t } = useTranslation();
@@ -27,9 +33,13 @@ export function InstallAppButton() {
 
   useEffect(() => {
     const onBeforeInstallPrompt = (e: Event) => {
-      // Suppress Chrome's own mini-infobar (desktop) so this button is the
-      // single, predictable install entry point.
-      e.preventDefault();
+      // On desktop the sidebar button is always visible, so suppress the
+      // mini-infobar and use it as the sole install trigger.
+      // On mobile the button is hidden inside the drawer, so let Chrome's
+      // native install UI (mini-infobar / rich dialog) appear automatically.
+      if (window.innerWidth >= SIDEBAR_COMPACT_BREAKPOINT) {
+        e.preventDefault();
+      }
       setPromptEvent(e as BeforeInstallPromptEvent);
     };
     const onInstalled = () => setPromptEvent(null);

--- a/frontend/src/components/InstallAppButton.tsx
+++ b/frontend/src/components/InstallAppButton.tsx
@@ -2,51 +2,48 @@ import { useState, useEffect } from 'react';
 import { Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from '../contexts/ToastContext';
-
-// The beforeinstallprompt event is not in the standard TS DOM lib.
-interface BeforeInstallPromptEvent extends Event {
-  readonly platforms: string[];
-  prompt: () => Promise<void>;
-  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
-}
-
-// Matches the compact-sidebar breakpoint in useIsSidebarCompact.ts
-const SIDEBAR_COMPACT_BREAKPOINT = 1144;
+import { type BeforeInstallPromptEvent, getPendingPrompt, clearPendingPrompt } from '../pwa';
 
 /**
  * Sidebar-footer button that installs Bambuddy as a PWA.
  *
- * On desktop (>= 1144px) this button is always visible in the sidebar, so we
- * suppress Chrome's mini-infobar and use this as the single install entry point.
+ * On desktop (>= 1144 px) the button is always visible in the sidebar, so
+ * pwa.ts suppresses Chrome's mini-infobar and this button is the sole install
+ * trigger.
  *
- * On mobile (< 1144px) the button is buried inside the hamburger drawer, so we
- * do NOT suppress the mini-infobar — Chrome's native install UI fires automatically
- * and the drawer button remains available as a secondary path.
+ * On mobile (< 1144 px) pwa.ts does NOT call e.preventDefault(), so Chrome's
+ * native mini-infobar fires automatically.  The button remains available inside
+ * the hamburger drawer as a secondary path.
  *
- * Renders nothing when there is no pending prompt (already installed, unsupported
- * browser, or iOS Safari which has no programmatic install API).
+ * The event is captured in pwa.ts (imported before React mounts) to avoid
+ * losing it during the auth-loading phase when this component hasn't mounted yet.
+ *
+ * Renders nothing when there is no pending prompt (already installed,
+ * unsupported browser, or iOS Safari which has no programmatic install API).
  */
 export function InstallAppButton() {
   const { t } = useTranslation();
   const { showToast } = useToast();
-  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
+
+  // Lazy initialiser: pick up any prompt that fired before this component mounted.
+  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(
+    () => getPendingPrompt(),
+  );
 
   useEffect(() => {
-    const onBeforeInstallPrompt = (e: Event) => {
-      // On desktop the sidebar button is always visible, so suppress the
-      // mini-infobar and use it as the sole install trigger.
-      // On mobile the button is hidden inside the drawer, so let Chrome's
-      // native install UI (mini-infobar / rich dialog) appear automatically.
-      if (window.innerWidth >= SIDEBAR_COMPACT_BREAKPOINT) {
-        e.preventDefault();
-      }
-      setPromptEvent(e as BeforeInstallPromptEvent);
+    // Listen for future events (Chrome re-fires beforeinstallprompt after the
+    // PWA is uninstalled; pwa.ts recaptures and relays it as a custom event).
+    const onPrompt = (e: Event) => {
+      setPromptEvent((e as CustomEvent<BeforeInstallPromptEvent>).detail);
     };
-    const onInstalled = () => setPromptEvent(null);
-    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+    const onInstalled = () => {
+      setPromptEvent(null);
+      clearPendingPrompt();
+    };
+    window.addEventListener('bambuddy:installprompt', onPrompt);
     window.addEventListener('appinstalled', onInstalled);
     return () => {
-      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+      window.removeEventListener('bambuddy:installprompt', onPrompt);
       window.removeEventListener('appinstalled', onInstalled);
     };
   }, []);
@@ -58,9 +55,9 @@ export function InstallAppButton() {
   const handleInstall = async () => {
     await promptEvent.prompt();
     const { outcome } = await promptEvent.userChoice;
-    // A captured prompt can only be used once; drop it either way so the
-    // button hides until the browser fires a fresh beforeinstallprompt.
+    // A captured prompt can only be used once; clear it either way.
     setPromptEvent(null);
+    clearPendingPrompt();
     if (outcome === 'accepted') {
       showToast(t('nav.installAppSuccess'), 'success');
     }

--- a/frontend/src/components/InstallAppButton.tsx
+++ b/frontend/src/components/InstallAppButton.tsx
@@ -5,21 +5,49 @@ import { useToast } from '../contexts/ToastContext';
 import { type BeforeInstallPromptEvent, getPendingPrompt, clearPendingPrompt } from '../pwa';
 
 /**
+ * Returns true when running inside a browser (not a PWA standalone window).
+ * Used to hide the button once the user has installed and reopened as a PWA.
+ */
+function isInStandaloneMode(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    // Safari/iOS sets this property instead
+    (window.navigator as unknown as { standalone?: boolean }).standalone === true
+  );
+}
+
+/**
+ * Returns true on stock Android Chrome (not Edge, Opera, Samsung Browser).
+ * These browsers all fire beforeinstallprompt and support programmatic install.
+ */
+function isAndroidChrome(): boolean {
+  const ua = navigator.userAgent;
+  return (
+    /Android/.test(ua) &&
+    /Chrome\//.test(ua) &&
+    !/EdgA|OPR\/|SamsungBrowser/.test(ua)
+  );
+}
+
+/**
  * Sidebar-footer button that installs Bambuddy as a PWA.
  *
- * On desktop (>= 1144 px) the button is always visible in the sidebar, so
- * pwa.ts suppresses Chrome's mini-infobar and this button is the sole install
- * trigger.
+ * Two modes:
  *
- * On mobile (< 1144 px) pwa.ts does NOT call e.preventDefault(), so Chrome's
- * native mini-infobar fires automatically.  The button remains available inside
- * the hamburger drawer as a secondary path.
+ * 1. **Native prompt** — when Chrome has fired `beforeinstallprompt` (captured
+ *    early in pwa.ts before React mounts), clicking triggers the browser's
+ *    native install dialog directly.
  *
- * The event is captured in pwa.ts (imported before React mounts) to avoid
- * losing it during the auth-loading phase when this component hasn't mounted yet.
+ * 2. **Manual fallback** — when Chrome hasn't fired the event (e.g. a per-site
+ *    cooldown from previous e.preventDefault() calls), the button is still shown
+ *    on Android Chrome so the user gets an actionable hint.  Clicking shows a
+ *    toast: "Tap ⋮ → Add to Home Screen".
  *
- * Renders nothing when there is no pending prompt (already installed,
- * unsupported browser, or iOS Safari which has no programmatic install API).
+ * On desktop (>= 1144 px) pwa.ts calls e.preventDefault() so only the sidebar
+ * button triggers install (never the mini-infobar).
+ *
+ * Returns null when already running as installed PWA, or on browsers / platforms
+ * that have no install path (iOS Safari, Firefox, desktop without a prompt).
  */
 export function InstallAppButton() {
   const { t } = useTranslation();
@@ -31,8 +59,7 @@ export function InstallAppButton() {
   );
 
   useEffect(() => {
-    // Listen for future events (Chrome re-fires beforeinstallprompt after the
-    // PWA is uninstalled; pwa.ts recaptures and relays it as a custom event).
+    // Listen for future events (Chrome re-fires after uninstall; pwa.ts relays it).
     const onPrompt = (e: Event) => {
       setPromptEvent((e as CustomEvent<BeforeInstallPromptEvent>).detail);
     };
@@ -48,18 +75,31 @@ export function InstallAppButton() {
     };
   }, []);
 
-  if (!promptEvent) {
-    return null;
-  }
+  // Never show the button once the app is running as an installed PWA.
+  if (isInStandaloneMode()) return null;
+
+  // If we have the native prompt, we can show the button on any platform.
+  // If not, only show the manual-fallback button on Android Chrome — it's the
+  // only mobile browser where we know "Add to Home Screen" is in the ⋮ menu.
+  if (!promptEvent && !isAndroidChrome()) return null;
 
   const handleInstall = async () => {
-    await promptEvent.prompt();
-    const { outcome } = await promptEvent.userChoice;
-    // A captured prompt can only be used once; clear it either way.
-    setPromptEvent(null);
-    clearPendingPrompt();
-    if (outcome === 'accepted') {
-      showToast(t('nav.installAppSuccess'), 'success');
+    if (promptEvent) {
+      // Native flow: Chrome shows its own install dialog.
+      await promptEvent.prompt();
+      const { outcome } = await promptEvent.userChoice;
+      setPromptEvent(null);
+      clearPendingPrompt();
+      if (outcome === 'accepted') {
+        showToast(t('nav.installAppSuccess'), 'success');
+      }
+    } else {
+      // Manual fallback: Chrome is in cooldown or hasn't offered the prompt yet.
+      // Guide the user to the browser's own install path.
+      showToast(
+        t('nav.installAppManual', { defaultValue: 'Tap the ⋮ menu → "Add to Home Screen" to install' }),
+        'info',
+      );
     }
   };
 

--- a/frontend/src/components/InstallAppButton.tsx
+++ b/frontend/src/components/InstallAppButton.tsx
@@ -97,7 +97,9 @@ export function InstallAppButton() {
       // Manual fallback: Chrome is in cooldown or hasn't offered the prompt yet.
       // Guide the user to the browser's own install path.
       showToast(
-        t('nav.installAppManual', { defaultValue: 'Tap the ⋮ menu → "Add to Home Screen" to install' }),
+        t('nav.installAppManual', {
+          defaultValue: 'Tap the ⋮ menu → "Install app" or "Add to Home Screen" to install',
+        }),
         'info',
       );
     }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import './pwa' // capture beforeinstallprompt before React mounts (#1460)
 import './index.css'
 import './i18n' // Initialize i18n
 import App from './App.tsx'

--- a/frontend/src/pwa.ts
+++ b/frontend/src/pwa.ts
@@ -1,0 +1,52 @@
+/**
+ * PWA install-prompt capture — must be imported before React mounts.
+ *
+ * `beforeinstallprompt` fires once, shortly after the page `load` event.
+ * `InstallAppButton` is buried inside `ProtectedRoute → Layout`, which is only
+ * rendered after the auth API call resolves.  If the event fires during that
+ * loading window the component-level `useEffect` listener doesn't exist yet
+ * and the event is silently dropped.
+ *
+ * Importing this module in main.tsx (before `createRoot`) installs the global
+ * listener synchronously so no event can ever be missed.  The captured prompt
+ * is retrieved via `getPendingPrompt()` and re-broadcast via a custom event
+ * for any component that mounts later.
+ */
+
+// The BeforeInstallPromptEvent is not in the standard TS DOM lib.
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  prompt(): Promise<void>;
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+// Must match the breakpoint in InstallAppButton / useIsSidebarCompact.
+const SIDEBAR_COMPACT_BREAKPOINT = 1144;
+
+let _pendingPrompt: BeforeInstallPromptEvent | null = null;
+
+/** Returns the most recently captured install prompt, or null. */
+export function getPendingPrompt(): BeforeInstallPromptEvent | null {
+  return _pendingPrompt;
+}
+
+/** Called by InstallAppButton after the prompt is consumed or dismissed. */
+export function clearPendingPrompt(): void {
+  _pendingPrompt = null;
+}
+
+window.addEventListener('beforeinstallprompt', (e) => {
+  // On desktop the sidebar install button is always visible, so suppress
+  // Chrome's mini-infobar and use the button as the sole install trigger.
+  // On mobile the button is buried inside the hamburger drawer, so let the
+  // mini-infobar appear naturally as the primary prompt.
+  if (window.innerWidth >= SIDEBAR_COMPACT_BREAKPOINT) {
+    e.preventDefault();
+  }
+  _pendingPrompt = e as BeforeInstallPromptEvent;
+  // Notify any already-mounted components (e.g. after an in-app uninstall
+  // Chrome re-fires the event; we relay it via a custom event).
+  window.dispatchEvent(
+    new CustomEvent<BeforeInstallPromptEvent>('bambuddy:installprompt', { detail: _pendingPrompt }),
+  );
+});


### PR DESCRIPTION
## Summary

- **Captures `beforeinstallprompt` before React mounts** (`pwa.ts` imported as the first side-effect in `main.tsx`) so the event is never dropped during the auth-loading window — previously the component-level `useEffect` listener missed the event if it fired before the auth API call resolved
- **Always shows the Install button on Android Chrome** — native prompt flow when the event fires, manual toast fallback ("Tap ⋮ → Install app") otherwise, so the button is useful even when Chrome is in a cooldown period
- **Suppresses the mini-infobar on desktop** (≥ 1144 px) via `e.preventDefault()` so the sidebar Download button is the sole install trigger; mobile lets Chrome's native UI appear naturally
- **Adds explicit `worker-src 'self'`** to the CSP in `security_headers_middleware` — without this Chrome 128+ may treat the fallback chain as ambiguous and refuse to count the service worker toward PWA installability
- **No-cache headers** on `/manifest.json`, `/sw.js`, and `/sw-register.js` so stale manifests never block an install eligibility re-check; `/manifest.json` and `/sw-register.js` also gain HEAD method support so health scanners don't return 405
- **Adds nonce to gcode-viewer `script-src`** to match the policy applied to the main SPA

## Test plan

- [ ] Desktop (≥ 1144 px): sidebar Download button appears and triggers Chrome's native install dialog; browser mini-infobar does **not** appear
- [ ] Android Chrome (fresh profile): `beforeinstallprompt` fires, Install button triggers native dialog
- [ ] Android Chrome (prompt unavailable / cooldown): Install button still visible in hamburger menu; tap shows toast with manual instructions
- [ ] Already installed (standalone mode): Install button hidden entirely
- [ ] `/manifest.json`, `/sw.js`, `/sw-register.js` return `Cache-Control: no-cache, no-store, must-revalidate`
- [ ] CSP response header includes `worker-src 'self'`
- [ ] `curl -I /manifest.json` returns 200 (not 405)

🤖 Generated with [Claude Code](https://claude.com/claude-code)