### PR TITLE
fix: remap filament_map_2=0 to AMS tray 0 before slicing

### DIFF
--- a/backend/app/api/routes/library.py
+++ b/backend/app/api/routes/library.py
@@ -3091,15 +3091,33 @@ def _sanitize_project_settings_sentinels(zip_bytes: bytes) -> bytes:
             if not isinstance(config, dict):
                 return zip_bytes
             removed = [key for key in _PROJECT_SETTINGS_SENTINEL_KEYS if config.get(key) == "-1"]
-            if not removed:
+            # Fix filament_map_2: value '0' means external spool, which causes ';VT H-1'
+            # in the output gcode so the printer ignores the AMS entirely. Remap any '0'
+            # to '1' (AMS tray 0); start_print()'s MQTT ams_mapping overrides the actual
+            # physical tray at runtime. Existing AMS assignments (value >= '1') are untouched.
+            filament_map_2 = config.get("filament_map_2")
+            fm2_patched_values = None
+            if isinstance(filament_map_2, list):
+                new_fm2 = ["1" if str(v) == "0" else v for v in filament_map_2]
+                if new_fm2 != filament_map_2:
+                    config["filament_map_2"] = new_fm2
+                    fm2_patched_values = new_fm2
+            if not removed and fm2_patched_values is None:
                 return zip_bytes
             for key in removed:
                 config.pop(key, None)
             patched = json.dumps(config)
-            logger.info(
-                "3MF sanitiser: removed sentinel '-1' for keys %s — slicer will use --load-settings defaults",
-                sorted(removed),
-            )
+            if removed:
+                logger.info(
+                    "3MF sanitiser: removed sentinel '-1' for keys %s — slicer will use --load-settings defaults",
+                    sorted(removed),
+                )
+            if fm2_patched_values is not None:
+                logger.info(
+                    "3MF sanitiser: patched filament_map_2 %s -> %s — AMS tray 0 instead of external spool",
+                    filament_map_2,
+                    fm2_patched_values,
+                )
             dst = BytesIO()
             with zipfile.ZipFile(dst, "w", zipfile.ZIP_DEFLATED) as zout:
                 for item in zin.infolist():


### PR DESCRIPTION
# [Bug]: Slicing MakerWorld 3MF files with external-spool project settings causes printer to ignore AMS — no filament loads

## Description

When printing 3MF files from MakerWorld (or any source) where `filament_map_2` is set to `0` (external spool) in the embedded `Metadata/project_settings.config`, the slicer CLI outputs `;VT{n} H-1` in the gcode. `H-1` is the Bambu firmware code for "use external spool." The printer starts the job and moves through all the motions but never loads filament from the AMS, so nothing extrudes.

This affects **library file slice-and-print** workflows. The print appears to run normally (the toolhead moves, timers count down) but the part comes out empty.

---

## Root Cause

Bambu Lab gcode encodes the physical AMS slot via a comment on each virtual tool assignment:

```
;VT0 H-1   ← H-1 = external spool (no AMS load)
;VT0 H0    ← H0  = AMS unit 0, tray 0
```

BambuStudio CLI derives the `H` value from `filament_map_2` in the project settings config:

| `filament_map_2` value | Meaning | Gcode H value |
|---|---|---|
| `0` | External spool | `H-1` |
| `1` | AMS tray 0 (unit 0, slot 0) | `H0` |
| `2` | AMS tray 1 (unit 0, slot 1) | `H1` |
| … | … | … |

Many MakerWorld-hosted 3MF files ship with `filament_map_2 = 0` because the original author sliced with "External spool" selected, or because the project was uploaded without AMS settings. When Bambuddy re-slices these files, it passes the project config through to the slicer CLI unchanged, so the `H-1` value propagates into the output gcode.

The MQTT `ams_mapping` array sent with the start-print command *can* override `H` at runtime, but only when Bambuddy's filament auto-matching resolves a valid tray. When no match is found (or the printer's AMS state is ambiguous at print time), the fallback is the gcode value — which is `H-1` → no load.

**Affected file:** `backend/app/api/routes/library.py` → `_sanitize_project_settings_sentinels()`

This function already reads and rewrites `Metadata/project_settings.config` to strip invalid sentinel values before slicing. It does not touch `filament_map_2`.

---

## Steps to Reproduce

1. Download any 3MF from MakerWorld that was sliced with "External spool" (many single-material models fall into this category).
2. Import it into the Bambuddy library.
3. Slice and print via Bambuddy with an AMS loaded.
4. Printer starts, toolhead moves, AMS never loads — zero extrusion.

To confirm the cause, unzip the `.gcode.3mf` output and inspect `Metadata/plate_N.gcode`:
- Look for `;VT0 H-1` — this is the symptom.
- Check `Metadata/project_settings.config` → `"filament_map_2": ["0"]` — this is the cause.

---

## Fix

In `_sanitize_project_settings_sentinels()`, after the existing sentinel-removal logic, remap any `filament_map_2` entry of `"0"` (external spool) to `"1"` (AMS tray 0). The MQTT `ams_mapping` sent by `start_print()` at print time will override the specific physical tray; this change just ensures the gcode baseline is "use AMS" rather than "use external spool."

```python
# In _sanitize_project_settings_sentinels(), replace:

removed = [key for key in _PROJECT_SETTINGS_SENTINEL_KEYS if config.get(key) == "-1"]
if not removed:
    return zip_bytes
for key in removed:
    config.pop(key, None)
patched = json.dumps(config)
logger.info(
    "3MF sanitiser: removed sentinel '-1' for keys %s — slicer will use --load-settings defaults",
    sorted(removed),
)

# With:

removed = [key for key in _PROJECT_SETTINGS_SENTINEL_KEYS if config.get(key) == "-1"]
# Fix filament_map_2: value '0' means external spool, which causes ';VT H-1'
# in the output gcode so the printer ignores the AMS entirely. Remap any '0'
# to '1' (AMS tray 0); start_print()'s MQTT ams_mapping overrides the actual
# physical tray at runtime. Existing AMS assignments (value >= '1') are untouched.
filament_map_2 = config.get("filament_map_2")
fm2_patched_values = None
if isinstance(filament_map_2, list):
    new_fm2 = ["1" if str(v) == "0" else v for v in filament_map_2]
    if new_fm2 != filament_map_2:
        config["filament_map_2"] = new_fm2
        fm2_patched_values = new_fm2
if not removed and fm2_patched_values is None:
    return zip_bytes
for key in removed:
    config.pop(key, None)
patched = json.dumps(config)
if removed:
    logger.info(
        "3MF sanitiser: removed sentinel '-1' for keys %s — slicer will use --load-settings defaults",
        sorted(removed),
    )
if fm2_patched_values is not None:
    logger.info(
        "3MF sanitiser: patched filament_map_2 %s -> %s — AMS tray 0 instead of external spool",
        filament_map_2,
        fm2_patched_values,
    )
```

This fix was tested on a H2S with a single AMS2 Pro unit. After applying it and re-slicing the same MakerWorld file, the gcode contained `;VT0 H0` and the AMS loaded correctly on print.

---

## Environment

- **Bambuddy version:** latest (Docker, `ghcr.io/maziggy/bambuddy:latest`)
- **Printer:** Bambu Lab H2S
- **AMS2 Pro:** 1 unit, 4 trays
- **Slicer API:** Not enabled (using virtual printer / built-in slicer flow)
- **OS:** Linux (self-hosted server)
