### PR TITLE
feat(pending-slot-assignment): Implement API for managing pending spool to slot assignments

### DIFF
--- a/backend/app/api/routes/inventory.py
+++ b/backend/app/api/routes/inventory.py
@@ -36,6 +36,8 @@ from backend.app.schemas.spool import (
     SpoolUpdate,
     normalize_effect_type,
     normalize_extra_colors,
+    PendingSlotAssignmentResponse,
+    PendingSlotAssignmentCreateRequest,
 )
 from backend.app.schemas.spool_usage import SpoolUsageHistoryResponse
 from backend.app.services.slicer_filament_resolver import resolve_slicer_filament
@@ -1494,6 +1496,71 @@ async def unassign_spool(
     )
 
     return {"status": "deleted"}
+
+
+# ── Pending Slot Assignments (assign-on-next-slot) ────────────────────────────
+
+@router.post("/spools/assign-on-next-slot", response_model=PendingSlotAssignmentResponse)
+async def assign_on_next_slot(
+    body: PendingSlotAssignmentCreateRequest,
+    db: AsyncSession = Depends(get_db),
+    _: User | None = RequirePermissionIfAuthEnabled(Permission.INVENTORY_UPDATE),
+):
+    """Create a pending spool-to-slot assignment request."""
+    from backend.app.services.pending_slot_assignment import create_pending_assignment
+
+    logger.info("Received assign-on-next-slot request: spool_id=%d tray_uuid=%s tag_uid=%s source=%s", body.spool_id, body.tray_uuid, body.tag_uid, body.source)
+    assignment = await create_pending_assignment(
+        db,
+        tray_uuid=body.tray_uuid,
+        tag_uid=body.tag_uid,
+        spool_id=body.spool_id,
+        printer_id=body.printer_id,
+        source=body.source,
+        timeout_seconds=body.timeout,
+    )
+    return PendingSlotAssignmentResponse.from_model(assignment)
+
+
+@router.get(
+    "/spools/assignments/{assignment_id}",
+    response_model=PendingSlotAssignmentResponse,
+    summary="Check pending assignment status",
+)
+async def get_pending_assignment_status(
+    assignment_id: int,
+    db: AsyncSession = Depends(get_db),
+    _: User | None = RequirePermissionIfAuthEnabled(Permission.INVENTORY_READ),
+):
+    """Get the status of a pending slot assignment."""
+    from backend.app.services.pending_slot_assignment import get_pending_assignment
+
+    assignment = await get_pending_assignment(db, assignment_id)
+    if not assignment:
+        raise HTTPException(status_code=404, detail="Assignment not found")
+    return PendingSlotAssignmentResponse.from_model(assignment)
+
+
+@router.delete(
+    "/spools/assignments/{assignment_id}",
+    response_model=PendingSlotAssignmentResponse,
+    summary="Cancel a pending assignment",
+)
+async def cancel_pending_assignment_endpoint(
+    assignment_id: int,
+    db: AsyncSession = Depends(get_db),
+    _: User | None = RequirePermissionIfAuthEnabled(Permission.INVENTORY_UPDATE),
+):
+    """Cancel a pending slot assignment. Only pending assignments can be cancelled."""
+    from backend.app.services.pending_slot_assignment import cancel_pending_assignment
+
+    assignment = await cancel_pending_assignment(db, assignment_id)
+    if not assignment:
+        raise HTTPException(
+            status_code=404,
+            detail="Assignment not found or not in pending status",
+        )
+    return PendingSlotAssignmentResponse.from_model(assignment)
 
 
 # ── Tag Linking ───────────────────────────────────────────────────────────────

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -188,6 +188,7 @@ async def init_db():
         oidc_provider,
         orca_base_cache,
         pending_upload,
+        pending_slot_assignment,
         print_batch,
         print_log,
         print_queue,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1496,6 +1496,28 @@ async def on_ams_change(printer_id: int, ams_data: list):
                                 )
                             continue
 
