### PR TITLE
feat(inventory): by-tag spool lookup, readable with Manage-Inventory keys (#1663)

### DIFF
--- a/backend/app/api/routes/inventory.py
+++ b/backend/app/api/routes/inventory.py
@@ -937,6 +937,49 @@ async def list_spools(
     return list(result.scalars().all())
 
 
+@router.get("/spools/by-tag", response_model=SpoolResponse)
+async def get_spool_by_tag(
+    tray_uuid: str | None = None,
+    tag_uid: str | None = None,
+    include_archived: bool = False,
+    db: AsyncSession = Depends(get_db),
+    _: User | None = RequirePermissionIfAuthEnabled(Permission.INVENTORY_READ),
+):
+    """Find a single spool by its NFC ``tray_uuid`` and/or ``tag_uid``.
+
+    Lets NFC inventory integrations dedupe a scan without listing the whole
+    inventory. ``tray_uuid`` is the primary identifier (it matches the value the
+    AMS reports over MQTT), so it is tried first; ``tag_uid`` is the fallback.
+    At least one identifier must be supplied. Returns 404 when nothing matches.
+
+    Requires ``inventory:read``, which for API keys is granted by either a
+    read-status or a Manage-Inventory scope (#1663) — so a key that can already
+    create/update spools can read them back too.
+    """
+    normalized_tray_uuid = normalize_tray_uuid(tray_uuid) or None
+    normalized_tag_uid = normalize_tag_uid(tag_uid) or None
+
+    if not normalized_tray_uuid and not normalized_tag_uid:
+        raise HTTPException(400, "Provide tray_uuid and/or tag_uid")
+
+    base_query = select(Spool).options(selectinload(Spool.k_profiles))
+    if not include_archived:
+        base_query = base_query.where(Spool.archived_at.is_(None))
+
+    for column, value in (
+        (Spool.tray_uuid, normalized_tray_uuid),
+        (Spool.tag_uid, normalized_tag_uid),
+    ):
+        if not value:
+            continue
+        result = await db.execute(base_query.where(func.upper(column) == value).order_by(Spool.id))
+        spool = result.scalars().first()
+        if spool:
+            return spool
+
+    raise HTTPException(404, "Spool not found")
+
+
 @router.get("/spools/{spool_id}", response_model=SpoolResponse)
 async def get_spool(
     spool_id: int,

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -58,7 +58,10 @@ logger = logging.getLogger(__name__)
 #                         delete of admin resources, settings writes, user/
 #                         group/api-key/backup admin ops, discovery scan,
 #                         cloud auth, library ALL-ownership perms, purges
-_APIKEY_SCOPE_BY_PERMISSION: dict[Permission, str] = {
+#
+# A permission may map to a SINGLE scope flag (the common case) or to a TUPLE
+# of flags, in which case ANY one of them grants it (see INVENTORY_READ below).
+_APIKEY_SCOPE_BY_PERMISSION: dict[Permission, str | tuple[str, ...]] = {
     # can_read_status — read-only access to status, history, and configuration
     Permission.PRINTERS_READ: "can_read_status",
     Permission.ARCHIVES_READ: "can_read_status",
@@ -66,7 +69,7 @@ _APIKEY_SCOPE_BY_PERMISSION: dict[Permission, str] = {
     Permission.LIBRARY_READ: "can_read_status",
     Permission.PROJECTS_READ: "can_read_status",
     Permission.FILAMENTS_READ: "can_read_status",
-    Permission.INVENTORY_READ: "can_read_status",
+    Permission.INVENTORY_READ: ("can_read_status", "can_manage_inventory"),
     Permission.INVENTORY_VIEW_ASSIGNMENTS: "can_read_status",
     Permission.INVENTORY_FORECAST_READ: "can_read_status",
     Permission.SMART_PLUGS_READ: "can_read_status",
@@ -198,16 +201,21 @@ _APIKEY_DENIED_PERMISSIONS: frozenset[Permission] = frozenset(
 )
 
 
-def _resolve_apikey_scope(perm_string: str) -> str | None:
-    """Return the scope-flag attribute name gating ``perm_string`` for API keys.
+def _resolve_apikey_scopes(perm_string: str) -> tuple[str, ...] | None:
+    """Return the scope-flag attribute name(s) gating ``perm_string`` for API keys.
 
-    None when the permission is unmapped (= admin-only / not API-key-usable).
+    A permission allowed by ANY of several flags returns all of them; a
+    single-flag permission returns a 1-tuple. None when the permission is
+    unmapped (= admin-only / not API-key-usable).
     """
     try:
         perm = Permission(perm_string)
     except ValueError:
         return None
-    return _APIKEY_SCOPE_BY_PERMISSION.get(perm)
+    scopes = _APIKEY_SCOPE_BY_PERMISSION.get(perm)
+    if scopes is None:
+        return None
+    return (scopes,) if isinstance(scopes, str) else scopes
 
 
 def _check_apikey_permissions(api_key: APIKey, perm_strings: list[str], *, require_any: bool = False) -> None:
@@ -233,16 +241,17 @@ def _check_apikey_permissions(api_key: APIKey, perm_strings: list[str], *, requi
 
     last_failure: HTTPException | None = None
     for perm_str in perm_strings:
-        scope_attr = _resolve_apikey_scope(perm_str)
-        if scope_attr is None:
+        scope_attrs = _resolve_apikey_scopes(perm_str)
+        if scope_attrs is None:
             failure = HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="API keys cannot be used for administrative operations",
             )
-        elif not getattr(api_key, scope_attr, False):
+        elif not any(getattr(api_key, scope_attr, False) for scope_attr in scope_attrs):
+            scopes_label = "' or '".join(scope_attrs)
             failure = HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"API key does not have '{scope_attr}' permission",
+                detail=f"API key does not have '{scopes_label}' permission",
             )
         else:
             failure = None

--- a/backend/tests/integration/test_auth_apikey_rbac.py
+++ b/backend/tests/integration/test_auth_apikey_rbac.py
@@ -216,7 +216,12 @@ class TestApiKeyScopeAllowlist:
             "can_manage_inventory",
             "can_access_cloud",
         }
-        used_flags = set(_APIKEY_SCOPE_BY_PERMISSION.values())
+        # Values may be a single flag string or a tuple of flags (any-of) — flatten.
+        used_flags = {
+            flag
+            for value in _APIKEY_SCOPE_BY_PERMISSION.values()
+            for flag in ((value,) if isinstance(value, str) else value)
+        }
         assert used_flags <= valid_flags, f"Unknown scope flags in mapping: {used_flags - valid_flags}"
         # And every flag must actually exist on the model.
         for flag in valid_flags:
@@ -247,7 +252,12 @@ class TestApiKeyScopeAllowlist:
         """If a scope flag has no permissions, it's dead code — fail loudly."""
         from backend.app.core.auth import _APIKEY_SCOPE_BY_PERMISSION
 
-        assert scope_flag in _APIKEY_SCOPE_BY_PERMISSION.values(), (
+        mapped_flags = {
+            flag
+            for value in _APIKEY_SCOPE_BY_PERMISSION.values()
+            for flag in ((value,) if isinstance(value, str) else value)
+        }
+        assert scope_flag in mapped_flags, (
             f"No permission maps to {scope_flag} — either remove the flag or classify a permission under it."
         )
 
@@ -350,6 +360,25 @@ class TestCheckApiKeyPermissionsMatrix:
             if f != required_flag
         }
         for other in other_flags:
+            with pytest.raises(HTTPException) as exc:
+                _check_apikey_permissions(_FakeApiKey(**{other: True}), [perm])
+            assert exc.value.status_code == 403
+
+    def test_inventory_read_allowed_by_either_inventory_scope(self):
+        """INVENTORY_READ is granted by can_read_status OR can_manage_inventory (#1663)."""
+        from fastapi import HTTPException
+
+        from backend.app.core.auth import _check_apikey_permissions
+        from backend.app.core.permissions import Permission
+
+        perm = Permission.INVENTORY_READ.value
+
+        # Either inventory scope on its own grants read.
+        _check_apikey_permissions(_FakeApiKey(can_read_status=True), [perm])
+        _check_apikey_permissions(_FakeApiKey(can_manage_inventory=True), [perm])
+
+        # A key with neither (e.g. queue/control only) is denied.
+        for other in ("can_queue", "can_control_printer", "can_manage_library"):
             with pytest.raises(HTTPException) as exc:
                 _check_apikey_permissions(_FakeApiKey(**{other: True}), [perm])
             assert exc.value.status_code == 403

--- a/backend/tests/integration/test_spool_by_tag_lookup.py
+++ b/backend/tests/integration/test_spool_by_tag_lookup.py
@@ -1,0 +1,178 @@
+"""By-tag spool lookup endpoint (#1663).
+
+``GET /api/v1/inventory/spools/by-tag`` lets NFC inventory integrations
+dedupe a scan by ``tray_uuid``/``tag_uid`` without listing the whole
+inventory, and is readable with either a read-status or a manage-inventory
+API-key scope.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.auth import generate_api_key
+from backend.app.models.api_key import APIKey
+from backend.app.models.settings import Settings
+from backend.app.models.spool import Spool
+
+TRAY_UUID = "AABBCCDDEEFF0011AABBCCDDEEFF0011"
+TAG_UID = "04A1B2C3"
+
+
+@pytest.fixture
+async def spool_factory(db_session: AsyncSession):
+    """Create a Spool with sensible defaults."""
+
+    async def _create(**kwargs):
+        defaults = {
+            "material": "PLA",
+            "subtype": "Basic",
+            "brand": "Bambu",
+            "color_name": "Red",
+            "rgba": "FF0000FF",
+            "label_weight": 1000,
+            "weight_used": 0,
+            "weight_used_baseline": 0,
+            "weight_locked": False,
+        }
+        defaults.update(kwargs)
+        spool = Spool(**defaults)
+        db_session.add(spool)
+        await db_session.commit()
+        await db_session.refresh(spool)
+        return spool
+
+    return _create
+
+
+class TestSpoolByTagLookup:
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_lookup_by_tray_uuid(self, async_client: AsyncClient, spool_factory):
+        spool = await spool_factory(tray_uuid=TRAY_UUID)
+        resp = await async_client.get(f"/api/v1/inventory/spools/by-tag?tray_uuid={TRAY_UUID}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == spool.id
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_lookup_by_tag_uid(self, async_client: AsyncClient, spool_factory):
+        spool = await spool_factory(tag_uid=TAG_UID)
+        resp = await async_client.get(f"/api/v1/inventory/spools/by-tag?tag_uid={TAG_UID}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == spool.id
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_lookup_normalizes_input(self, async_client: AsyncClient, spool_factory):
+        """Lowercase / separator-laden input still matches the stored hex."""
+        spool = await spool_factory(tray_uuid=TRAY_UUID)
+        messy = "aa:bb:cc:dd:ee:ff:00:11:aa:bb:cc:dd:ee:ff:00:11"
+        resp = await async_client.get(f"/api/v1/inventory/spools/by-tag?tray_uuid={messy}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == spool.id
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_tray_uuid_preferred_over_tag_uid(self, async_client: AsyncClient, spool_factory):
+        """When both identifiers are given, tray_uuid wins (it's the AMS key)."""
+        by_uuid = await spool_factory(tray_uuid=TRAY_UUID)
+        await spool_factory(tag_uid=TAG_UID)
+        resp = await async_client.get(f"/api/v1/inventory/spools/by-tag?tray_uuid={TRAY_UUID}&tag_uid={TAG_UID}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == by_uuid.id
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_no_identifier_is_400(self, async_client: AsyncClient):
+        resp = await async_client.get("/api/v1/inventory/spools/by-tag")
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_non_hex_identifier_is_400(self, async_client: AsyncClient):
+        """A value with no hex characters normalizes to empty → treated as absent."""
+        resp = await async_client.get("/api/v1/inventory/spools/by-tag?tray_uuid=zzz")
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_no_match_is_404(self, async_client: AsyncClient, spool_factory):
+        await spool_factory(tray_uuid=TRAY_UUID)
+        resp = await async_client.get("/api/v1/inventory/spools/by-tag?tray_uuid=" + "FF" * 16)
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_archived_excluded_by_default(self, async_client: AsyncClient, spool_factory):
+        from datetime import datetime, timezone
+
+        await spool_factory(tray_uuid=TRAY_UUID, archived_at=datetime.now(timezone.utc))
+        resp = await async_client.get(f"/api/v1/inventory/spools/by-tag?tray_uuid={TRAY_UUID}")
+        assert resp.status_code == 404
+
+        resp = await async_client.get(f"/api/v1/inventory/spools/by-tag?tray_uuid={TRAY_UUID}&include_archived=true")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_does_not_collide_with_spool_id_route(self, async_client: AsyncClient, spool_factory):
+        """'by-tag' must route to the lookup handler, not /spools/{spool_id}."""
+        await spool_factory(tray_uuid=TRAY_UUID)
+        resp = await async_client.get("/api/v1/inventory/spools/by-tag?tray_uuid=" + TRAY_UUID)
+        assert resp.status_code == 200
+
+
+async def _make_api_key(db_session: AsyncSession, **scopes) -> str:
+    full_key, key_hash, key_prefix = generate_api_key()
+    flags = {
+        "can_queue": False,
+        "can_control_printer": False,
+        "can_read_status": False,
+        "can_manage_inventory": False,
+    }
+    flags.update(scopes)
+    db_session.add(APIKey(name="test-key", key_hash=key_hash, key_prefix=key_prefix, enabled=True, **flags))
+    db_session.add(Settings(key="auth_enabled", value="true"))
+    await db_session.commit()
+    return full_key
+
+
+class TestSpoolByTagApiKeyScope:
+    """The endpoint is the core ask of #1663: a Manage-Inventory key (which can
+    already create/update spools) must be able to read them back."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_manage_inventory_key_can_read(self, async_client: AsyncClient, db_session, spool_factory):
+        spool = await spool_factory(tray_uuid=TRAY_UUID)
+        key = await _make_api_key(db_session, can_manage_inventory=True)
+        resp = await async_client.get(
+            f"/api/v1/inventory/spools/by-tag?tray_uuid={TRAY_UUID}",
+            headers={"X-API-Key": key},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == spool.id
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_read_status_key_can_read(self, async_client: AsyncClient, db_session, spool_factory):
+        spool = await spool_factory(tray_uuid=TRAY_UUID)
+        key = await _make_api_key(db_session, can_read_status=True)
+        resp = await async_client.get(
+            f"/api/v1/inventory/spools/by-tag?tray_uuid={TRAY_UUID}",
+            headers={"X-API-Key": key},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == spool.id
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_key_without_inventory_scope_is_denied(self, async_client: AsyncClient, db_session, spool_factory):
+        await spool_factory(tray_uuid=TRAY_UUID)
+        key = await _make_api_key(db_session, can_control_printer=True)
+        resp = await async_client.get(
+            f"/api/v1/inventory/spools/by-tag?tray_uuid={TRAY_UUID}",
+            headers={"X-API-Key": key},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
## Description

Adds a by-tag spool lookup endpoint and lets a Manage-Inventory API key read inventory, so NFC inventory integrations can dedupe a scan with a single, narrowly-scoped key instead of pulling the whole inventory under the broad `can_read_status` scope.

## Related Issue

Fixes #1663

## Documentation

**Companion docs PRs**:
- Wiki: maziggy/bambuddy-wiki#42

**Pick one**:
- [x] Docs PR(s) linked above

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Add `GET /api/v1/inventory/spools/by-tag?tray_uuid=…&tag_uid=…` — looks up a single spool; `tray_uuid` (the value the AMS reports over MQTT) is matched first, `tag_uid` is the fallback. Inputs are normalised, archived spools excluded by default, `400` if neither identifier is given, `404` if nothing matches.
- Extend `_APIKEY_SCOPE_BY_PERMISSION` so a permission can map to **either** a single scope flag **or** a tuple of flags (any one grants it). `INVENTORY_READ` now maps to `("can_read_status", "can_manage_inventory")`.
- This is deliberately additive: rather than re-pointing `INVENTORY_READ` at `can_manage_inventory` (which would break existing integrations reading inventory with a `can_read_status` key), read-status keys keep working unchanged and Manage-Inventory keys additionally gain inventory read.
- `_resolve_apikey_scope` → `_resolve_apikey_scopes` (returns a tuple); the scope check passes if any mapped flag is set.

## Testing

- [x] I have tested this on my local machine

New `test_spool_by_tag_lookup.py` (match / normalise / tray-uuid precedence / 400 / 404 / archived / route-collision, plus the three API-key scope cases). Updated the RBAC scope matrix + introspection tests for tuple-valued mappings. `ruff check`/`format` clean; by-tag, RBAC, route-auth-coverage and endpoint-auth suites pass (69 tests).

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly