### PR TITLE
fix(updater): use app_dir for all git ops when DATA_DIR is separate

### DIFF
--- a/backend/app/api/routes/updates.py
+++ b/backend/app/api/routes/updates.py
@@ -194,7 +194,7 @@ async def _origin_points_at_repo(git_path: str, git_config: list[str], base_dir,
             "remote",
             "get-url",
             "origin",
-            cwd=str(base_dir),
+            cwd=str(app_dir),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -556,6 +556,7 @@ async def _perform_update(target_ref: str):
 
     try:
         base_dir = settings.base_dir
+        app_dir = settings.app_dir
 
         # Find git executable (may not be in PATH when running as systemd service)
         git_path = _find_executable("git")
@@ -570,8 +571,10 @@ async def _perform_update(target_ref: str):
 
         logger.info("Using git at: %s", git_path)
 
-        # Git config to avoid safe.directory issues
-        git_config = ["-c", f"safe.directory={base_dir}"]
+        # safe.directory must point at the working tree (app_dir).
+        # When systemd sets DATA_DIR=<install>/data, base_dir != app_dir and
+        # data/ may be on a separate mount — git won't cross filesystem boundaries.
+        git_config = ["-c", f"safe.directory={app_dir}"]
 
         _update_status = {
             "status": "downloading",
@@ -593,7 +596,7 @@ async def _perform_update(target_ref: str):
         # correct repo are preserved; only missing / wrong / corrupted
         # origins get reset to HTTPS.
         https_url = f"https://github.com/{GITHUB_REPO}.git"
-        if not await _origin_points_at_repo(git_path, git_config, base_dir, GITHUB_REPO):
+        if not await _origin_points_at_repo(git_path, git_config, app_dir, GITHUB_REPO):
             process = await asyncio.create_subprocess_exec(
                 git_path,
                 *git_config,
@@ -601,7 +604,7 @@ async def _perform_update(target_ref: str):
                 "set-url",
                 "origin",
                 https_url,
-                cwd=str(base_dir),
+                cwd=str(app_dir),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -635,7 +638,7 @@ async def _perform_update(target_ref: str):
             "--tags",
             "--force",
             "origin",
-            cwd=str(base_dir),
+            cwd=str(app_dir),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -671,7 +674,7 @@ async def _perform_update(target_ref: str):
             "reset",
             "--hard",
             target_ref,
-            cwd=str(base_dir),
+            cwd=str(app_dir),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -697,11 +700,6 @@ async def _perform_update(target_ref: str):
 
         # Install Python dependencies — must run from the source-code directory
         # (where requirements.txt lives), not the data dir. On native installs
-        # systemd sets DATA_DIR=INSTALL_PATH/data, so `base_dir` is the data dir,
-        # not the working tree. `git reset` above worked from base_dir because
-        # git walks up looking for .git, but `pip install -r requirements.txt`
-        # needs the file in cwd literally.
-        app_dir = settings.app_dir
         process = await asyncio.create_subprocess_exec(
             sys.executable,
             "-m",


### PR DESCRIPTION
## Description

On native systemd installs the service file sets DATA_DIR=<install>/data, which means settings.base_dir resolves to the data directory rather than the source tree. All git subprocess calls (remote get-url, fetch, reset --hard) were running with cwd=base_dir and safe.directory=base_dir, so git would fail with:

  fatal: not a git repository (or any parent up to mount point /)
  Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)

This affects every native systemd install that follows the official guide, because that guide sets DATA_DIR=/srv/bambuddy/data in the service unit.

## Related Issue

Fix: derive app_dir = settings.app_dir at the top of _perform_update and use it for every git command. base_dir is kept for non-git operations (pip install path was already correct). The _origin_points_at_repo helper already received the directory as its base_dir parameter — the caller now passes app_dir as that argument, which is the correct working tree.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: P1S