+                        # Check pending assign-on-next-slot requests before auto-assign
+                        try:
+                            from backend.app.services.pending_slot_assignment import (
+                                try_complete_pending_assignments,
+                            )
+
+                            if await try_complete_pending_assignments(db, printer_id, ams_id, tray_id):
+                                logger.info(
+                                    "Pending slot assignment completed for printer %d AMS%d-T%d",
+                                    printer_id,
+                                    ams_id,
+                                    tray_id,
+                                )
+                                continue
+                        except Exception:
+                            logger.exception(
+                                "Pending slot assignment check failed for printer %d AMS%d-T%d",
+                                printer_id,
+                                ams_id,
+                                tray_id,
+                            )
+
                         if is_bambu_tag(tag_uid, tray_uuid, tray_info_idx):
                             # BL spool with RFID tag: auto-match → inventory match → auto-create
                             spool = await get_spool_by_tag(db, tag_uid, tray_uuid)
@@ -5506,6 +5528,11 @@ async def lifespan(app: FastAPI):
 
     # Rehydrate persisted awaiting-plate-clear gate (#961) so prompts survive restarts
     await printer_manager.load_awaiting_plate_clear_from_db()
+
+    # Restore pending slot assignment timeout tasks that survived a restart
+    from backend.app.services.pending_slot_assignment import restore_pending_timeouts
+
+    await restore_pending_timeouts()
 
     # Layer change callback for external camera timelapse
     async def on_layer_change(printer_id: int, layer_num: int):

--- a/backend/app/models/pending_slot_assignment.py
+++ b/backend/app/models/pending_slot_assignment.py
@@ -1,0 +1,57 @@
+"""Model for pending spool-to-slot assignment requests.
+
+A pending assignment represents a request to assign a spool to the next AMS slot
+that transitions from empty → filled. The backend monitors AMS events and completes
+the assignment automatically when a matching slot change is detected.
+"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Float, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.app.core.database import Base
+
+
+class PendingSlotAssignment(Base):
+    """A pending request to assign a spool to the next available AMS slot."""
+
+    __tablename__ = "pending_slot_assignment"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    # Spool identifiers — at least one must be non-null
+    tray_uuid: Mapped[str | None] = mapped_column(String(64), index=True)
+    tag_uid: Mapped[str | None] = mapped_column(String(32), index=True)
+    # Resolved spool_id once matched (nullable until resolved)
+    spool_id: Mapped[int | None] = mapped_column(Integer)
+    # Target printer (NULL = any printer)
+    printer_id: Mapped[int | None] = mapped_column(Integer)
+    # Source of the request
+    source: Mapped[str] = mapped_column(String(20))  # "nfc" | "qr" | "spoolbuddy"
+    # Status: pending, completed, timed_out, cancelled
+    status: Mapped[str] = mapped_column(String(20), default="pending", index=True)
+    # Timeout in seconds
+    timeout_seconds: Mapped[int] = mapped_column(Integer, default=300)
+
+    # Completion details (filled when status transitions to completed)
+    assigned_printer_id: Mapped[int | None] = mapped_column(Integer)
+    assigned_ams_id: Mapped[int | None] = mapped_column(Integer)
+    assigned_tray_id: Mapped[int | None] = mapped_column(Integer)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime)
+
+    # Metrics
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    time_to_placement: Mapped[float | None] = mapped_column(Float)  # seconds
+
+    @property
+    def lookup_key(self) -> str:
+        """Return the primary identifier used for spool lookup (tray_uuid preferred)."""
+        return self.tray_uuid or self.tag_uid or ""
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if this pending assignment has timed out."""
+        if self.status != "pending":
+            return False
+        elapsed = (datetime.now(timezone.utc) - self.created_at.replace(tzinfo=timezone.utc)).total_seconds()
+        return elapsed > self.timeout_seconds

