### PR TITLE
fix(library): preview sidecar-generated .gcode.3mf files

### DIFF
--- a/backend/app/api/routes/library.py
+++ b/backend/app/api/routes/library.py
@@ -3681,9 +3681,9 @@ async def slice_and_persist(
         file_path=to_relative_path(out_path),
         # Sliced output is a `.gcode.3mf` zip with embedded G-code, but the
         # user-facing meaning is "ready-to-print G-code" — using "gcode"
-        # gives it the same badge as plain .gcode files and distinguishes
-        # it from un-sliced `.3mf` source models.
-        file_type="gcode",
+        # Keep the compound type so preview/download paths know the payload
+        # must be opened as a ZIP rather than returned as plain-text G-code.
+        file_type="gcode.3mf",
         file_size=len(result.content),
         file_hash=hashlib.sha256(result.content).hexdigest(),
         thumbnail_path=thumbnail_relative,
@@ -4435,9 +4435,9 @@ async def get_gcode(
     if not abs_path or not abs_path.exists():
         raise HTTPException(status_code=404, detail="File not found on disk")
 
-    if file.file_type == "gcode":
-        return FastAPIFileResponse(str(abs_path), media_type="text/plain")
-    elif file.file_type in ("3mf", "gcode.3mf"):
+    is_gcode_3mf = file.file_type in ("3mf", "gcode.3mf") or file.filename.lower().endswith(".gcode.3mf")
+
+    if is_gcode_3mf:
         # Extract gcode from 3mf zip container. `.gcode.3mf` sliced outputs
         # carry the same `Metadata/plate_*.gcode` entries as a `.3mf`, so
         # the unzip path is identical — just had to expand the gate.
@@ -4453,6 +4453,8 @@ async def get_gcode(
                 return Response(content=gcode_content, media_type="text/plain")
         except zipfile.BadZipFile:
             raise HTTPException(status_code=400, detail="Invalid 3MF file")
+    elif file.file_type == "gcode":
+        return FastAPIFileResponse(str(abs_path), media_type="text/plain")
     else:
         raise HTTPException(status_code=400, detail="Unsupported file type")
 

--- a/backend/tests/integration/test_library_api.py
+++ b/backend/tests/integration/test_library_api.py
@@ -1276,6 +1276,37 @@ class TestPrintFileUploadValidation:
 
     @pytest.mark.asyncio
     @pytest.mark.integration
+    async def test_library_get_gcode_recovers_legacy_gcode_type_for_3mf(
+        self, async_client: AsyncClient, db_session
+    ):
+        """Sliced library rows created by older code stored
+        ``file_type='gcode'`` even though the payload was a `.gcode.3mf`
+        ZIP. The preview endpoint must inspect the filename and extract
+        embedded G-code instead of returning ZIP bytes as text."""
+        from backend.app.models.library import LibraryFile
+
+        with tempfile.NamedTemporaryFile(suffix=".gcode.3mf", delete=False) as tmp:
+            tmp.write(self._valid_3mf_bytes(name="Metadata/plate_1.gcode"))
+            tmp_path = tmp.name
+
+        lib_file = LibraryFile(
+            filename="legacy-sliced.gcode.3mf",
+            file_path=tmp_path,
+            file_type="gcode",
+            file_size=Path(tmp_path).stat().st_size,
+        )
+        db_session.add(lib_file)
+        await db_session.commit()
+        await db_session.refresh(lib_file)
+
+        response = await async_client.get(f"/api/v1/library/files/{lib_file.id}/gcode")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/plain")
+        assert b"G28" in response.content
+        assert not response.content.startswith(b"PK")
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
     async def test_library_still_accepts_non_print_extensions(self, async_client: AsyncClient, db_session):
         """STL / image / other non-print uploads bypass the validator
         entirely — Bambuddy is also a library, not just a print dispatcher."""


### PR DESCRIPTION
## Summary
- store sidecar-generated `.gcode.3mf` library outputs using the canonical `gcode.3mf` file type
- recover legacy sliced rows stored as `file_type="gcode"` by checking the compound filename before returning plain-text G-code
- add a regression test proving the preview endpoint extracts `Metadata/plate_1.gcode` instead of returning ZIP bytes beginning with `PK`

## Root cause
`slice_and_persist()` writes a ZIP-shaped `.gcode.3mf` file but records it as `file_type="gcode"`. The G-code preview endpoint handles `gcode` as plain text before reaching its 3MF extraction branch, so the embedded viewer receives the entire ZIP container and renders no toolpath.

## Test plan
- `python -m pytest backend/tests/integration/test_library_api.py -k "get_gcode_endpoint_accepts_compound_file_type or get_gcode_recovers_legacy_gcode_type_for_3mf" -q` (2 passed)
- `python -m pytest backend/tests/integration/test_library_slice_api.py -q` (41 passed)