### PR TITLE
fix(printers): serve raw-gcode .gcode.3mf files in G-code Preview (don't 400 "Invalid 3MF file")

### DIFF
--- a/backend/app/api/routes/printers.py
+++ b/backend/app/api/routes/printers.py
@@ -1194,6 +1194,12 @@ async def get_printer_file_gcode(
                 gcode_content = zf.read(gcode_files[0])
                 return Response(content=gcode_content, media_type="text/plain")
         except zipfile.BadZipFile:
+            # Some printers store a sliced job as raw gcode under a ".gcode.3mf"
+            # name (not a real ZIP container). Detect raw gcode and serve it for
+            # the G-code Preview instead of failing the whole preview.
+            head = data[:1024].lstrip()
+            if head[:1] in (b";", b"G", b"M") or b"HEADER_BLOCK_START" in data[:2048]:
+                return Response(content=data, media_type="text/plain")
             raise HTTPException(status_code=400, detail="Invalid 3MF file")
 
     raise HTTPException(status_code=400, detail="Unsupported file type")


### PR DESCRIPTION
## Problem
`get_printer_file_gcode` (`/api/v1/printers/{id}/files/gcode`) assumes any `.gcode.3mf` is a ZIP container. Some printers (observed on P1S/P1P) store a sliced job on the SD card as **raw G-code under a `.gcode.3mf` filename** — not a real ZIP. `zipfile.ZipFile` then raises `BadZipFile`, the endpoint returns `400 "Invalid 3MF file"`, and the File Manager's **G-code Preview** dead-ends with "Failed to load file" even though the file is valid and prints fine.

## Reproduce
1. On a P1-series printer, a sliced job is saved to SD as e.g. `Plate 0.gcode.3mf`.
2. That file is plain G-code (`; HEADER_BLOCK_START` / `; BambuStudio ...`, no `PK` ZIP signature).
3. `GET /api/v1/printers/{id}/files/gcode?path=/Plate%200.gcode.3mf` -> `400 {"detail":"Invalid 3MF file"}`.

## Fix
On `BadZipFile`, sniff for raw G-code (leading `;`/`G`/`M`, or `HEADER_BLOCK_START` in the first 2 KB) and serve it as `text/plain`; otherwise keep the original error. Minimal, no behavior change for real 3MF zips.

## Scope / note
This restores the **G-code Preview** tab. The **3D Model** tab stays empty for these files by design — a sliced G-code has no mesh (expected, not part of this fix).

## Tested
Verified on a live P1-series printer running bambuddy 0.2.4.6: a raw-gcode `.gcode.3mf` on the SD that previously returned `400 "Invalid 3MF file"` from `GET .../files/gcode` now returns `200 text/plain` (~6.9 MB) with this patch, so the G-code Preview can load it. The handler is byte-identical in 0.2.4.6, 0.2.4.7, and the latest daily beta.

## Related
#1711, #1543, #1600, #1522 (related preview / `.gcode.3mf` reports on other code paths).