--- a/backend/app/schemas/pending_slot_assignment.py
+++ b/backend/app/schemas/pending_slot_assignment.py
@@ -1,0 +1,66 @@
+"""Pydantic schemas for the pending slot assignment API."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class PendingSlotAssignmentCreate(BaseModel):
+    """Request body for POST /api/v1/inventory/spools/assign-on-next-slot."""
+
+    tray_uuid: str | None = Field(
+        default=None,
+        max_length=64,
+        description="The spool's tray_uuid (Bambu Lab spool UUID, 32 hex chars). "
+        "Read from the NFC tag NDEF payload or decoded from a QR code.",
+    )
+    tag_uid: str | None = Field(
+        default=None,
+        max_length=32,
+        description="The NFC tag hardware UID (up to 32 hex chars). "
+        "Used as fallback when tray_uuid is not available (generic/3rd-party tags).",
+    )
+    printer_id: int | None = Field(
+        default=None,
+        description="Target printer ID. If omitted, listens on all printers.",
+    )
+    source: str = Field(
+        ...,
+        pattern=r"^(nfc|qr|spoolbuddy)$",
+        description="Source of the scan: nfc, qr, or spoolbuddy.",
+    )
+    timeout: int = Field(
+        default=300,
+        ge=10,
+        le=3600,
+        description="Timeout in seconds before marking as timed_out (10–3600).",
+    )
+
+    @model_validator(mode="after")
+    def _require_at_least_one_identifier(self) -> "PendingSlotAssignmentCreate":
+        if not self.tray_uuid and not self.tag_uid:
+            raise ValueError("At least one of tray_uuid or tag_uid must be provided.")
+        return self
+
+
+class PendingSlotAssignmentResponse(BaseModel):
+    """Response body for assignment endpoints."""
+
+    assignment_id: int
+    tray_uuid: str | None = None
+    tag_uid: str | None = None
+    spool_id: int | None = None
+    printer_id: int | None = None
+    source: str
+    status: str  # pending, completed, timed_out, cancelled
+    timeout_seconds: int
+    # Completion details
+    assigned_printer_id: int | None = None
+    assigned_ams_id: int | None = None
+    assigned_tray_id: int | None = None
+    completed_at: datetime | None = None
+    time_to_placement: float | None = None
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/spool.py
+++ b/backend/app/schemas/spool.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Visual variant applied to a spool's swatch — purely cosmetic, does not
 # affect MQTT/firmware. Kept independent of `subtype` so users can override
@@ -243,3 +243,54 @@ class SpoolAssignmentResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+
+class PendingSlotAssignmentCreateRequest(BaseModel):
+    spool_id: int | None = None
+    tray_uuid: str | None = None
+    tag_uid: str | None = None
+    printer_id: int | None = None
+    source: str
+    timeout: int
+
+
+class PendingSlotAssignmentResponse(BaseModel):
+    """Response body for pending assignment endpoints."""
+
+    assignment_id: int
+    tray_uuid: str | None = None
+    tag_uid: str | None = None
+    spool_id: int | None = None
+    printer_id: int | None = None
+    source: str
+    status: str  # pending, completed, timed_out, cancelled
+    timeout_seconds: int
+    assigned_printer_id: int | None = None
+    assigned_ams_id: int | None = None
+    assigned_tray_id: int | None = None
+    completed_at: str | None = None
+    time_to_placement: float | None = None
+    created_at: str
+
+    class Config:
+        from_attributes = True
+
+    @staticmethod
+    def from_model(pending_assignment) -> "PendingSlotAssignmentResponse":
+        return PendingSlotAssignmentResponse(
+            assignment_id=pending_assignment.id,
+            tray_uuid=pending_assignment.tray_uuid,
+            tag_uid=pending_assignment.tag_uid,
+            spool_id=pending_assignment.spool_id,
+            printer_id=pending_assignment.printer_id,
+            source=pending_assignment.source,
+            status=pending_assignment.status,
+            timeout_seconds=pending_assignment.timeout_seconds,
+            assigned_printer_id=pending_assignment.assigned_printer_id,
+            assigned_ams_id=pending_assignment.assigned_ams_id,
+            assigned_tray_id=pending_assignment.assigned_tray_id,
+            completed_at=pending_assignment.completed_at.isoformat() if pending_assignment.completed_at else None,
+            time_to_placement=pending_assignment.time_to_placement,
+            created_at=pending_assignment.created_at.isoformat() if pending_assignment.created_at else "",
+        )

--- a/backend/app/services/mqtt_relay.py
+++ b/backend/app/services/mqtt_relay.py
@@ -687,6 +687,56 @@ class MQTTRelayService:
             },
         )
 
+    async def on_slot_assignment_completed(
+        self,
+        assignment_id: int,
+        tray_uuid: str | None,
+        tag_uid: str | None,
+        spool_id: int,
+        printer_id: int,
+        ams_id: int,
+        tray_id: int,
+        time_to_placement: float,
+    ):
+        """Publish event when a pending slot assignment is completed."""
+        if not self.enabled or not self.connected:
+            return
+
+        self._publish(
+            f"{self.topic_prefix}/inventory/slot_assignment/completed",
+            {
+                "assignment_id": assignment_id,
+                "tray_uuid": tray_uuid,
+                "tag_uid": tag_uid,
+                "spool_id": spool_id,
+                "printer_id": printer_id,
+                "ams_id": ams_id,
+                "tray_id": tray_id,
+                "time_to_placement": time_to_placement,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+    async def on_slot_assignment_timed_out(
+        self,
+        assignment_id: int,
+        tray_uuid: str | None,
+        tag_uid: str | None,
+    ):
+        """Publish event when a pending slot assignment times out."""
+        if not self.enabled or not self.connected:
+            return
+
+        self._publish(
+            f"{self.topic_prefix}/inventory/slot_assignment/timed_out",
+            {
+                "assignment_id": assignment_id,
+                "tray_uuid": tray_uuid,
+                "tag_uid": tag_uid,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
 
 # Global instance
 mqtt_relay = MQTTRelayService()

--- a/backend/app/services/pending_slot_assignment.py
+++ b/backend/app/services/pending_slot_assignment.py
@@ -1,0 +1,383 @@
+"""Service layer for pending slot assignments.
+
+Manages the lifecycle of assign-on-next-slot requests: creation, completion on
+AMS slot transitions, timeout expiry, cancellation, and event broadcasting.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.core.websocket import ws_manager
+from backend.app.models.pending_slot_assignment import PendingSlotAssignment
+from backend.app.models.spool import Spool
+
+logger = logging.getLogger(__name__)
+
+# In-memory set of active timeout tasks keyed by assignment ID so they can be
+# cancelled if the assignment completes or is explicitly cancelled.
+_timeout_tasks: dict[int, asyncio.Task] = {}
+
+
+async def _resolve_spool(db: AsyncSession, spool_id: int | None, tray_uuid: str | None, tag_uid: str | None) -> Spool | None:
+    """Find an inventory spool by spool_id (preferred), tray_uuid, or tag_uid (fallback)."""
+    if spool_id:
+        result = await db.execute(
+            select(Spool).where(Spool.id == spool_id, Spool.archived_at.is_(None))
+        )
+        spool = result.scalar_one_or_none()
+        if spool:
+            return spool
+    if tray_uuid:
+        result = await db.execute(
+            select(Spool).where(
+                func.upper(Spool.tray_uuid) == tray_uuid.upper(),
+                Spool.archived_at.is_(None),
+            )
+        )
+        spool = result.scalar_one_or_none()
+        if spool:
+            return spool
+    if tag_uid:
+        result = await db.execute(
+            select(Spool).where(
+                func.upper(Spool.tag_uid) == tag_uid.upper(),
+                Spool.archived_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+    return None
+
+
+async def create_pending_assignment(
+    db: AsyncSession,
+    *,
+    tray_uuid: str | None,
+    tag_uid: str | None,
+    printer_id: int | None,
+    spool_id: int | None,
+    source: str,
+    timeout_seconds: int,
+) -> PendingSlotAssignment:
+    """Create a new pending assignment or return existing one for idempotency.
+
+    Idempotency is based on tray_uuid/tag_uid: if a pending assignment already
+    exists for the same spool identifiers, the existing one is returned.
+    """
+
+    # Build filters to match an existing pending assignment by identifiers
+    id_filters = []
+    if spool_id:
+        id_filters.append(PendingSlotAssignment.spool_id == spool_id)
+    if tray_uuid:
+        id_filters.append(func.upper(PendingSlotAssignment.tray_uuid) == tray_uuid.upper())
+    if tag_uid:
+        id_filters.append(func.upper(PendingSlotAssignment.tag_uid) == tag_uid.upper())
+
+    # Check for an existing pending assignment for the same spool
+    # to avoid assigning the same spool to multiple slots concurrently.
+    if id_filters:
+        existing_spool = await db.execute(
+            select(PendingSlotAssignment).where(
+                PendingSlotAssignment.status == "pending",
+                or_(*id_filters),
+            )
+        )
+        found_spool = existing_spool.scalar_one_or_none()
+        if found_spool:
+            return found_spool
+
+    # Resolve spool_id from tray_uuid or tag_uid
+    spool = await _resolve_spool(db, spool_id, tray_uuid, tag_uid)
+
+    assignment = PendingSlotAssignment(
+        tray_uuid=tray_uuid,
+        tag_uid=tag_uid,
+        spool_id= spool.id if spool else None,
+        printer_id=printer_id,
+        source=source,
+        status="pending",
+        timeout_seconds=timeout_seconds,
+    )
+    db.add(assignment)
+    await db.commit()
+    await db.refresh(assignment)
+
+    # Schedule timeout task
+    _schedule_timeout(assignment.id, timeout_seconds)
+
+    logger.info(
+        "Created pending slot assignment %d for spool_id=%d tray_uuid=%s tag_uid=%s printer=%s source=%s timeout=%ds",
+        assignment.id,
+        spool_id,
+        tray_uuid,
+        tag_uid,
+        printer_id,
+        source,
+        timeout_seconds,
+    )
+
+    return assignment
+
+
+def _schedule_timeout(assignment_id: int, timeout_seconds: int) -> None:
+    """Schedule an asyncio task to expire the assignment after timeout."""
+    task = asyncio.ensure_future(_expire_assignment(assignment_id, timeout_seconds))
+    _timeout_tasks[assignment_id] = task
+    task.add_done_callback(lambda _: _timeout_tasks.pop(assignment_id, None))
+
+
+async def _expire_assignment(assignment_id: int, timeout_seconds: int) -> None:
+    """Wait for timeout and then mark the assignment as timed_out."""
+    await asyncio.sleep(timeout_seconds)
+
+    from backend.app.core.database import async_session
+
+    async with async_session() as db:
+        result = await db.execute(
+            select(PendingSlotAssignment).where(
+                PendingSlotAssignment.id == assignment_id,
+                PendingSlotAssignment.status == "pending",
+            )
+        )
+        assignment = result.scalar_one_or_none()
+        if assignment:
+            assignment.status = "timed_out"
+            await db.commit()
+
+            logger.info("Pending slot assignment %d timed out", assignment_id)
+
+            # Notify clients via WebSocket
+            await ws_manager.broadcast(
+                {
+                    "type": "pending_slot_assignment_timed_out",
+                    "assignment_id": assignment_id,
+                    "tray_uuid": assignment.tray_uuid,
+                    "tag_uid": assignment.tag_uid,
+                }
+            )
+
+            # Notify via MQTT relay
+            try:
+                from backend.app.services.mqtt_relay import mqtt_relay
+
+                await mqtt_relay.on_slot_assignment_timed_out(
+                    assignment_id=assignment_id,
+                    tray_uuid=assignment.tray_uuid,
+                    tag_uid=assignment.tag_uid,
+                )
+            except Exception:
+                pass
+
+
+async def cancel_pending_assignment(db: AsyncSession, assignment_id: int) -> PendingSlotAssignment | None:
+    """Cancel a pending assignment. Returns the updated record or None if not found."""
+    result = await db.execute(
+        select(PendingSlotAssignment).where(
+            PendingSlotAssignment.id == assignment_id,
+            PendingSlotAssignment.status == "pending",
+        )
+    )
+    assignment = result.scalar_one_or_none()
+    if not assignment:
+        return None
+
+    assignment.status = "cancelled"
+    await db.commit()
+
+    # Cancel the timeout task
+    task = _timeout_tasks.pop(assignment_id, None)
+    if task and not task.done():
+        task.cancel()
+
+    logger.info("Cancelled pending slot assignment %d", assignment_id)
+
+    await ws_manager.broadcast(
+        {
+            "type": "pending_slot_assignment_cancelled",
+            "assignment_id": assignment_id,
+            "tray_uuid": assignment.tray_uuid,
+            "tag_uid": assignment.tag_uid,
+        }
+    )
+
+    return assignment
+
+
+async def get_pending_assignment(db: AsyncSession, assignment_id: int) -> PendingSlotAssignment | None:
+    """Get a pending assignment by ID."""
+    result = await db.execute(
+        select(PendingSlotAssignment).where(PendingSlotAssignment.id == assignment_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def try_complete_pending_assignments(
+    db: AsyncSession,
+    printer_id: int,
+    ams_id: int,
+    tray_id: int,
+) -> bool:
+    """Check if any pending assignment should be completed for this slot.
+
+    Called from the AMS change handler when a slot transitions from empty → filled.
+    Returns True if a pending assignment was completed.
+    """
+    # Find pending assignments that match this printer (or any printer)
+    result = await db.execute(
+        select(PendingSlotAssignment).where(
+            PendingSlotAssignment.status == "pending",
+            (
+                (PendingSlotAssignment.printer_id == printer_id)
+                | (PendingSlotAssignment.printer_id.is_(None))
+            ),
+        ).order_by(PendingSlotAssignment.created_at.asc())
+    )
+    pending_assignments = result.scalars().all()
+
+    if not pending_assignments:
+        return False
+
+    # Take the oldest pending assignment (FIFO)
+    assignment = pending_assignments[0]
+
+    # Resolve the spool if not already resolved
+    spool_id = assignment.spool_id
+    if not spool_id:
+        spool = await _resolve_spool(db, assignment.tray_uuid, assignment.tag_uid)
+        if spool:
+            spool_id = spool.id
+            assignment.spool_id = spool_id
+
+    if not spool_id:
+        logger.warning(
+            "Pending assignment %d: no inventory spool found for tray_uuid=%s tag_uid=%s, skipping",
+            assignment.id,
+            assignment.tray_uuid,
+            assignment.tag_uid,
+        )
+        return False
+
+    # Delegate the actual assignment (upsert + MQTT config + WS broadcast) to
+    # the existing assign_spool endpoint handler.
+    try:
+        from backend.app.api.routes.inventory import assign_spool
+        from backend.app.schemas.spool import SpoolAssignmentCreate
+
+        await assign_spool(
+            data=SpoolAssignmentCreate(
+                spool_id=spool_id,
+                printer_id=printer_id,
+                ams_id=ams_id,
+                tray_id=tray_id,
+            ),
+            db=db,
+            current_user=None,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to execute assign_spool for pending assignment %d (spool %d → printer %d AMS%d-T%d)",
+            assignment.id,
+            spool_id,
+            printer_id,
+            ams_id,
+            tray_id,
+        )
+        return False
+
+    # Mark the pending assignment as completed
+    now = datetime.now(timezone.utc)
+    time_to_placement = (now - assignment.created_at.replace(tzinfo=timezone.utc)).total_seconds()
+
+    assignment.status = "completed"
+    assignment.assigned_printer_id = printer_id
+    assignment.assigned_ams_id = ams_id
+    assignment.assigned_tray_id = tray_id
+    assignment.completed_at = now
+    assignment.time_to_placement = time_to_placement
+
+    await db.commit()
+
+    # Cancel timeout task
+    task = _timeout_tasks.pop(assignment.id, None)
+    if task and not task.done():
+        task.cancel()
+
+    logger.info(
+        "Completed pending slot assignment %d: spool %d → printer %d AMS%d-T%d (%.1fs)",
+        assignment.id,
+        spool_id,
+        printer_id,
+        ams_id,
+        tray_id,
+        time_to_placement,
+    )
+
+    # Notify clients via WebSocket
+    await ws_manager.broadcast(
+        {
+            "type": "pending_slot_assignment_completed",
+            "assignment_id": assignment.id,
+            "tray_uuid": assignment.tray_uuid,
+            "tag_uid": assignment.tag_uid,
+            "spool_id": spool_id,
+            "printer_id": printer_id,
+            "ams_id": ams_id,
+            "tray_id": tray_id,
+            "time_to_placement": time_to_placement,
+        }
+    )
+
+    # Notify via MQTT relay
+    try:
+        from backend.app.services.mqtt_relay import mqtt_relay
+
+        await mqtt_relay.on_slot_assignment_completed(
+            assignment_id=assignment.id,
+            tray_uuid=assignment.tray_uuid,
+            tag_uid=assignment.tag_uid,
+            spool_id=spool_id,
+            printer_id=printer_id,
+            ams_id=ams_id,
+            tray_id=tray_id,
+            time_to_placement=time_to_placement,
+        )
+    except Exception:
+        pass
+
+    return True
+
+
+async def restore_pending_timeouts() -> None:
+    """Re-schedule timeout tasks for any pending assignments on startup.
+
+    Called during application lifespan startup to resume monitoring of
+    assignments that were created before a restart.
+    """
+    from backend.app.core.database import async_session
+
+    async with async_session() as db:
+        result = await db.execute(
+            select(PendingSlotAssignment).where(PendingSlotAssignment.status == "pending")
+        )
+        pending = result.scalars().all()
+        now = datetime.now(timezone.utc)
+        for assignment in pending:
+            created = assignment.created_at.replace(tzinfo=timezone.utc)
+            elapsed = (now - created).total_seconds()
+            remaining = assignment.timeout_seconds - elapsed
+            if remaining <= 0:
+                # Already expired — mark it
+                assignment.status = "timed_out"
+            else:
+                _schedule_timeout(assignment.id, int(remaining))
+        if pending:
+            await db.commit()
+            logger.info(
+                "Restored %d pending slot assignment timeout tasks on startup",
+                len([a for a in pending if a.status == "pending"]),
+            )
+


### PR DESCRIPTION
## Description

This feature allows you to automatically load a spool into the next available AMS slot.

An allocation request is sent to the backend, specifying the reel (with its ID, tag_uid, or tray_uuid), the timing, and optionally the printer.

The backend will return an allocation ID if the spool is successfully found and will begin listening for changes in the AMS slots.

When a change occurs, it will allocate the reel to that slot and send an MQTT event.

An endpoint is available to check the allocation status and another to delete it.

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #1725 

## Documentation

<!--
If this PR changes user-visible behavior, config keys, ports, CLI flags,
URLs, or installation steps, link matching PRs in the docs repos below.
Internal refactors, bug fixes with no observable change, and test-only
changes are exempt — just check the "not required" box and say why.

See CONTRIBUTING.md → Documentation Requirements for the full rules.
-->

**Pick one**:
- [ ] Docs PR(s) linked above
- [x] No docs update required — reason:  Autodoc on swagger

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

<!-- List the specific changes made in this PR -->

- 3 new endpoints on inventory
- 2 new mqtt events

## Screenshots

<!-- If applicable, add screenshots to demonstrate your changes -->

## Testing

Several tests using differents combinations

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: X1C

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

I'm working on an Android app to manage spools. It connects to the backend and lists them. It allows you to use this allocation system simply by tapping "load" or reading an NFC tag; then you just place the spool in its position and Bambuddy automatically assigns it.

I've tried to cover various needs, such as using the ID, tag_uid, and tray_uuid so that spoolbuddy can also use them.