### PR TITLE
[codex] Add FlashForge Creator 5 Pro LAN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Optional but recommended — drop the [`slicer-api/` Compose stack](slicer-api/R
 - **Full automation** — Schedule prints, auto power-off, get notified when done
 - **Multi-printer support** — Manage your entire print farm from one interface
 
+### FlashForge LAN support
+
+Bambuddy includes experimental FlashForge LAN support for confirmed compatible models such as the Creator 5 Pro. It supports monitoring, camera snapshots/streaming, upload/start, pause/resume/stop, heater targets, chamber light, print speed, file listing, thumbnails, and notifications. Some Bambu-only controls are intentionally hidden when the FlashForge LAN API does not expose an equivalent command. See [docs/flashforge-local-api.md](docs/flashforge-local-api.md) for the current feature matrix and capability contract.
+
 ---
 
 ## ✨ Features

--- a/backend/app/api/routes/camera.py
+++ b/backend/app/api/routes/camera.py
@@ -28,6 +28,7 @@ from backend.app.services.camera import (
     get_camera_port,
     get_ffmpeg_path,
     is_chamber_image_model,
+    read_flashforge_mjpeg_frame,
     read_next_chamber_frame,
     rtsp_socket_timeout_flag,
     test_camera_connection,
@@ -80,6 +81,29 @@ def get_buffered_frame(printer_id: int) -> bytes | None:
     Returns the JPEG frame data if available, or None if no active stream.
     """
     return _last_frames.get(printer_id)
+
+
+def _format_mjpeg_frame(frame: bytes) -> bytes:
+    return (
+        b"--frame\r\n"
+        b"Content-Type: image/jpeg\r\n"
+        b"Content-Length: " + str(len(frame)).encode() + b"\r\n"
+        b"\r\n" + frame + b"\r\n"
+    )
+
+
+async def _generate_flashforge_polling_stream(printer_id: int, ip_address: str, fps: int) -> AsyncGenerator[bytes, None]:
+    """Generate a browser-friendly MJPEG stream from FlashForge's flaky stream endpoint."""
+    import time
+
+    frame_interval = 1.0 / max(fps, 1)
+    while True:
+        frame = await read_flashforge_mjpeg_frame(ip_address, timeout=8.0)
+        if frame:
+            _last_frames[printer_id] = frame
+            _last_frame_times[printer_id] = time.time()
+            yield _format_mjpeg_frame(frame)
+        await asyncio.sleep(frame_interval)
 
 
 def is_stream_active(printer_id: int) -> bool:
@@ -633,17 +657,13 @@ async def camera_stream(
     if is_flashforge_model(printer.model):
         import time
 
-        from backend.app.services.external_camera import generate_mjpeg_stream
-
-        fps = min(max(fps, 1), 15)
-        stream_url = f"http://{printer.ip_address}:8080/?action=stream"
+        fps = min(max(fps, 1), 2)
         _stream_start_times[printer_id] = time.time()
         _active_external_streams.add(printer_id)
 
         async def flashforge_stream_wrapper():
             try:
-                async for frame in generate_mjpeg_stream(stream_url, "mjpeg", fps):
-                    _last_frame_times[printer_id] = time.time()
+                async for frame in _generate_flashforge_polling_stream(printer_id, printer.ip_address, fps):
                     yield frame
             finally:
                 _active_external_streams.discard(printer_id)
@@ -888,10 +908,7 @@ async def camera_snapshot(
     printer = await get_printer_or_404(printer_id, db)
 
     if is_flashforge_model(printer.model):
-        from backend.app.services.external_camera import capture_frame
-
-        stream_url = f"http://{printer.ip_address}:8080/?action=stream"
-        frame_data = await capture_frame(stream_url, "mjpeg", timeout=15)
+        frame_data = await read_flashforge_mjpeg_frame(printer.ip_address, timeout=15.0)
         if not frame_data:
             raise HTTPException(
                 status_code=503,

--- a/backend/app/api/routes/camera.py
+++ b/backend/app/api/routes/camera.py
@@ -39,6 +39,7 @@ from backend.app.services.camera_fanout import (
     shutdown_broadcaster,
 )
 from backend.app.services.camera_profiles import get_camera_profile
+from backend.app.services.flashforge_local import is_flashforge_model
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/printers", tags=["camera"])
@@ -629,6 +630,35 @@ async def camera_stream(
     """
     printer = await get_printer_or_404(printer_id, db)
 
+    if is_flashforge_model(printer.model):
+        import time
+
+        from backend.app.services.external_camera import generate_mjpeg_stream
+
+        fps = min(max(fps, 1), 15)
+        stream_url = f"http://{printer.ip_address}:8080/?action=stream"
+        _stream_start_times[printer_id] = time.time()
+        _active_external_streams.add(printer_id)
+
+        async def flashforge_stream_wrapper():
+            try:
+                async for frame in generate_mjpeg_stream(stream_url, "mjpeg", fps):
+                    _last_frame_times[printer_id] = time.time()
+                    yield frame
+            finally:
+                _active_external_streams.discard(printer_id)
+                logger.info("FlashForge camera stream ended for printer %s", printer_id)
+
+        return StreamingResponse(
+            flashforge_stream_wrapper(),
+            media_type="multipart/x-mixed-replace; boundary=frame",
+            headers={
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma": "no-cache",
+                "Expires": "0",
+            },
+        )
+
     # Check for external camera first
     if printer.external_camera_enabled and printer.external_camera_url:
         import time
@@ -856,6 +886,25 @@ async def camera_snapshot(
     from pathlib import Path
 
     printer = await get_printer_or_404(printer_id, db)
+
+    if is_flashforge_model(printer.model):
+        from backend.app.services.external_camera import capture_frame
+
+        stream_url = f"http://{printer.ip_address}:8080/?action=stream"
+        frame_data = await capture_frame(stream_url, "mjpeg", timeout=15)
+        if not frame_data:
+            raise HTTPException(
+                status_code=503,
+                detail="Failed to capture frame from FlashForge camera.",
+            )
+        return Response(
+            content=frame_data,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Content-Disposition": f'inline; filename="snapshot_{printer_id}.jpg"',
+            },
+        )
 
     # Check for external camera first
     if printer.external_camera_enabled and printer.external_camera_url:

--- a/backend/app/api/routes/printers.py
+++ b/backend/app/api/routes/printers.py
@@ -88,6 +88,7 @@ async def create_printer(
         ip_address=printer_data.ip_address,
         serial_number=printer_data.serial_number,
         access_code=printer_data.access_code,
+        model=printer_data.model,
     )
     if not test_result.get("success"):
         # The frontend renders the user-facing message via i18n on `code`;

--- a/backend/app/api/routes/printers.py
+++ b/backend/app/api/routes/printers.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 import zipfile
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
@@ -25,6 +26,7 @@ from backend.app.schemas.printer import (
     HMSErrorResponse,
     NozzleInfoResponse,
     NozzleRackSlot,
+    PrinterCapabilities,
     PrinterCreate,
     PrinterDiagnosticResult,
     PrinterResponse,
@@ -41,7 +43,11 @@ from backend.app.services.bambu_ftp import (
     get_storage_info_async,
     list_files_async,
 )
-from backend.app.services.flashforge_local import is_flashforge_model
+from backend.app.services.flashforge_local import (
+    get_flashforge_current_thumbnail,
+    get_flashforge_gcode_thumbnail,
+    is_flashforge_model,
+)
 from backend.app.services.printer_diagnostic import run_connection_diagnostic
 from backend.app.services.printer_manager import (
     get_derived_status_name,
@@ -54,6 +60,40 @@ from backend.app.utils.http import build_content_disposition
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/printers", tags=["printers"])
+
+
+def _printer_capabilities(model: str | None) -> PrinterCapabilities:
+    if is_flashforge_model(model):
+        local_api_gap = "FlashForge's known LAN API does not expose this Bambu control."
+        file_gap = "FlashForge's known LAN API exposes file listing/upload, but not direct file download, delete, preview, or directory browsing."
+        return PrinterCapabilities(
+            can_chamber_light=True,
+            can_print_speed=True,
+            can_set_temperature=True,
+            can_airduct_mode=False,
+            can_bed_jog=False,
+            can_home_axes=False,
+            can_skip_objects=False,
+            can_dry_filament=False,
+            can_calibrate=False,
+            can_download_files=False,
+            can_delete_files=False,
+            can_preview_files=False,
+            can_browse_files=False,
+            unsupported_reasons={
+                "can_airduct_mode": local_api_gap,
+                "can_bed_jog": local_api_gap,
+                "can_home_axes": local_api_gap,
+                "can_skip_objects": local_api_gap,
+                "can_dry_filament": local_api_gap,
+                "can_calibrate": local_api_gap,
+                "can_download_files": file_gap,
+                "can_delete_files": file_gap,
+                "can_preview_files": file_gap,
+                "can_browse_files": file_gap,
+            },
+        )
+    return PrinterCapabilities()
 
 
 @router.get("/", response_model=list[PrinterResponse])
@@ -399,16 +439,17 @@ async def get_printer_status(
             id=printer_id,
             name=printer.name,
             connected=False,
+            capabilities=_printer_capabilities(printer.model),
         )
 
     # Determine cover URL if there's an active print (including paused)
     cover_url = None
-    if state.state in ("RUNNING", "PAUSE") and state.gcode_file and not is_flashforge_model(printer.model):
+    if state.state in ("RUNNING", "PAUSE") and state.gcode_file:
         cover_url = f"/api/v1/printers/{printer_id}/cover"
 
     # Convert HMS errors to response format
     hms_errors = [
-        HMSErrorResponse(code=e.code, attr=e.attr, module=e.module, severity=e.severity)
+        HMSErrorResponse(code=e.code, attr=e.attr, module=e.module, severity=e.severity, message=e.message)
         for e in (state.hms_errors or [])
     ]
 
@@ -679,6 +720,7 @@ async def get_printer_status(
         developer_mode=state.developer_mode if state else None,
         awaiting_plate_clear=printer_manager.is_awaiting_plate_clear(printer_id),
         supports_drying=supports_drying(printer.model, state.firmware_version),
+        capabilities=_printer_capabilities(printer.model),
         current_archive_id=current_archive_id,
         current_plate_id=current_plate_id,
         fila_switch=(
@@ -871,6 +913,23 @@ async def get_printer_cover(
     subtask_name = state.subtask_name
     if not subtask_name:
         raise HTTPException(404, f"No subtask_name in printer state (state={state.state})")
+
+    if is_flashforge_model(printer.model):
+        cache_key = (subtask_name, view or "default")
+        if printer_id in _cover_cache and cache_key in _cover_cache[printer_id]:
+            return Response(content=_cover_cache[printer_id][cache_key], media_type="image/png")
+        image = await asyncio.to_thread(
+            get_flashforge_current_thumbnail,
+            printer.ip_address,
+            printer.serial_number or "",
+            printer.access_code,
+            state.gcode_file or subtask_name,
+        )
+        if not image:
+            raise HTTPException(404, f"No cover available for '{subtask_name}'")
+        image_data, media_type = image
+        _cover_cache.setdefault(printer_id, {})[cache_key] = image_data
+        return Response(content=image_data, media_type=media_type)
 
     # Resolve the active plate. Precedence (#1166):
     #   1. The plate Bambuddy dispatched (authoritative when we sent the print)
@@ -1109,15 +1168,41 @@ async def list_printer_files(
     if not printer:
         raise HTTPException(404, "Printer not found")
 
-    files = await list_files_async(printer.ip_address, printer.access_code, path, printer_model=printer.model)
+    files = await list_files_async(
+        printer.ip_address,
+        printer.access_code,
+        path,
+        printer_model=printer.model,
+        serial_number=printer.serial_number,
+    )
 
     # Add full path to each file
     for f in files:
         f["path"] = f"{path.rstrip('/')}/{f['name']}" if path != "/" else f"/{f['name']}"
+        if is_flashforge_model(printer.model) and not f.get("is_directory"):
+            f["thumbnail_url"] = f"/api/v1/printers/{printer_id}/files/thumbnail?path={quote(f['path'])}"
+
+    if is_flashforge_model(printer.model):
+        capabilities = {
+            "can_download": False,
+            "can_delete": False,
+            "can_preview": False,
+            "can_browse_directories": False,
+            "unsupported_reason": "FlashForge's known LAN API exposes file listing/upload, but not direct file download, delete, preview, or directory browsing.",
+        }
+    else:
+        capabilities = {
+            "can_download": True,
+            "can_delete": True,
+            "can_preview": True,
+            "can_browse_directories": True,
+            "unsupported_reason": None,
+        }
 
     return {
         "path": path,
         "files": files,
+        "capabilities": capabilities,
     }
 
 
@@ -1134,7 +1219,16 @@ async def download_printer_file(
     if not printer:
         raise HTTPException(404, "Printer not found")
 
-    data = await download_file_bytes_async(printer.ip_address, printer.access_code, path, printer_model=printer.model)
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose file downloads")
+
+    data = await download_file_bytes_async(
+        printer.ip_address,
+        printer.access_code,
+        path,
+        printer_model=printer.model,
+        serial_number=printer.serial_number,
+    )
     if data is None:
         raise HTTPException(404, f"File not found: {path}")
 
@@ -1178,7 +1272,16 @@ async def get_printer_file_gcode(
     if not printer:
         raise HTTPException(404, "Printer not found")
 
-    data = await download_file_bytes_async(printer.ip_address, printer.access_code, path, printer_model=printer.model)
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose G-code downloads")
+
+    data = await download_file_bytes_async(
+        printer.ip_address,
+        printer.access_code,
+        path,
+        printer_model=printer.model,
+        serial_number=printer.serial_number,
+    )
     if data is None:
         raise HTTPException(404, f"File not found: {path}")
 
@@ -1201,6 +1304,35 @@ async def get_printer_file_gcode(
     raise HTTPException(status_code=400, detail="Unsupported file type")
 
 
+@router.get("/{printer_id}/files/thumbnail")
+async def get_printer_file_thumbnail(
+    printer_id: int,
+    path: str = Query(..., description="Full path to the printer-stored file"),
+    _=RequirePermissionIfAuthEnabled(Permission.PRINTERS_FILES),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a lightweight thumbnail for a printer-stored file when the printer exposes one."""
+    result = await db.execute(select(Printer).where(Printer.id == printer_id))
+    printer = result.scalar_one_or_none()
+    if not printer:
+        raise HTTPException(404, "Printer not found")
+
+    if not is_flashforge_model(printer.model):
+        raise HTTPException(501, "This printer does not expose generic file thumbnails")
+
+    image = await asyncio.to_thread(
+        get_flashforge_gcode_thumbnail,
+        printer.ip_address,
+        printer.serial_number or "",
+        printer.access_code,
+        path,
+    )
+    if not image:
+        raise HTTPException(404, f"No thumbnail available for: {path}")
+    image_data, media_type = image
+    return Response(content=image_data, media_type=media_type)
+
+
 @router.get("/{printer_id}/files/plates")
 async def get_printer_file_plates(
     printer_id: int,
@@ -1220,6 +1352,9 @@ async def get_printer_file_plates(
     if not printer:
         raise HTTPException(404, "Printer not found")
 
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose 3MF plate metadata downloads")
+
     filename = path.split("/")[-1]
     if not filename.lower().endswith(".3mf"):
         return {
@@ -1230,7 +1365,13 @@ async def get_printer_file_plates(
             "is_multi_plate": False,
         }
 
-    data = await download_file_bytes_async(printer.ip_address, printer.access_code, path, printer_model=printer.model)
+    data = await download_file_bytes_async(
+        printer.ip_address,
+        printer.access_code,
+        path,
+        printer_model=printer.model,
+        serial_number=printer.serial_number,
+    )
     if data is None:
         raise HTTPException(404, f"File not found: {path}")
 
@@ -1461,7 +1602,16 @@ async def get_printer_file_plate_thumbnail(
     if not printer:
         raise HTTPException(404, "Printer not found")
 
-    data = await download_file_bytes_async(printer.ip_address, printer.access_code, path, printer_model=printer.model)
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose 3MF plate thumbnails")
+
+    data = await download_file_bytes_async(
+        printer.ip_address,
+        printer.access_code,
+        path,
+        printer_model=printer.model,
+        serial_number=printer.serial_number,
+    )
     if data is None:
         raise HTTPException(404, f"File not found: {path}")
 
@@ -1496,13 +1646,20 @@ async def download_printer_files_as_zip(
     if not printer:
         raise HTTPException(404, "Printer not found")
 
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose file downloads")
+
     # Create ZIP in memory
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
         for path in paths:
             try:
                 data = await download_file_bytes_async(
-                    printer.ip_address, printer.access_code, path, printer_model=printer.model
+                    printer.ip_address,
+                    printer.access_code,
+                    path,
+                    printer_model=printer.model,
+                    serial_number=printer.serial_number,
                 )
                 if data:
                     filename = path.split("/")[-1]
@@ -1539,7 +1696,16 @@ async def delete_printer_file(
 
     from backend.app.services.bambu_ftp import DeleteResult
 
-    result = await delete_file_async(printer.ip_address, printer.access_code, path, printer_model=printer.model)
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose file deletion")
+
+    result = await delete_file_async(
+        printer.ip_address,
+        printer.access_code,
+        path,
+        printer_model=printer.model,
+        serial_number=printer.serial_number,
+    )
     if result == DeleteResult.NOT_FOUND:
         raise HTTPException(404, f"File not found on printer: {path}")
     if result == DeleteResult.FAILED:
@@ -1560,7 +1726,12 @@ async def get_printer_storage(
     if not printer:
         raise HTTPException(404, "Printer not found")
 
-    storage_info = await get_storage_info_async(printer.ip_address, printer.access_code, printer_model=printer.model)
+    storage_info = await get_storage_info_async(
+        printer.ip_address,
+        printer.access_code,
+        printer_model=printer.model,
+        serial_number=printer.serial_number,
+    )
 
     return storage_info or {"used_bytes": None, "free_bytes": None}
 
@@ -1672,6 +1843,8 @@ async def start_drying(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose filament drying control")
 
     # Server-side guard: reject if this model/firmware doesn't support drying
     live_state = printer_manager.get_status(printer_id)
@@ -1747,6 +1920,8 @@ async def stop_drying(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose filament drying control")
 
     success = printer_manager.send_drying_command(printer_id, ams_id, temp=0, duration=0, mode=0)
     if not success:
@@ -1782,6 +1957,8 @@ async def set_print_option(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose AI print option control")
 
     client = printer_manager.get_client(printer_id)
     if not client or not client.state.connected:
@@ -1857,6 +2034,8 @@ async def start_calibration(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose calibration control")
 
     client = printer_manager.get_client(printer_id)
     if not client or not client.state.connected:
@@ -2775,6 +2954,8 @@ async def set_airduct_mode(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose airduct mode control")
 
     client = printer_manager.get_client(printer_id)
     if not client:
@@ -2807,8 +2988,58 @@ async def set_chamber_light(
     success = client.set_chamber_light(on)
     if not success:
         raise HTTPException(500, "Failed to control chamber light")
+    if hasattr(client, "state") and client.state:
+        client.state.chamber_light = on
 
     return {"success": True, "message": f"Chamber light {'on' if on else 'off'}"}
+
+
+@router.post("/{printer_id}/temperature")
+async def set_temperature(
+    printer_id: int,
+    heater: str = Query(..., description="Heater to control: nozzle, bed, or chamber"),
+    target: int = Query(..., description="Target temperature in °C. Use 0 to turn the heater off."),
+    _=RequirePermissionIfAuthEnabled(Permission.PRINTERS_CONTROL),
+    db: AsyncSession = Depends(get_db),
+):
+    """Set a heater target temperature on printers with a supported local API."""
+    heater = heater.lower()
+    limits = {
+        "nozzle": (0, 280),
+        "bed": (0, 120),
+        "chamber": (0, 70),
+    }
+    if heater not in limits:
+        raise HTTPException(400, "heater must be 'nozzle', 'bed', or 'chamber'")
+    min_temp, max_temp = limits[heater]
+    if target < min_temp or target > max_temp:
+        raise HTTPException(400, f"{heater} target must be between {min_temp}°C and {max_temp}°C")
+
+    result = await db.execute(select(Printer).where(Printer.id == printer_id))
+    printer = result.scalar_one_or_none()
+    if not printer:
+        raise HTTPException(404, "Printer not found")
+    if not is_flashforge_model(printer.model):
+        raise HTTPException(501, "Temperature control is only implemented for FlashForge local API printers")
+
+    client = printer_manager.get_client(printer_id)
+    if not client:
+        raise HTTPException(400, "Printer not connected")
+    if not hasattr(client, "set_temperature"):
+        raise HTTPException(501, "This printer client does not expose temperature control")
+
+    success = client.set_temperature(heater, target)
+    if not success:
+        raise HTTPException(500, f"Failed to set {heater} temperature")
+    if hasattr(client, "state") and client.state:
+        temps = dict(client.state.temperatures or {})
+        target_key = f"{heater}_target"
+        temps[target_key] = target
+        current = temps.get(heater, 0)
+        temps[f"{heater}_heating"] = target > current + 1
+        client.state.temperatures = temps
+
+    return {"success": True, "message": f"{heater.title()} target set to {target}°C"}
 
 
 @router.post("/{printer_id}/bed-jog")
@@ -2850,6 +3081,8 @@ async def bed_jog(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose Z jog control")
 
     client = printer_manager.get_client(printer_id)
     if not client:
@@ -2905,6 +3138,8 @@ async def home_axes(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose homing control")
 
     client = printer_manager.get_client(printer_id)
     if not client:
@@ -2958,6 +3193,8 @@ async def get_printable_objects(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose object skipping")
 
     client = printer_manager.get_client(printer_id)
     if not client:
@@ -3066,6 +3303,8 @@ async def skip_objects(
     printer = result.scalar_one_or_none()
     if not printer:
         raise HTTPException(404, "Printer not found")
+    if is_flashforge_model(printer.model):
+        raise HTTPException(501, "FlashForge local API does not expose object skipping")
 
     client = printer_manager.get_client(printer_id)
     if not client:

--- a/backend/app/api/routes/printers.py
+++ b/backend/app/api/routes/printers.py
@@ -41,6 +41,7 @@ from backend.app.services.bambu_ftp import (
     get_storage_info_async,
     list_files_async,
 )
+from backend.app.services.flashforge_local import is_flashforge_model
 from backend.app.services.printer_diagnostic import run_connection_diagnostic
 from backend.app.services.printer_manager import (
     get_derived_status_name,
@@ -402,7 +403,7 @@ async def get_printer_status(
 
     # Determine cover URL if there's an active print (including paused)
     cover_url = None
-    if state.state in ("RUNNING", "PAUSE") and state.gcode_file:
+    if state.state in ("RUNNING", "PAUSE") and state.gcode_file and not is_flashforge_model(printer.model):
         cover_url = f"/api/v1/printers/{printer_id}/cover"
 
     # Convert HMS errors to response format

--- a/backend/app/schemas/printer.py
+++ b/backend/app/schemas/printer.py
@@ -140,6 +140,7 @@ class HMSErrorResponse(BaseModel):
     attr: int = 0  # Attribute value for constructing wiki URL
     module: int
     severity: int  # 1=fatal, 2=serious, 3=common, 4=info
+    message: str | None = None
 
 
 class AMSTray(BaseModel):
@@ -241,6 +242,30 @@ class PrintOptionsResponse(BaseModel):
     filament_tangle_detect: bool = False
 
 
+class PrinterCapabilities(BaseModel):
+    can_pause: bool = True
+    can_resume: bool = True
+    can_stop: bool = True
+    can_clear_errors: bool = True
+    can_chamber_light: bool = True
+    can_print_speed: bool = True
+    can_set_temperature: bool = False
+    can_airduct_mode: bool = True
+    can_bed_jog: bool = True
+    can_home_axes: bool = True
+    can_skip_objects: bool = True
+    can_dry_filament: bool = True
+    can_calibrate: bool = True
+    can_upload_files: bool = True
+    can_list_files: bool = True
+    can_download_files: bool = True
+    can_delete_files: bool = True
+    can_preview_files: bool = True
+    can_browse_files: bool = True
+    can_stream_camera: bool = True
+    unsupported_reasons: dict[str, str] = Field(default_factory=dict)
+
+
 class PrinterStatus(BaseModel):
     id: int
     name: str
@@ -316,6 +341,7 @@ class PrinterStatus(BaseModel):
     awaiting_plate_clear: bool = False
     # AMS drying support
     supports_drying: bool = False
+    capabilities: PrinterCapabilities = Field(default_factory=PrinterCapabilities)
     # Linked archive for the active print (resolved via subtask_id). Frontend uses
     # this to fetch plate metadata and show the plate name when the source 3MF is
     # multi-plate (#881 follow-up).

--- a/backend/app/services/background_dispatch.py
+++ b/backend/app/services/background_dispatch.py
@@ -573,6 +573,7 @@ class BackgroundDispatchService:
             printer_ip = printer.ip_address
             printer_access_code = printer.access_code
             printer_model = printer.model
+            printer_serial_number = printer.serial_number
             archive_filename = archive.filename
 
             if not printer_manager.is_connected(job.printer_id):
@@ -635,6 +636,7 @@ class BackgroundDispatchService:
                         progress_callback=upload_progress_callback,
                         socket_timeout=ftp_timeout,
                         printer_model=printer_model,
+                        serial_number=printer_serial_number,
                         max_retries=ftp_retry_count,
                         retry_delay=ftp_retry_delay,
                         operation_name=f"Upload for reprint to {printer_name}",
@@ -649,6 +651,7 @@ class BackgroundDispatchService:
                         progress_callback=upload_progress_callback,
                         socket_timeout=ftp_timeout,
                         printer_model=printer_model,
+                        serial_number=printer_serial_number,
                     )
 
                 if uploaded:
@@ -770,6 +773,7 @@ class BackgroundDispatchService:
             printer_ip = printer.ip_address
             printer_access_code = printer.access_code
             printer_model = printer.model
+            printer_serial_number = printer.serial_number
             library_filename = lib_file.filename
 
             if not printer_manager.is_connected(job.printer_id):
@@ -842,6 +846,7 @@ class BackgroundDispatchService:
                         progress_callback=upload_progress_callback,
                         socket_timeout=ftp_timeout,
                         printer_model=printer_model,
+                        serial_number=printer_serial_number,
                         max_retries=ftp_retry_count,
                         retry_delay=ftp_retry_delay,
                         operation_name=f"Upload for print to {printer_name}",
@@ -856,6 +861,7 @@ class BackgroundDispatchService:
                         progress_callback=upload_progress_callback,
                         socket_timeout=ftp_timeout,
                         printer_model=printer_model,
+                        serial_number=printer_serial_number,
                     )
 
                 if uploaded:

--- a/backend/app/services/bambu_ftp.py
+++ b/backend/app/services/bambu_ftp.py
@@ -841,6 +841,17 @@ async def download_file_async(
         printer_model: Printer model for A1-specific workarounds
     """
     loop = asyncio.get_event_loop()
+
+    from backend.app.services.flashforge_local import is_flashforge_model
+
+    if is_flashforge_model(printer_model):
+        logger.info(
+            "FlashForge file download is not supported by the known local API for %s (%s)",
+            ip_address,
+            remote_path,
+        )
+        return False
+
     is_a1 = printer_model in BambuFTPClient.A1_MODELS if printer_model else False
 
     # Per-attempt completion state: asyncio.wait_for cannot cancel
@@ -947,6 +958,12 @@ async def download_file_try_paths_async(
     """
     loop = asyncio.get_event_loop()
 
+    from backend.app.services.flashforge_local import is_flashforge_model
+
+    if is_flashforge_model(printer_model):
+        logger.info("FlashForge multi-path file download is not supported for %s", ip_address)
+        return False
+
     def _download():
         client = BambuFTPClient(ip_address, access_code, timeout=socket_timeout, printer_model=printer_model)
         if not client.connect():
@@ -978,6 +995,7 @@ async def upload_file_async(
     progress_callback: Callable[[int, int], None] | None = None,
     socket_timeout: float | None = None,
     printer_model: str | None = None,
+    serial_number: str | None = None,
 ) -> bool:
     """Async wrapper for uploading a file with timeout and progress callback.
 
@@ -993,8 +1011,32 @@ async def upload_file_async(
         progress_callback: Optional callback for progress updates
         socket_timeout: FTP socket timeout for slow connections (e.g., A1 printers)
         printer_model: Printer model for A1-specific workarounds
+        serial_number: Printer serial number for FlashForge local HTTP uploads
     """
     loop = asyncio.get_event_loop()
+
+    from backend.app.services.flashforge_local import is_flashforge_model, upload_flashforge_file
+
+    if is_flashforge_model(printer_model):
+        try:
+            return await asyncio.wait_for(
+                loop.run_in_executor(
+                    None,
+                    lambda: upload_flashforge_file(
+                        ip_address,
+                        serial_number or "",
+                        access_code,
+                        local_path,
+                        remote_path,
+                        progress_callback=progress_callback,
+                    ),
+                ),
+                timeout=timeout,
+            )
+        except TimeoutError:
+            logger.warning("FlashForge upload timed out after %ss for %s", timeout, remote_path)
+            return False
+
     is_a1 = printer_model in BambuFTPClient.A1_MODELS if printer_model else False
 
     def _upload(force_prot_c: bool = False) -> bool:
@@ -1054,6 +1096,7 @@ async def list_files_async(
     timeout: float = 30.0,
     socket_timeout: float | None = None,
     printer_model: str | None = None,
+    serial_number: str | None = None,
 ) -> list[dict]:
     """Async wrapper for listing files with timeout.
 
@@ -1062,6 +1105,21 @@ async def list_files_async(
         printer_model: Printer model for A1-specific workarounds
     """
     loop = asyncio.get_event_loop()
+
+    from backend.app.services.flashforge_local import is_flashforge_model, list_flashforge_files
+
+    if is_flashforge_model(printer_model):
+        try:
+            return await asyncio.wait_for(
+                loop.run_in_executor(
+                    None,
+                    lambda: list_flashforge_files(ip_address, serial_number or "", access_code, path),
+                ),
+                timeout=timeout,
+            )
+        except TimeoutError:
+            logger.warning("FlashForge list_files timed out after %ss for %s", timeout, path)
+            return []
 
     def _list():
         client = BambuFTPClient(ip_address, access_code, timeout=socket_timeout, printer_model=printer_model)
@@ -1085,6 +1143,7 @@ async def delete_file_async(
     remote_path: str,
     socket_timeout: float | None = None,
     printer_model: str | None = None,
+    serial_number: str | None = None,
 ) -> DeleteResult:
     """Async wrapper for deleting a file.
 
@@ -1097,6 +1156,16 @@ async def delete_file_async(
         printer_model: Printer model for A1-specific workarounds
     """
     loop = asyncio.get_event_loop()
+
+    from backend.app.services.flashforge_local import is_flashforge_model
+
+    if is_flashforge_model(printer_model):
+        logger.info(
+            "FlashForge file deletion is not supported by the known local API for %s (%s)",
+            ip_address,
+            remote_path,
+        )
+        return DeleteResult.FAILED
 
     def _delete() -> DeleteResult:
         client = BambuFTPClient(ip_address, access_code, timeout=socket_timeout, printer_model=printer_model)
@@ -1116,6 +1185,7 @@ async def download_file_bytes_async(
     remote_path: str,
     socket_timeout: float | None = None,
     printer_model: str | None = None,
+    serial_number: str | None = None,
 ) -> bytes | None:
     """Async wrapper for downloading file as bytes.
 
@@ -1124,6 +1194,16 @@ async def download_file_bytes_async(
         printer_model: Printer model for A1-specific workarounds
     """
     loop = asyncio.get_event_loop()
+
+    from backend.app.services.flashforge_local import is_flashforge_model
+
+    if is_flashforge_model(printer_model):
+        logger.info(
+            "FlashForge file download is not supported by the known local API for %s (%s)",
+            ip_address,
+            remote_path,
+        )
+        return None
 
     def _download():
         client = BambuFTPClient(ip_address, access_code, timeout=socket_timeout, printer_model=printer_model)
@@ -1142,6 +1222,7 @@ async def get_storage_info_async(
     access_code: str,
     socket_timeout: float | None = None,
     printer_model: str | None = None,
+    serial_number: str | None = None,
 ) -> dict | None:
     """Async wrapper for getting storage info.
 
@@ -1150,6 +1231,21 @@ async def get_storage_info_async(
         printer_model: Printer model for A1-specific workarounds
     """
     loop = asyncio.get_event_loop()
+
+    from backend.app.services.flashforge_local import get_flashforge_storage_info, is_flashforge_model
+
+    if is_flashforge_model(printer_model):
+        try:
+            return await asyncio.wait_for(
+                loop.run_in_executor(
+                    None,
+                    lambda: get_flashforge_storage_info(ip_address, serial_number or "", access_code),
+                ),
+                timeout=10,
+            )
+        except TimeoutError:
+            logger.warning("FlashForge storage info timed out for %s", ip_address)
+            return None
 
     def _get_storage():
         client = BambuFTPClient(ip_address, access_code, timeout=socket_timeout, printer_model=printer_model)

--- a/backend/app/services/camera.py
+++ b/backend/app/services/camera.py
@@ -12,9 +12,12 @@ import shutil
 import ssl
 import struct
 import subprocess
+import urllib.request
 import uuid
 from datetime import datetime
 from pathlib import Path
+
+from backend.app.services.flashforge_local import is_flashforge_model
 
 logger = logging.getLogger(__name__)
 
@@ -304,6 +307,35 @@ def is_chamber_image_model(model: str | None) -> bool:
     return not supports_rtsp(model)
 
 
+def _read_flashforge_mjpeg_frame_sync(ip_address: str, timeout: float) -> bytes | None:
+    """Read a single JPEG frame from FlashForge's local MJPEG endpoint."""
+    url = f"http://{ip_address}:8080/?action=stream"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            buffer = b""
+            while True:
+                chunk = response.read(8192)
+                if not chunk:
+                    return None
+                buffer += chunk
+
+                start = buffer.find(JPEG_START)
+                end = buffer.find(JPEG_END, start + 2) if start != -1 else -1
+                if start != -1 and end != -1:
+                    return buffer[start : end + 2]
+
+                if len(buffer) > 2_000_000:
+                    buffer = buffer[-1_000_000:]
+    except Exception as exc:
+        logger.warning("FlashForge MJPEG frame capture failed from %s: %s", url, exc)
+        return None
+
+
+async def read_flashforge_mjpeg_frame(ip_address: str, timeout: float = 15.0) -> bytes | None:
+    """Read a single JPEG frame from FlashForge's local MJPEG endpoint."""
+    return await asyncio.to_thread(_read_flashforge_mjpeg_frame_sync, ip_address, timeout)
+
+
 def build_camera_url(ip_address: str, access_code: str, model: str | None) -> str:
     """Build the RTSPS URL for the printer camera (RTSP models only)."""
     port = get_camera_port(model)
@@ -547,6 +579,10 @@ async def capture_camera_frame_bytes(
     Returns:
         JPEG bytes if capture was successful, None otherwise
     """
+    if is_flashforge_model(model):
+        logger.info("Capturing camera frame bytes from %s using FlashForge MJPEG (model: %s)", ip_address, model)
+        return await read_flashforge_mjpeg_frame(ip_address, timeout=float(timeout))
+
     # Chamber image models: A1/P1 - returns bytes directly
     if is_chamber_image_model(model):
         logger.info("Capturing camera frame bytes from %s using chamber image protocol (model: %s)", ip_address, model)

--- a/backend/app/services/camera_diagnose.py
+++ b/backend/app/services/camera_diagnose.py
@@ -15,15 +15,17 @@ Stages
 
 1. **tcp_reachable** — open a TCP socket to the camera port (322 for
    RTSPS models, 6000 for the chamber-image-protocol A1 / P1 family).
+   FlashForge LAN printers use their local MJPEG camera port (8080).
    Distinguishes "printer down" / "firewall" / "LAN-only off" from
    stream-content problems.
 2. **first_frame** — call the existing ``capture_camera_frame_bytes``
    pipeline (same code that powers /camera/snapshot) and verify at
    least one JPEG comes back within the model's profile-derived
-   timeout. Combines auth + protocol handshake + first keyframe into
-   one stage because splitting RTSP's ``ffmpeg`` invocation is heavy
-   and the user-facing answer is the same either way: "the camera
-   itself isn't producing frames".
+   timeout. FlashForge uses the local MJPEG reader for this stage.
+   Combines auth + protocol handshake + first keyframe into one stage
+   because splitting RTSP's ``ffmpeg`` invocation is heavy and the
+   user-facing answer is the same either way: "the camera itself isn't
+   producing frames".
 
 Shortcut
 --------
@@ -48,8 +50,10 @@ from backend.app.services.camera import (
     capture_camera_frame_bytes,
     get_camera_port,
     is_chamber_image_model,
+    read_flashforge_mjpeg_frame,
 )
 from backend.app.services.camera_profiles import DEFAULT_PROFILE, get_camera_profile
+from backend.app.services.flashforge_local import is_flashforge_model
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +81,7 @@ class CameraDiagnoseStage:
 @dataclass
 class CameraDiagnoseResult:
     printer_id: int
-    protocol: str  # "rtsp" | "chamber_image"
+    protocol: str  # "rtsp" | "chamber_image" | "flashforge_mjpeg"
     port: int
     # Whether this model's camera path uses the default profile or has
     # an override entry in ``camera_profiles._PROFILES``. Useful for
@@ -199,6 +203,33 @@ async def _check_first_frame(
     )
 
 
+async def _check_flashforge_first_frame(ip_address: str, timeout: int) -> CameraDiagnoseStage:
+    """Stage 2 for FlashForge — capture one frame from the local MJPEG endpoint."""
+    started = time.monotonic()
+    try:
+        jpeg = await read_flashforge_mjpeg_frame(ip_address=ip_address, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 — preserve Bambu diagnostic behavior
+        logger.warning("FlashForge camera diagnose first-frame capture raised: %s", exc)
+        return CameraDiagnoseStage(
+            name="first_frame",
+            status="failed",
+            duration_ms=int((time.monotonic() - started) * 1000),
+            code="capture_exception",
+        )
+    if jpeg:
+        return CameraDiagnoseStage(
+            name="first_frame",
+            status="ok",
+            duration_ms=int((time.monotonic() - started) * 1000),
+        )
+    return CameraDiagnoseStage(
+        name="first_frame",
+        status="failed",
+        duration_ms=int((time.monotonic() - started) * 1000),
+        code="no_frame",
+    )
+
+
 def _summary_for_stages(stages: list[CameraDiagnoseStage]) -> str:
     """Pick the remediation key from the first failing stage's ``code``,
     or ``all_ok`` when every stage passed."""
@@ -237,9 +268,10 @@ async def diagnose_camera(
     a ``live_stream_active`` stage and ``all_ok`` summary — real-world
     proof of a working camera beats any synthetic test.
     """
-    is_chamber = is_chamber_image_model(model)
-    protocol = "chamber_image" if is_chamber else "rtsp"
-    port = get_camera_port(model)
+    is_flashforge = is_flashforge_model(model)
+    is_chamber = False if is_flashforge else is_chamber_image_model(model)
+    protocol = "flashforge_mjpeg" if is_flashforge else "chamber_image" if is_chamber else "rtsp"
+    port = 8080 if is_flashforge else get_camera_port(model)
 
     result = CameraDiagnoseResult(
         printer_id=printer_id,
@@ -274,13 +306,18 @@ async def diagnose_camera(
     result.stages.append(tcp_stage)
     if tcp_stage.status != "ok":
         result.overall_status = "failed"
-        # Skip first_frame — without TCP there's no point spawning ffmpeg.
+        # Skip first_frame — without TCP there's no point spawning ffmpeg
+        # or polling the FlashForge MJPEG endpoint.
         result.stages.append(CameraDiagnoseStage(name="first_frame", status="skipped", duration_ms=0))
         result.summary_code = _summary_for_stages(result.stages)
         return result
 
     # Stage 2
-    frame_stage = await _check_first_frame(ip_address, access_code, model, capture_timeout)
+    frame_stage = (
+        await _check_flashforge_first_frame(ip_address, capture_timeout)
+        if is_flashforge
+        else await _check_first_frame(ip_address, access_code, model, capture_timeout)
+    )
     result.stages.append(frame_stage)
     if frame_stage.status != "ok":
         result.overall_status = "failed"

--- a/backend/app/services/flashforge_local.py
+++ b/backend/app/services/flashforge_local.py
@@ -1,0 +1,305 @@
+"""FlashForge local API monitoring client.
+
+This is intentionally monitoring-first. It maps the FlashForge HTTP `/detail`
+response onto Bambuddy's existing PrinterState shape so the dashboard,
+WebSocket updates, and notification plumbing can observe non-Bambu printers
+without enabling print dispatch or control paths yet.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from backend.app.services.bambu_mqtt import PrinterState
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FLASHFORGE_PORT = 8898
+FLASHFORGE_POLL_INTERVAL_SECONDS = 10.0
+FLASHFORGE_STALE_AFTER_SECONDS = 45.0
+
+
+def is_flashforge_model(model: str | None) -> bool:
+    """Return True when a printer model should use the FlashForge local API."""
+    if not model:
+        return False
+    normalized = model.strip().upper()
+    return "FLASHFORGE" in normalized or "CREATOR 5 PRO" in normalized
+
+
+def _first_number(values: Any, default: float = 0.0) -> float:
+    if isinstance(values, list) and values:
+        return _number(values[0], default)
+    return _number(values, default)
+
+
+def _max_number(values: Any, default: float = 0.0) -> float:
+    if not isinstance(values, list) or not values:
+        return _number(values, default)
+    parsed = [_number(value, default) for value in values]
+    return max(parsed) if parsed else default
+
+
+def _number(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None or value == "":
+            return default
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_state(status: Any) -> str:
+    """Map FlashForge status strings onto Bambuddy's broad state buckets."""
+    raw = str(status or "").strip().lower()
+    if raw in {"building", "printing", "print", "running"}:
+        return "RUNNING"
+    if raw in {"pause", "paused", "pausing"}:
+        return "PAUSE"
+    if raw in {"finish", "finished", "complete", "completed", "done"}:
+        return "FINISH"
+    if raw in {"error", "failed", "failure", "fault"}:
+        return "FAILED"
+    if raw in {"ready", "idle", "standby", "completed"}:
+        return "IDLE"
+    if raw in {"loading", "heating", "preheating", "preparing"}:
+        return "PREPARE"
+    return raw.upper() if raw else "unknown"
+
+
+def _slot_to_tray(slot: dict[str, Any], index: int) -> dict[str, Any]:
+    color = str(slot.get("materialColor") or slot.get("color") or "808080").replace("#", "")
+    if len(color) == 6:
+        color = f"{color}FF"
+    return {
+        "id": index,
+        "tray_color": color,
+        "tray_type": slot.get("materialName") or slot.get("materialType") or slot.get("type") or "",
+        "tray_sub_brands": "",
+        "tray_id_name": "",
+        "tray_info_idx": "",
+        "remain": 0,
+        "state": 10 if slot.get("hasFilament", bool(slot)) else 9,
+    }
+
+
+@dataclass
+class FlashForgeLocalClient:
+    """Small polling client for FlashForge's LAN-only HTTP API."""
+
+    ip_address: str
+    serial_number: str
+    access_code: str
+    model: str | None = None
+    on_state_change: Callable[[PrinterState], None] | None = None
+    on_print_start: Callable[[dict], None] | None = None
+    on_print_complete: Callable[[dict], None] | None = None
+
+    def __post_init__(self) -> None:
+        self.state = PrinterState(connected=False, state="unknown")
+        self.logging_enabled = False
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._last_seen = 0.0
+        self._last_state = "unknown"
+
+    def connect(self) -> None:
+        """Start polling the printer."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._poll_loop,
+            name=f"flashforge-{self.serial_number}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def disconnect(self, timeout: float = 0) -> None:
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=timeout or 2.0)
+        self.state.connected = False
+
+    def check_staleness(self) -> bool:
+        if self._last_seen and time.time() - self._last_seen > FLASHFORGE_STALE_AFTER_SECONDS:
+            self.state.connected = False
+        return self.state.connected
+
+    def request_status_update(self) -> bool:
+        detail = self._fetch_detail()
+        if detail is None:
+            return False
+        self._apply_detail(detail)
+        return True
+
+    def start_print(self, *args: Any, **kwargs: Any) -> bool:
+        logger.warning("FlashForge start_print is not implemented yet")
+        return False
+
+    def stop_print(self) -> bool:
+        logger.warning("FlashForge stop_print is not implemented yet")
+        return False
+
+    def pause_print(self) -> bool:
+        logger.warning("FlashForge pause_print is not implemented yet")
+        return False
+
+    def resume_print(self) -> bool:
+        logger.warning("FlashForge resume_print is not implemented yet")
+        return False
+
+    def clear_hms_errors(self) -> bool:
+        return False
+
+    def enable_logging(self, enabled: bool = True) -> None:
+        self.logging_enabled = enabled
+
+    def get_logs(self) -> list:
+        return []
+
+    def clear_logs(self) -> None:
+        return None
+
+    def _poll_loop(self) -> None:
+        while not self._stop_event.is_set():
+            detail = self._fetch_detail()
+            if detail is not None:
+                self._apply_detail(detail)
+            else:
+                self.check_staleness()
+                if self.on_state_change:
+                    self.on_state_change(self.state)
+            self._stop_event.wait(FLASHFORGE_POLL_INTERVAL_SECONDS)
+
+    def _fetch_detail(self) -> dict[str, Any] | None:
+        body = json.dumps(
+            {"serialNumber": self.serial_number, "checkCode": self.access_code}
+        ).encode()
+        request = Request(
+            f"http://{self.ip_address}:{DEFAULT_FLASHFORGE_PORT}/detail",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode())
+        except (OSError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+            logger.debug("FlashForge detail request failed for %s: %s", self.ip_address, exc)
+            return None
+        if payload.get("code") != 0:
+            logger.warning("FlashForge detail request returned non-zero code for %s: %s", self.ip_address, payload)
+            return None
+        detail = payload.get("detail")
+        return detail if isinstance(detail, dict) else None
+
+    def _apply_detail(self, detail: dict[str, Any]) -> None:
+        now = time.time()
+        raw_status = detail.get("status")
+        mapped_state = _normalize_state(raw_status)
+        previous_state = self.state.state
+
+        self.state.connected = True
+        self.state.state = mapped_state
+        self.state.current_print = (
+            detail.get("printFileName")
+            or detail.get("currentPrintFile")
+            or detail.get("fileName")
+        )
+        self.state.subtask_name = self.state.current_print
+        self.state.gcode_file = self.state.current_print
+        progress = _number(detail.get("printProgress", detail.get("progress")), 0.0)
+        self.state.progress = progress * 100 if 0 <= progress <= 1 else progress
+        self.state.remaining_time = _int(detail.get("estimatedTime", detail.get("remainingTime")), 0)
+        self.state.layer_num = _int(detail.get("printLayer", detail.get("currentLayer")), 0)
+        self.state.total_layers = _int(detail.get("targetPrintLayer", detail.get("totalLayer")), 0)
+        self.state.firmware_version = str(detail.get("firmwareVersion") or "")
+        self.state.ipcam = bool(detail.get("camera") or detail.get("cameraStreamUrl"))
+        self.state.cooling_fan_speed = _int(detail.get("coolingFanSpeed"), 0)
+        self.state.big_fan2_speed = _int(detail.get("chamberFanSpeed"), 0)
+        self.state.chamber_light = str(detail.get("lightStatus") or "").lower() == "open"
+        self.state.door_open = str(detail.get("doorStatus") or "").lower() == "open"
+        self.state.raw_data = {
+            **detail,
+            "device_model": detail.get("model") or self.model or "FlashForge",
+            "vendor": "flashforge",
+        }
+
+        nozzle_temp = _max_number(detail.get("nozzleTemps"), _number(detail.get("nozzleTemp"), 0.0))
+        nozzle_target = _max_number(
+            detail.get("nozzleTargetTemps"),
+            _number(detail.get("nozzleTargetTemp"), 0.0),
+        )
+        bed_temp = _number(detail.get("platTemp"), _number(detail.get("bedTemp"), 0.0))
+        bed_target = _number(detail.get("platTargetTemp"), _number(detail.get("bedTargetTemp"), 0.0))
+        chamber_temp = _number(detail.get("chamberTemp"), 0.0)
+
+        self.state.temperatures = {
+            "nozzle": nozzle_temp,
+            "nozzle_target": nozzle_target,
+            "bed": bed_temp,
+            "bed_target": bed_target,
+            "chamber": chamber_temp,
+        }
+
+        station = detail.get("matlStationInfo") if isinstance(detail.get("matlStationInfo"), dict) else {}
+        slots = station.get("slotInfos") if isinstance(station.get("slotInfos"), list) else []
+        if slots:
+            self.state.raw_data["ams"] = [
+                {
+                    "id": 0,
+                    "tray": [_slot_to_tray(slot, idx) for idx, slot in enumerate(slots)],
+                    "sn": "",
+                    "module_type": "flashforge_ifs",
+                }
+            ]
+        else:
+            self.state.raw_data["ams"] = []
+
+        self._last_seen = now
+        if previous_state != mapped_state:
+            if self.on_print_start and mapped_state == "RUNNING" and previous_state not in {"RUNNING", "PAUSE"}:
+                self.on_print_start({"filename": self.state.gcode_file})
+            if self.on_print_complete and mapped_state in {"FINISH", "FAILED"} and previous_state in {"RUNNING", "PAUSE"}:
+                self.on_print_complete(
+                    {
+                        "filename": self.state.gcode_file,
+                        "status": "completed" if mapped_state == "FINISH" else "failed",
+                    }
+                )
+            if self.on_state_change:
+                self.on_state_change(self.state)
+        elif self.on_state_change:
+            self.on_state_change(self.state)
+
+
+async def probe_flashforge_connection(ip_address: str, serial_number: str, access_code: str) -> dict:
+    """Probe a FlashForge printer once using the LAN HTTP API."""
+    client = FlashForgeLocalClient(ip_address, serial_number, access_code)
+    detail = await asyncio.to_thread(client._fetch_detail)
+    if detail is None:
+        return {"success": False, "state": None, "model": None}
+    return {
+        "success": True,
+        "state": _normalize_state(detail.get("status")),
+        "model": detail.get("model") or detail.get("name") or "FlashForge",
+    }

--- a/backend/app/services/flashforge_local.py
+++ b/backend/app/services/flashforge_local.py
@@ -1,31 +1,41 @@
-"""FlashForge local API monitoring client.
-
-This is intentionally monitoring-first. It maps the FlashForge HTTP `/detail`
-response onto Bambuddy's existing PrinterState shape so the dashboard,
-WebSocket updates, and notification plumbing can observe non-Bambu printers
-without enabling print dispatch or control paths yet.
-"""
+"""FlashForge local API client."""
 
 from __future__ import annotations
 
+import asyncio
+import base64
 import json
 import logging
+import math
 import threading
 import time
-import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
-from backend.app.services.bambu_mqtt import PrinterState
+import httpx
+
+from backend.app.services.bambu_mqtt import HMSError, PrinterState
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_FLASHFORGE_PORT = 8898
 FLASHFORGE_POLL_INTERVAL_SECONDS = 10.0
 FLASHFORGE_STALE_AFTER_SECONDS = 45.0
+FLASHFORGE_JOB_CONTROL_CMD = "jobCtl_cmd"
+FLASHFORGE_STATE_CONTROL_CMD = "stateCtrl_cmd"
+FLASHFORGE_LIGHT_CONTROL_CMD = "lightControl_cmd"
+FLASHFORGE_PRINTER_CONTROL_CMD = "printerCtl_cmd"
+FLASHFORGE_TEMPERATURE_CONTROL_CMD = "temperatureCtl_cmd"
+FLASHFORGE_SPEED_MODE_TO_PERCENT = {
+    1: 50,
+    2: 100,
+    3: 124,
+    4: 166,
+}
 
 
 def is_flashforge_model(model: str | None) -> bool:
@@ -33,7 +43,8 @@ def is_flashforge_model(model: str | None) -> bool:
     if not model:
         return False
     normalized = model.strip().upper()
-    return "FLASHFORGE" in normalized or "CREATOR 5 PRO" in normalized
+    compact = "".join(normalized.split())
+    return "CREATOR5PRO" in compact
 
 
 def _first_number(values: Any, default: float = 0.0) -> float:
@@ -65,6 +76,121 @@ def _int(value: Any, default: int = 0) -> int:
         return int(float(value))
     except (TypeError, ValueError):
         return default
+
+
+def _seconds_to_minutes(value: Any, default: int = 0) -> int:
+    seconds = _number(value, 0.0)
+    if seconds <= 0:
+        return default
+    return max(1, int(math.ceil(seconds / 60)))
+
+
+def _remaining_minutes(detail: dict[str, Any], mapped_state: str) -> int:
+    """Return remaining print time in Bambuddy minutes from FlashForge detail data.
+
+    FlashForge reports `estimatedTime` as the total job estimate, while
+    Bambuddy expects `remaining_time` to be minutes left. Some firmware builds
+    also expose a `remainingTime` field that can be wildly stale, so prefer
+    values derived from total estimate, elapsed duration, and progress when
+    those are available.
+    """
+    if mapped_state == "FINISH":
+        return 0
+
+    candidates: list[float] = []
+    estimated_seconds = _number(detail.get("estimatedTime"), 0.0)
+    duration_seconds = _number(detail.get("printDuration"), 0.0)
+
+    if mapped_state in {"RUNNING", "PAUSE"} and estimated_seconds > 0 and duration_seconds > 0:
+        seconds_left = estimated_seconds - duration_seconds
+        if seconds_left > 0:
+            candidates.append(seconds_left)
+        else:
+            return 0
+
+    progress = _number(detail.get("printProgress", detail.get("progress")), 0.0)
+    if 0 < progress <= 1:
+        progress *= 100
+    if mapped_state in {"RUNNING", "PAUSE"} and duration_seconds > 0 and 0 < progress < 100:
+        progress_left = duration_seconds * ((100 - progress) / progress)
+        if progress_left > 0:
+            candidates.append(progress_left)
+
+    remaining = _number(detail.get("remainingTime"), 0.0)
+    if remaining > 0:
+        if not candidates:
+            candidates.append(remaining)
+        else:
+            # Treat explicit remaining time as advisory. The FlashForge field
+            # can be a stale/overflowed value; only trust it when it is in the
+            # same rough range as the derived estimates.
+            nearest = min(candidates)
+            if remaining <= nearest * 1.5:
+                candidates.append(remaining)
+
+    if candidates:
+        return _seconds_to_minutes(min(candidates), 0)
+
+    return _seconds_to_minutes(estimated_seconds, 0)
+
+
+def _speed_percent_to_level(value: Any) -> int:
+    percent = _number(value, 100.0)
+    if percent <= 75:
+        return 1
+    if percent < 112:
+        return 2
+    if percent < 145:
+        return 3
+    return 4
+
+
+def _success_code(value: Any) -> bool:
+    return _int(value, -1) in {0, 200}
+
+
+def _remote_filename(filename: Any) -> str:
+    name = Path(str(filename or "")).name.strip()
+    return name or "bambuddy-print.gcode.3mf"
+
+
+def _path_is_flashforge_root(path: str | None) -> bool:
+    normalized = str(path or "/").strip()
+    return normalized in {"", "/", ".", "/cache", "cache"}
+
+
+def _decode_base64_image(value: Any) -> bytes | None:
+    if not value:
+        return None
+    try:
+        return base64.b64decode(str(value), validate=True)
+    except (ValueError, TypeError):
+        return None
+
+
+def _image_media_type(data: bytes) -> str:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(b"BM"):
+        return "image/bmp"
+    return "application/octet-stream"
+
+
+def _firmware_at_least(version: str | None, minimum: tuple[int, int, int]) -> bool:
+    try:
+        parts = [int(part) for part in str(version or "").split(".")[:3]]
+    except ValueError:
+        return False
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3]) >= minimum
+
+
+def _material_mappings_header(material_mappings: Any = None) -> str:
+    mappings = material_mappings if isinstance(material_mappings, list) else []
+    return base64.b64encode(json.dumps(mappings, separators=(",", ":")).encode()).decode()
 
 
 def _normalize_state(status: Any) -> str:
@@ -101,6 +227,63 @@ def _slot_to_tray(slot: dict[str, Any], index: int) -> dict[str, Any]:
     }
 
 
+def _active_tray_index(station: dict[str, Any], slots: list[dict[str, Any]]) -> int | None:
+    raw_slot = _int(station.get("currentSlot"), -1)
+    if raw_slot < 0:
+        return None
+    for index, slot in enumerate(slots):
+        if _int(slot.get("slotId"), -999) == raw_slot:
+            return index
+    if 0 <= raw_slot < len(slots):
+        return raw_slot
+    return None
+
+
+def _gcode_entry_to_file(entry: Any) -> dict[str, Any] | None:
+    if isinstance(entry, str):
+        name = _remote_filename(entry)
+        return {
+            "name": name,
+            "is_directory": False,
+            "size": 0,
+            "mtime": None,
+        }
+    if not isinstance(entry, dict):
+        return None
+    name = (
+        entry.get("gcodeFileName")
+        or entry.get("fileName")
+        or entry.get("name")
+        or entry.get("filename")
+    )
+    if not name:
+        return None
+    seconds = _int(entry.get("printingTime") or entry.get("printTime") or entry.get("estimatedTime"), 0)
+    weight = _number(entry.get("totalFilamentWeight") or entry.get("filamentWeight"), 0.0)
+    return {
+        "name": _remote_filename(name),
+        "is_directory": False,
+        "size": _int(entry.get("fileSize") or entry.get("size"), 0),
+        "mtime": entry.get("modifyTime") or entry.get("modifiedTime") or entry.get("time"),
+        "printing_time": seconds or None,
+        "filament_weight": weight or None,
+        "use_matl_station": bool(entry.get("useMatlStation")),
+    }
+
+
+def _hms_errors_to_dicts(errors: list[HMSError]) -> list[dict[str, Any]]:
+    return [
+        {
+            "code": error.code,
+            "attr": error.attr,
+            "module": error.module,
+            "severity": error.severity,
+            "message": error.message,
+        }
+        for error in errors
+    ]
+
+
 @dataclass
 class FlashForgeLocalClient:
     """Small polling client for FlashForge's LAN-only HTTP API."""
@@ -120,6 +303,7 @@ class FlashForgeLocalClient:
         self._thread: threading.Thread | None = None
         self._last_seen = 0.0
         self._last_state = "unknown"
+        self._has_seen_state = False
 
     def connect(self) -> None:
         """Start polling the printer."""
@@ -152,23 +336,61 @@ class FlashForgeLocalClient:
         return True
 
     def start_print(self, *args: Any, **kwargs: Any) -> bool:
-        logger.warning("FlashForge start_print is not implemented yet")
-        return False
+        filename = _remote_filename(args[0] if args else kwargs.get("filename"))
+        detail = self._fetch_detail() or {}
+        payload: dict[str, Any] = {
+            "serialNumber": self.serial_number,
+            "checkCode": self.access_code,
+            "fileName": filename,
+            "levelingBeforePrint": bool(kwargs.get("bed_levelling", True)),
+        }
+        if _firmware_at_least(str(detail.get("firmwareVersion") or ""), (3, 1, 3)):
+            payload.update(
+                {
+                    "flowCalibration": bool(kwargs.get("flow_cali", False)),
+                    "useMatlStation": bool(kwargs.get("use_ams", True)),
+                    "gcodeToolCnt": _int(kwargs.get("gcode_tool_count"), 0),
+                    "materialMappings": kwargs.get("material_mappings")
+                    if isinstance(kwargs.get("material_mappings"), list)
+                    else [],
+                }
+            )
+        response = self._post_json("printGcode", payload, timeout=15)
+        return bool(response and _success_code(response.get("code")))
 
     def stop_print(self) -> bool:
-        logger.warning("FlashForge stop_print is not implemented yet")
-        return False
+        return self._send_job_control("cancel")
 
     def pause_print(self) -> bool:
-        logger.warning("FlashForge pause_print is not implemented yet")
-        return False
+        return self._send_job_control("pause")
 
     def resume_print(self) -> bool:
-        logger.warning("FlashForge resume_print is not implemented yet")
-        return False
+        return self._send_job_control("continue")
 
     def clear_hms_errors(self) -> bool:
-        return False
+        return self._send_control_command(FLASHFORGE_STATE_CONTROL_CMD, {"action": "setClearPlatform"})
+
+    def set_chamber_light(self, on: bool) -> bool:
+        return self._send_control_command(FLASHFORGE_LIGHT_CONTROL_CMD, {"status": "open" if on else "close"})
+
+    def set_print_speed(self, mode: int) -> bool:
+        percent = FLASHFORGE_SPEED_MODE_TO_PERCENT.get(mode)
+        if percent is None:
+            logger.warning("Invalid FlashForge print speed mode for %s: %s", self.ip_address, mode)
+            return False
+        return self._send_control_command(FLASHFORGE_PRINTER_CONTROL_CMD, {"speed": percent})
+
+    def set_temperature(self, heater: str, target: int) -> bool:
+        if heater == "nozzle":
+            args = {"nozzle": target}
+        elif heater == "bed":
+            args = {"platform": target}
+        elif heater == "chamber":
+            args = {"chamber": target}
+        else:
+            logger.warning("Invalid FlashForge heater for %s: %s", self.ip_address, heater)
+            return False
+        return self._send_control_command(FLASHFORGE_TEMPERATURE_CONTROL_CMD, args)
 
     def enable_logging(self, enabled: bool = True) -> None:
         self.logging_enabled = enabled
@@ -191,57 +413,105 @@ class FlashForgeLocalClient:
             self._stop_event.wait(FLASHFORGE_POLL_INTERVAL_SECONDS)
 
     def _fetch_detail(self) -> dict[str, Any] | None:
-        body = json.dumps(
-            {"serialNumber": self.serial_number, "checkCode": self.access_code}
-        ).encode()
+        payload = self._post_json(
+            "detail",
+            {"serialNumber": self.serial_number, "checkCode": self.access_code},
+            timeout=5,
+        )
+        if not payload:
+            return None
+        if not _success_code(payload.get("code")):
+            logger.warning("FlashForge detail request returned non-zero code for %s: %s", self.ip_address, payload)
+            return None
+        detail = payload.get("detail")
+        return detail if isinstance(detail, dict) else None
+
+    def _post_json(self, path: str, payload: dict[str, Any], timeout: float = 5) -> dict[str, Any] | None:
+        body = json.dumps(payload).encode()
         request = Request(
-            f"http://{self.ip_address}:{DEFAULT_FLASHFORGE_PORT}/detail",
+            f"http://{self.ip_address}:{DEFAULT_FLASHFORGE_PORT}/{path.lstrip('/')}",
             data=body,
             headers={"Content-Type": "application/json"},
             method="POST",
         )
         try:
-            with urlopen(request, timeout=5) as response:
-                payload = json.loads(response.read().decode())
+            with urlopen(request, timeout=timeout) as response:
+                return json.loads(response.read().decode())
         except (OSError, URLError, TimeoutError, json.JSONDecodeError) as exc:
-            logger.debug("FlashForge detail request failed for %s: %s", self.ip_address, exc)
+            logger.debug("FlashForge %s request failed for %s: %s", path, self.ip_address, exc)
             return None
-        if payload.get("code") != 0:
-            logger.warning("FlashForge detail request returned non-zero code for %s: %s", self.ip_address, payload)
-            return None
-        detail = payload.get("detail")
-        return detail if isinstance(detail, dict) else None
+
+    def _send_control_command(self, command: str, args: dict[str, Any]) -> bool:
+        response = self._post_json(
+            "control",
+            {
+                "serialNumber": self.serial_number,
+                "checkCode": self.access_code,
+                "payload": {"cmd": command, "args": args},
+            },
+            timeout=15,
+        )
+        return bool(response and _success_code(response.get("code")))
+
+    def _send_job_control(self, action: str) -> bool:
+        return self._send_control_command(FLASHFORGE_JOB_CONTROL_CMD, {"jobID": "", "action": action})
+
+    def _event_payload(self, status: str | None = None) -> dict[str, Any]:
+        return {
+            "filename": self.state.gcode_file,
+            "subtask_name": self.state.subtask_name,
+            "status": status,
+            "remaining_time": self.state.remaining_time * 60 if self.state.remaining_time else None,
+            "progress": self.state.progress,
+            "last_progress": self.state.progress,
+            "last_layer_num": self.state.layer_num,
+            "layer_num": self.state.layer_num,
+            "total_layers": self.state.total_layers,
+            "raw_data": self.state.raw_data,
+            "hms_errors": _hms_errors_to_dicts(self.state.hms_errors or []),
+        }
 
     def _apply_detail(self, detail: dict[str, Any]) -> None:
         now = time.time()
         raw_status = detail.get("status")
         mapped_state = _normalize_state(raw_status)
         previous_state = self.state.state
+        previous_print = self.state.current_print or self.state.gcode_file or self.state.subtask_name
 
         self.state.connected = True
         self.state.state = mapped_state
-        self.state.current_print = (
+        current_print = (
             detail.get("printFileName")
             or detail.get("currentPrintFile")
             or detail.get("fileName")
         )
+        if not current_print and mapped_state in {"FINISH", "FAILED"}:
+            current_print = previous_print
+        self.state.current_print = current_print
         self.state.subtask_name = self.state.current_print
         self.state.gcode_file = self.state.current_print
         progress = _number(detail.get("printProgress", detail.get("progress")), 0.0)
         self.state.progress = progress * 100 if 0 <= progress <= 1 else progress
-        self.state.remaining_time = _int(detail.get("estimatedTime", detail.get("remainingTime")), 0)
+        if mapped_state == "FINISH":
+            self.state.progress = max(self.state.progress, 100.0)
+        self.state.remaining_time = _remaining_minutes(detail, mapped_state)
         self.state.layer_num = _int(detail.get("printLayer", detail.get("currentLayer")), 0)
         self.state.total_layers = _int(detail.get("targetPrintLayer", detail.get("totalLayer")), 0)
         self.state.firmware_version = str(detail.get("firmwareVersion") or "")
         self.state.ipcam = bool(detail.get("camera") or detail.get("cameraStreamUrl"))
         self.state.cooling_fan_speed = _int(detail.get("coolingFanSpeed"), 0)
+        self.state.big_fan1_speed = _int(detail.get("leftFanSpeed"), _int(detail.get("airFanSpeed"), 0))
         self.state.big_fan2_speed = _int(detail.get("chamberFanSpeed"), 0)
+        self.state.speed_level = _speed_percent_to_level(detail.get("printSpeedAdjust"))
         self.state.chamber_light = str(detail.get("lightStatus") or "").lower() == "open"
         self.state.door_open = str(detail.get("doorStatus") or "").lower() == "open"
+        self.state.sdcard = True
         self.state.raw_data = {
             **detail,
             "device_model": detail.get("model") or self.model or "FlashForge",
             "vendor": "flashforge",
+            "estimated_time_seconds": _int(detail.get("estimatedTime", detail.get("remainingTime")), 0),
+            "print_duration_seconds": _int(detail.get("printDuration"), 0),
         }
 
         nozzle_temp = _max_number(detail.get("nozzleTemps"), _number(detail.get("nozzleTemp"), 0.0))
@@ -252,13 +522,18 @@ class FlashForgeLocalClient:
         bed_temp = _number(detail.get("platTemp"), _number(detail.get("bedTemp"), 0.0))
         bed_target = _number(detail.get("platTargetTemp"), _number(detail.get("bedTargetTemp"), 0.0))
         chamber_temp = _number(detail.get("chamberTemp"), 0.0)
+        chamber_target = _number(detail.get("chamberTargetTemp"), 0.0)
 
         self.state.temperatures = {
             "nozzle": nozzle_temp,
             "nozzle_target": nozzle_target,
+            "nozzle_heating": nozzle_target > nozzle_temp + 1,
             "bed": bed_temp,
             "bed_target": bed_target,
+            "bed_heating": bed_target > bed_temp + 1,
             "chamber": chamber_temp,
+            "chamber_target": chamber_target,
+            "chamber_heating": chamber_target > chamber_temp + 1,
         }
 
         station = detail.get("matlStationInfo") if isinstance(detail.get("matlStationInfo"), dict) else {}
@@ -272,24 +547,51 @@ class FlashForgeLocalClient:
                     "module_type": "flashforge_ifs",
                 }
             ]
+            current_slot = _active_tray_index(station, slots)
+            if current_slot is not None:
+                self.state.tray_now = current_slot
+                self.state.last_loaded_tray = current_slot
         else:
             self.state.raw_data["ams"] = []
 
+        error_code = detail.get("errorCode")
+        if error_code in (None, "", 0, "0", "OK", "ok"):
+            self.state.hms_errors = []
+        else:
+            code = str(error_code)
+            attr = _int(error_code, 0)
+            self.state.hms_errors = [
+                HMSError(
+                    code=code,
+                    attr=attr,
+                    module=0,
+                    severity=2,
+                    message=str(detail.get("errorMessage") or detail.get("errorStatus") or code),
+                )
+            ]
+
         self._last_seen = now
         if previous_state != mapped_state:
-            if self.on_print_start and mapped_state == "RUNNING" and previous_state not in {"RUNNING", "PAUSE"}:
-                self.on_print_start({"filename": self.state.gcode_file})
-            if self.on_print_complete and mapped_state in {"FINISH", "FAILED"} and previous_state in {"RUNNING", "PAUSE"}:
-                self.on_print_complete(
-                    {
-                        "filename": self.state.gcode_file,
-                        "status": "completed" if mapped_state == "FINISH" else "failed",
-                    }
-                )
+            can_emit_transition = self._has_seen_state
+            if (
+                can_emit_transition
+                and self.on_print_start
+                and mapped_state == "RUNNING"
+                and previous_state not in {"RUNNING", "PAUSE"}
+            ):
+                self.on_print_start(self._event_payload())
+            if (
+                can_emit_transition
+                and self.on_print_complete
+                and mapped_state in {"FINISH", "FAILED"}
+                and previous_state in {"RUNNING", "PAUSE"}
+            ):
+                self.on_print_complete(self._event_payload("completed" if mapped_state == "FINISH" else "failed"))
             if self.on_state_change:
                 self.on_state_change(self.state)
         elif self.on_state_change:
             self.on_state_change(self.state)
+        self._has_seen_state = True
 
 
 async def probe_flashforge_connection(ip_address: str, serial_number: str, access_code: str) -> dict:
@@ -303,3 +605,160 @@ async def probe_flashforge_connection(ip_address: str, serial_number: str, acces
         "state": _normalize_state(detail.get("status")),
         "model": detail.get("model") or detail.get("name") or "FlashForge",
     }
+
+
+def list_flashforge_files(
+    ip_address: str,
+    serial_number: str,
+    access_code: str,
+    path: str = "/",
+) -> list[dict]:
+    """List recent/local G-code files exposed by the FlashForge LAN API."""
+    if not serial_number or not _path_is_flashforge_root(path):
+        return []
+    client = FlashForgeLocalClient(ip_address, serial_number, access_code)
+    response = client._post_json(
+        "gcodeList",
+        {"serialNumber": serial_number, "checkCode": access_code},
+        timeout=10,
+    )
+    if not response or not _success_code(response.get("code")):
+        return []
+    entries = response.get("gcodeListDetail")
+    if not isinstance(entries, list):
+        entries = response.get("gcodeList")
+    if not isinstance(entries, list):
+        return []
+    files = []
+    seen = set()
+    for entry in entries:
+        file_info = _gcode_entry_to_file(entry)
+        if not file_info or file_info["name"] in seen:
+            continue
+        seen.add(file_info["name"])
+        files.append(file_info)
+    return files
+
+
+def get_flashforge_gcode_thumbnail(
+    ip_address: str,
+    serial_number: str,
+    access_code: str,
+    filename: str,
+) -> tuple[bytes, str] | None:
+    """Fetch a thumbnail for a stored FlashForge G-code/3MF file."""
+    if not serial_number:
+        return None
+    remote_name = _remote_filename(filename)
+    client = FlashForgeLocalClient(ip_address, serial_number, access_code)
+    response = client._post_json(
+        "gcodeThumb",
+        {
+            "serialNumber": serial_number,
+            "checkCode": access_code,
+            "fileName": remote_name,
+        },
+        timeout=10,
+    )
+    image = _decode_base64_image((response or {}).get("imageData"))
+    if image:
+        return image, _image_media_type(image)
+    return None
+
+
+def get_flashforge_current_thumbnail(
+    ip_address: str,
+    serial_number: str,
+    access_code: str,
+    filename: str | None = None,
+) -> tuple[bytes, str] | None:
+    """Fetch the current print thumbnail, falling back to the printer's getThum endpoint."""
+    if filename:
+        image = get_flashforge_gcode_thumbnail(ip_address, serial_number, access_code, filename)
+        if image:
+            return image
+    try:
+        with urlopen(f"http://{ip_address}:{DEFAULT_FLASHFORGE_PORT}/getThum", timeout=10) as response:
+            data = response.read()
+    except (OSError, URLError, TimeoutError) as exc:
+        logger.debug("FlashForge current thumbnail request failed for %s: %s", ip_address, exc)
+        return None
+    if not data:
+        return None
+    return data, _image_media_type(data)
+
+
+def get_flashforge_storage_info(ip_address: str, serial_number: str, access_code: str) -> dict | None:
+    """Return storage information from FlashForge detail data when available."""
+    if not serial_number:
+        return None
+    client = FlashForgeLocalClient(ip_address, serial_number, access_code)
+    detail = client._fetch_detail()
+    if not detail:
+        return None
+    free_gb = _number(detail.get("remainingDiskSpace"), 0.0)
+    if free_gb <= 0:
+        return {"used_bytes": None, "free_bytes": None}
+    return {"used_bytes": None, "free_bytes": int(free_gb * 1024 * 1024 * 1024)}
+
+
+def upload_flashforge_file(
+    ip_address: str,
+    serial_number: str,
+    access_code: str,
+    local_path: Path,
+    remote_path: str,
+    *,
+    print_now: bool = False,
+    bed_levelling: bool = True,
+    timelapse: bool = False,
+    use_ams: bool = True,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> bool:
+    """Upload a 3MF/G-code file through FlashForge's local HTTP API."""
+    path = Path(local_path)
+    if not serial_number:
+        logger.error("FlashForge upload requires a serial number for %s", ip_address)
+        return False
+    if not path.exists():
+        logger.error("FlashForge upload source does not exist: %s", path)
+        return False
+
+    file_size = path.stat().st_size
+    filename = _remote_filename(remote_path)
+    headers = {
+        "serialNumber": serial_number,
+        "checkCode": access_code,
+        "fileSize": str(file_size),
+        "printNow": "true" if print_now else "false",
+        "levelingBeforePrint": "true" if bed_levelling else "false",
+        "flowCalibration": "false",
+        "firstLayerInspection": "false",
+        "timeLapseVideo": "true" if timelapse else "false",
+        "useMatlStation": "true" if use_ams else "false",
+        "gcodeToolCnt": "0",
+        "materialMappings": _material_mappings_header(),
+    }
+    url = f"http://{ip_address}:{DEFAULT_FLASHFORGE_PORT}/uploadGcode"
+
+    try:
+        if progress_callback:
+            progress_callback(0, file_size)
+        with path.open("rb") as handle:
+            response = httpx.post(
+                url,
+                headers=headers,
+                files={"gcodeFile": (filename, handle, "application/octet-stream")},
+                timeout=600,
+            )
+        if progress_callback:
+            progress_callback(file_size, file_size)
+        payload = response.json()
+    except (OSError, httpx.HTTPError, ValueError) as exc:
+        logger.warning("FlashForge upload failed for %s: %s", ip_address, exc)
+        return False
+
+    if not _success_code(payload.get("code")):
+        logger.warning("FlashForge upload returned non-success response for %s: %s", ip_address, payload)
+        return False
+    return True

--- a/backend/app/services/print_scheduler.py
+++ b/backend/app/services/print_scheduler.py
@@ -2086,6 +2086,7 @@ class PrintScheduler:
                     remote_path,
                     socket_timeout=ftp_timeout,
                     printer_model=printer.model,
+                    serial_number=printer.serial_number,
                     max_retries=ftp_retry_count,
                     retry_delay=ftp_retry_delay,
                     operation_name=f"Upload print to {printer.name}",
@@ -2098,6 +2099,7 @@ class PrintScheduler:
                     remote_path,
                     socket_timeout=ftp_timeout,
                     printer_model=printer.model,
+                    serial_number=printer.serial_number,
                 )
         except Exception as e:
             uploaded = False

--- a/backend/app/services/printer_diagnostic.py
+++ b/backend/app/services/printer_diagnostic.py
@@ -1,9 +1,9 @@
-"""Connection diagnostic for Bambu printers.
+"""Connection diagnostic for local-network printers.
 
 Runs the checks a maintainer performs by hand when triaging a
-"printer won't connect / won't print" report — port reachability, LAN
-developer mode, Docker network mode, subnet match, and MQTT credentials —
-so users can self-diagnose setup problems instead of opening an issue.
+"printer won't connect / won't print" report — port reachability,
+LAN mode, Docker network mode, subnet match, and credentials — so users
+can self-diagnose setup problems instead of opening an issue.
 
 See the 2026-05-21 issue-triage analysis: ~1/3 of closed issues were
 user-side setup errors clustered on exactly these causes.
@@ -17,6 +17,11 @@ import socket
 from backend.app.models.printer import Printer
 from backend.app.schemas.printer import DiagnosticCheck, PrinterDiagnosticResult
 from backend.app.services.discovery import is_running_in_docker
+from backend.app.services.flashforge_local import (
+    DEFAULT_FLASHFORGE_PORT,
+    is_flashforge_model,
+    probe_flashforge_connection,
+)
 from backend.app.services.printer_manager import printer_manager
 from backend.app.utils.printer_models import has_external_storage
 
@@ -26,6 +31,7 @@ logger = logging.getLogger(__name__)
 PORT_MQTT = 8883  # MQTT over TLS — control + status. Connection-critical.
 PORT_FTPS = 990  # FTPS — file upload; required to send prints.
 PORT_RTSPS = 322  # RTSPS — camera stream; optional.
+PORT_FLASHFORGE_CAMERA = 8080  # MJPEG snapshot/stream; optional.
 
 _PORT_PROBE_TIMEOUT = 3.0
 
@@ -98,6 +104,94 @@ def _same_subnet(ip_a: str, ip_b: str) -> bool | None:
     return net_a == net_b
 
 
+def _append_environment_checks(checks: list[DiagnosticCheck], ip_address: str) -> str | None:
+    """Append Docker/subnet checks shared by all printer families."""
+    network_mode: str | None = None
+    if is_running_in_docker():
+        network_mode = _detect_docker_network_mode()
+        checks.append(
+            DiagnosticCheck(
+                id="network_mode",
+                status="pass" if network_mode == "host" else "warn",
+                params={"mode": network_mode},
+            )
+        )
+    else:
+        checks.append(DiagnosticCheck(id="network_mode", status="skip"))
+
+    if network_mode == "bridge":
+        checks.append(DiagnosticCheck(id="subnet", status="skip"))
+    else:
+        host_ip = _get_host_ip()
+        same = _same_subnet(ip_address, host_ip) if host_ip else None
+        if same is None:
+            checks.append(DiagnosticCheck(id="subnet", status="skip"))
+        else:
+            checks.append(
+                DiagnosticCheck(
+                    id="subnet",
+                    status="pass" if same else "warn",
+                    params={"printer_ip": ip_address, "host_ip": host_ip},
+                )
+            )
+    return network_mode
+
+
+async def _run_flashforge_diagnostic(ip_address: str, printer: Printer) -> PrinterDiagnosticResult:
+    """Run FlashForge-specific connection checks for a saved printer."""
+    checks: list[DiagnosticCheck] = []
+
+    api_ok, camera_ok = await asyncio.gather(
+        _check_port(ip_address, DEFAULT_FLASHFORGE_PORT),
+        _check_port(ip_address, PORT_FLASHFORGE_CAMERA),
+    )
+    checks.append(DiagnosticCheck(id="port_flashforge_api", status="pass" if api_ok else "fail"))
+    checks.append(DiagnosticCheck(id="port_flashforge_camera", status="pass" if camera_ok else "warn"))
+
+    _append_environment_checks(checks, ip_address)
+
+    serial_number = getattr(printer, "serial_number", None)
+    access_code = getattr(printer, "access_code", None)
+    if not api_ok:
+        checks.append(DiagnosticCheck(id="flashforge_auth", status="skip"))
+    elif serial_number and access_code:
+        try:
+            result = await probe_flashforge_connection(
+                ip_address,
+                serial_number,
+                access_code,
+            )
+            checks.append(DiagnosticCheck(id="flashforge_auth", status="pass" if result.get("success") else "fail"))
+        except Exception:
+            logger.debug("FlashForge probe failed during diagnostic", exc_info=True)
+            checks.append(DiagnosticCheck(id="flashforge_auth", status="fail"))
+    else:
+        checks.append(DiagnosticCheck(id="flashforge_auth", status="fail"))
+
+    state = printer_manager.get_status(printer.id)
+    if state is None:
+        checks.append(DiagnosticCheck(id="flashforge_polling", status="skip"))
+    elif getattr(state, "connected", False):
+        checks.append(DiagnosticCheck(id="flashforge_polling", status="pass"))
+    else:
+        checks.append(DiagnosticCheck(id="flashforge_polling", status="fail"))
+
+    statuses = {c.status for c in checks}
+    if "fail" in statuses:
+        overall = "problems"
+    elif "warn" in statuses:
+        overall = "warnings"
+    else:
+        overall = "ok"
+
+    return PrinterDiagnosticResult(
+        printer_id=printer.id,
+        ip_address=ip_address,
+        overall=overall,
+        checks=checks,
+    )
+
+
 async def run_connection_diagnostic(
     ip_address: str,
     *,
@@ -115,6 +209,9 @@ async def run_connection_diagnostic(
     pass / fail / warn / skip; the frontend renders the human-readable
     title and fix text (localized) keyed on that id + status.
     """
+    if printer is not None and is_flashforge_model(getattr(printer, "model", None)):
+        return await _run_flashforge_diagnostic(ip_address, printer)
+
     checks: list[DiagnosticCheck] = []
 
     # --- Port reachability (probed in parallel) ---
@@ -128,38 +225,7 @@ async def run_connection_diagnostic(
     checks.append(DiagnosticCheck(id="port_ftps", status="pass" if ftps_ok else "warn"))
     checks.append(DiagnosticCheck(id="port_rtsps", status="pass" if rtsps_ok else "warn"))
 
-    # --- Docker network mode ---
-    network_mode: str | None = None
-    if is_running_in_docker():
-        network_mode = _detect_docker_network_mode()
-        checks.append(
-            DiagnosticCheck(
-                id="network_mode",
-                status="pass" if network_mode == "host" else "warn",
-                params={"mode": network_mode},
-            )
-        )
-    else:
-        checks.append(DiagnosticCheck(id="network_mode", status="skip"))
-
-    # --- Subnet match ---
-    # Skipped in bridge mode: the container IP is the bridge IP, not the host's,
-    # so the comparison is meaningless and the network_mode check already covers it.
-    if network_mode == "bridge":
-        checks.append(DiagnosticCheck(id="subnet", status="skip"))
-    else:
-        host_ip = _get_host_ip()
-        same = _same_subnet(ip_address, host_ip) if host_ip else None
-        if same is None:
-            checks.append(DiagnosticCheck(id="subnet", status="skip"))
-        else:
-            checks.append(
-                DiagnosticCheck(
-                    id="subnet",
-                    status="pass" if same else "warn",
-                    params={"printer_ip": ip_address, "host_ip": host_ip},
-                )
-            )
+    _append_environment_checks(checks, ip_address)
 
     # --- External storage (printer-side "Store sent files on external storage") ---
     # Install step 4. The setting has two variants depending on

--- a/backend/app/services/printer_manager.py
+++ b/backend/app/services/printer_manager.py
@@ -87,6 +87,8 @@ def supports_chamber_temp(model: str | None) -> bool:
     """
     if not model:
         return False
+    if is_flashforge_model(model):
+        return True
     # Normalize model name (uppercase, strip whitespace)
     model_upper = model.strip().upper()
     return model_upper in CHAMBER_TEMP_SUPPORTED_MODELS
@@ -164,6 +166,8 @@ def supports_drying(model: str | None, firmware: str | None) -> bool:
     the command fails gracefully with result: "fail" if unsupported.
     """
     if not model:
+        return False
+    if "FLASHFORGE" in model.strip().upper() or is_flashforge_model(model):
         return False
     model_upper = model.strip().upper()
     if model_upper in _DRYING_UNSUPPORTED_MODELS:
@@ -852,7 +856,6 @@ def printer_state_to_dict(state: PrinterState, printer_id: int | None = None, mo
     ams_units = []
     vt_tray = []
     raw_data = state.raw_data or {}
-    is_flashforge = raw_data.get("vendor") == "flashforge"
 
     # Build K-profile lookup map: cali_idx -> k_value
     kprofile_map: dict[int, float] = {}
@@ -1020,7 +1023,7 @@ def printer_state_to_dict(state: PrinterState, printer_id: int | None = None, mo
         "total_layers": state.total_layers,
         "temperatures": temperatures,
         "hms_errors": [
-            {"code": e.code, "attr": e.attr, "module": e.module, "severity": e.severity}
+            {"code": e.code, "attr": e.attr, "module": e.module, "severity": e.severity, "message": e.message}
             for e in (state.hms_errors or [])
         ],
         # AMS data for filament colors
@@ -1083,9 +1086,7 @@ def printer_state_to_dict(state: PrinterState, printer_id: int | None = None, mo
     }
     # Add cover URL if there's an active print and printer_id is provided
     # Include PAUSE state so skip objects modal can show cover
-    if is_flashforge:
-        result["cover_url"] = None
-    elif printer_id and state.state in ("RUNNING", "PAUSE") and state.gcode_file:
+    if printer_id and state.state in ("RUNNING", "PAUSE") and state.gcode_file:
         result["cover_url"] = f"/api/v1/printers/{printer_id}/cover"
     else:
         result["cover_url"] = None

--- a/backend/app/services/printer_manager.py
+++ b/backend/app/services/printer_manager.py
@@ -9,6 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.models.printer import Printer
 from backend.app.services.bambu_mqtt import BambuMQTTClient, MQTTLogEntry, PrinterState, get_stage_name
+from backend.app.services.flashforge_local import (
+    FlashForgeLocalClient,
+    is_flashforge_model,
+    probe_flashforge_connection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +29,8 @@ CHAMBER_TEMP_SUPPORTED_MODELS = frozenset(
         "X1E",  # X1 series
         "X2D",  # X2 series
         "P2S",  # P2 series
+        "CREATOR 5 PRO",
+        "FLASHFORGE CREATOR 5 PRO",
         "H2C",
         "H2D",
         "H2DPRO",
@@ -133,7 +140,19 @@ _DRYING_MIN_FIRMWARE: dict[str, str] = {
     "N7": "01.02.00.00",  # P2S internal model code
 }
 # Models that definitely don't support AMS drying (no AMS 2 Pro / AMS-HT compatibility)
-_DRYING_UNSUPPORTED_MODELS = frozenset({"A1", "A1MINI", "A1-MINI", "A1 MINI", "O1S", "N1", "N2S"})
+_DRYING_UNSUPPORTED_MODELS = frozenset(
+    {
+        "A1",
+        "A1MINI",
+        "A1-MINI",
+        "A1 MINI",
+        "O1S",
+        "N1",
+        "N2S",
+        "CREATOR 5 PRO",
+        "FLASHFORGE CREATOR 5 PRO",
+    }
+)
 
 
 def supports_drying(model: str | None, firmware: str | None) -> bool:
@@ -423,21 +442,32 @@ class PrinterManager:
             if self._on_drying_complete:
                 self._schedule_async(self._on_drying_complete(printer_id, ams_id))
 
-        client = BambuMQTTClient(
-            ip_address=printer.ip_address,
-            serial_number=printer.serial_number,
-            access_code=printer.access_code,
-            model=printer.model,
-            on_state_change=on_state_change,
-            on_print_start=on_print_start,
-            on_print_complete=on_print_complete,
-            on_ams_change=on_ams_change,
-            on_layer_change=on_layer_change,
-            on_bed_temp_update=on_bed_temp_update,
-            on_drying_complete=on_drying_complete,
-            on_print_running_observed=on_print_running_observed,
-            on_finish_photo_moment=on_finish_photo_moment,
-        )
+        if is_flashforge_model(printer.model):
+            client = FlashForgeLocalClient(
+                ip_address=printer.ip_address,
+                serial_number=printer.serial_number,
+                access_code=printer.access_code,
+                model=printer.model,
+                on_state_change=on_state_change,
+                on_print_start=on_print_start,
+                on_print_complete=on_print_complete,
+            )
+        else:
+            client = BambuMQTTClient(
+                ip_address=printer.ip_address,
+                serial_number=printer.serial_number,
+                access_code=printer.access_code,
+                model=printer.model,
+                on_state_change=on_state_change,
+                on_print_start=on_print_start,
+                on_print_complete=on_print_complete,
+                on_ams_change=on_ams_change,
+                on_layer_change=on_layer_change,
+                on_bed_temp_update=on_bed_temp_update,
+                on_drying_complete=on_drying_complete,
+                on_print_running_observed=on_print_running_observed,
+                on_finish_photo_moment=on_finish_photo_moment,
+            )
 
         client.connect()
         self._clients[printer_id] = client
@@ -669,6 +699,7 @@ class PrinterManager:
         ip_address: str,
         serial_number: str,
         access_code: str,
+        model: str | None = None,
     ) -> dict:
         """Test connection to a printer without persisting.
 
@@ -680,6 +711,9 @@ class PrinterManager:
         original synchronous teardown produced the #1445 "Docker container
         hangs" symptom on P1S when called from POST /printers/.
         """
+        if is_flashforge_model(model):
+            return await probe_flashforge_connection(ip_address, serial_number, access_code)
+
         client = BambuMQTTClient(
             ip_address=ip_address,
             serial_number=serial_number,
@@ -818,6 +852,7 @@ def printer_state_to_dict(state: PrinterState, printer_id: int | None = None, mo
     ams_units = []
     vt_tray = []
     raw_data = state.raw_data or {}
+    is_flashforge = raw_data.get("vendor") == "flashforge"
 
     # Build K-profile lookup map: cali_idx -> k_value
     kprofile_map: dict[int, float] = {}
@@ -1048,7 +1083,9 @@ def printer_state_to_dict(state: PrinterState, printer_id: int | None = None, mo
     }
     # Add cover URL if there's an active print and printer_id is provided
     # Include PAUSE state so skip objects modal can show cover
-    if printer_id and state.state in ("RUNNING", "PAUSE") and state.gcode_file:
+    if is_flashforge:
+        result["cover_url"] = None
+    elif printer_id and state.state in ("RUNNING", "PAUSE") and state.gcode_file:
         result["cover_url"] = f"/api/v1/printers/{printer_id}/cover"
     else:
         result["cover_url"] = None

--- a/backend/tests/integration/test_camera_api.py
+++ b/backend/tests/integration/test_camera_api.py
@@ -3,6 +3,7 @@
 Tests the full request/response cycle for /api/v1/printers/{id}/camera/ endpoints.
 """
 
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -240,6 +241,40 @@ class TestCameraAPI:
         assert [s["name"] for s in body["stages"]] == ["tcp_reachable", "first_frame"]
         assert body["stages"][1]["code"] == "no_frame"
 
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_camera_diagnose_flashforge_reports_mjpeg_protocol(self, async_client: AsyncClient, printer_factory):
+        """The Diagnose button should use FlashForge's MJPEG path, not Bambu RTSP metadata."""
+        printer = await printer_factory(model="FlashForge Creator 5 Pro")
+
+        async def _tcp_ok(*_a, **_kw):
+            writer = AsyncMock()
+            return AsyncMock(), writer
+
+        with (
+            patch("backend.app.services.camera_diagnose.asyncio.open_connection", new=_tcp_ok),
+            patch(
+                "backend.app.services.camera_diagnose.read_flashforge_mjpeg_frame",
+                new_callable=AsyncMock,
+                return_value=b"\xff\xd8\xff\xe0frame",
+            ),
+            patch(
+                "backend.app.services.camera_diagnose.capture_camera_frame_bytes",
+                new_callable=AsyncMock,
+            ) as bambu_capture,
+        ):
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/camera/diagnose")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["printer_id"] == printer.id
+        assert body["protocol"] == "flashforge_mjpeg"
+        assert body["port"] == 8080
+        assert body["overall_status"] == "ok"
+        assert body["summary_code"] == "all_ok"
+        assert [s["name"] for s in body["stages"]] == ["tcp_reachable", "first_frame"]
+        bambu_capture.assert_not_awaited()
+
     # ========================================================================
     # Camera Snapshot Endpoint
     # ========================================================================
@@ -361,6 +396,28 @@ class TestCameraAPI:
         assert response.status_code == 503
         assert "external camera" in response.json()["detail"].lower()
 
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_camera_snapshot_flashforge_uses_local_mjpeg_reader(self, async_client: AsyncClient, printer_factory):
+        """FlashForge snapshots come from the printer's local MJPEG endpoint."""
+        printer = await printer_factory(model="FlashForge Creator 5 Pro")
+        fake_jpeg = b"\xff\xd8\xff\xe0flashforge-frame"
+
+        with (
+            patch(
+                "backend.app.api.routes.camera.read_flashforge_mjpeg_frame",
+                new=AsyncMock(return_value=fake_jpeg),
+            ) as read_mock,
+            patch("backend.app.api.routes.camera.capture_camera_frame", new_callable=AsyncMock) as capture_mock,
+        ):
+            response = await async_client.get(f"/api/v1/printers/{printer.id}/camera/snapshot")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/jpeg"
+        assert response.content == fake_jpeg
+        read_mock.assert_awaited_once_with(printer.ip_address, timeout=15.0)
+        capture_mock.assert_not_called()
+
     # ========================================================================
     # Camera Stream Endpoint
     # ========================================================================
@@ -391,6 +448,45 @@ class TestCameraAPI:
             )
             # Response will be a streaming response with error
             assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_flashforge_polling_stream_updates_camera_status(self, async_client: AsyncClient, printer_factory):
+        """FlashForge stream frames must update status bookkeeping for stall detection."""
+        from backend.app.api.routes import camera as camera_routes
+
+        printer = await printer_factory(model="FlashForge Creator 5 Pro")
+        fake_jpeg = b"\xff\xd8\xff\xe0flashforge-stream-frame"
+
+        stream = camera_routes._generate_flashforge_polling_stream(printer.id, printer.ip_address, fps=1)
+        try:
+            with patch(
+                "backend.app.api.routes.camera.read_flashforge_mjpeg_frame",
+                new=AsyncMock(return_value=fake_jpeg),
+            ):
+                frame = await anext(stream)
+        finally:
+            await stream.aclose()
+
+        assert frame.startswith(b"--frame\r\nContent-Type: image/jpeg")
+        assert camera_routes._last_frames[printer.id] == fake_jpeg
+        assert printer.id in camera_routes._last_frame_times
+
+        camera_routes._active_external_streams.add(printer.id)
+        camera_routes._stream_start_times[printer.id] = time.time() - 1
+        try:
+            response = await async_client.get(f"/api/v1/printers/{printer.id}/camera/status")
+        finally:
+            camera_routes._active_external_streams.discard(printer.id)
+            camera_routes._last_frames.pop(printer.id, None)
+            camera_routes._last_frame_times.pop(printer.id, None)
+            camera_routes._stream_start_times.pop(printer.id, None)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["active"] is True
+        assert body["has_frames"] is True
+        assert body["stalled"] is False
 
     # ========================================================================
     # Plate Detection Endpoints

--- a/backend/tests/integration/test_printers_api.py
+++ b/backend/tests/integration/test_printers_api.py
@@ -334,6 +334,129 @@ class TestPrintersAPI:
         encoded_name = content_disposition.split("filename*=UTF-8''", 1)[1]
         assert unquote(encoded_name) == filename
 
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_list_printer_files_flashforge_reports_limited_capabilities(
+        self,
+        async_client: AsyncClient,
+        printer_factory,
+    ):
+        """FlashForge supports file listing, but not Bambu-style file actions."""
+        printer = await printer_factory(
+            model="FlashForge Creator 5 Pro",
+            serial_number="FF-TEST-SERIAL",
+            access_code="ff-test-key",
+        )
+        listed_files = [
+            {
+                "name": "cow.gcode.3mf",
+                "size": 12345,
+                "modified": None,
+                "is_directory": False,
+            }
+        ]
+
+        with patch(
+            "backend.app.api.routes.printers.list_files_async",
+            new=AsyncMock(return_value=listed_files),
+        ) as list_mock:
+            response = await async_client.get(
+                f"/api/v1/printers/{printer.id}/files",
+                params={"path": "/"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["files"][0]["path"] == "/cow.gcode.3mf"
+        assert data["files"][0]["thumbnail_url"] == f"/api/v1/printers/{printer.id}/files/thumbnail?path=/cow.gcode.3mf"
+        assert data["capabilities"]["can_download"] is False
+        assert data["capabilities"]["can_delete"] is False
+        assert data["capabilities"]["can_preview"] is False
+        assert data["capabilities"]["can_browse_directories"] is False
+        assert "file listing/upload" in data["capabilities"]["unsupported_reason"]
+        list_mock.assert_awaited_once_with(
+            printer.ip_address,
+            printer.access_code,
+            "/",
+            printer_model="FlashForge Creator 5 Pro",
+            serial_number="FF-TEST-SERIAL",
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_flashforge_file_thumbnail_uses_local_api(
+        self,
+        async_client: AsyncClient,
+        printer_factory,
+    ):
+        printer = await printer_factory(
+            model="FlashForge Creator 5 Pro",
+            serial_number="FF-TEST-SERIAL",
+            access_code="ff-test-key",
+        )
+
+        with patch(
+            "backend.app.api.routes.printers.get_flashforge_gcode_thumbnail",
+            return_value=(b"\xff\xd8\xff\xe0thumb", "image/jpeg"),
+        ) as thumb_mock:
+            response = await async_client.get(
+                f"/api/v1/printers/{printer.id}/files/thumbnail",
+                params={"path": "/cow.gcode.3mf"},
+            )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/jpeg"
+        assert response.content.startswith(b"\xff\xd8\xff")
+        thumb_mock.assert_called_once_with(
+            printer.ip_address,
+            "FF-TEST-SERIAL",
+            "ff-test-key",
+            "/cow.gcode.3mf",
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        ("method", "path", "kwargs", "expected_detail"),
+        [
+            ("GET", "/files/download", {"params": {"path": "/cow.gcode.3mf"}}, "file downloads"),
+            ("GET", "/files/gcode", {"params": {"path": "/cow.gcode.3mf"}}, "G-code downloads"),
+            ("GET", "/files/plates", {"params": {"path": "/cow.gcode.3mf"}}, "3MF plate metadata"),
+            (
+                "GET",
+                "/files/plate-thumbnail/1",
+                {"params": {"path": "/cow.gcode.3mf"}},
+                "3MF plate thumbnails",
+            ),
+            ("POST", "/files/download-zip", {"json": {"paths": ["/cow.gcode.3mf"]}}, "file downloads"),
+            ("DELETE", "/files", {"params": {"path": "/cow.gcode.3mf"}}, "file deletion"),
+        ],
+    )
+    async def test_flashforge_file_actions_report_unsupported_before_ftp_access(
+        self,
+        async_client: AsyncClient,
+        printer_factory,
+        method: str,
+        path: str,
+        kwargs: dict,
+        expected_detail: str,
+    ):
+        """Unsupported FlashForge file actions should fail cleanly without trying FTP."""
+        printer = await printer_factory(model="FlashForge Creator 5 Pro")
+
+        with (
+            patch("backend.app.api.routes.printers.download_file_bytes_async", new=AsyncMock()) as download_mock,
+            patch("backend.app.api.routes.printers.delete_file_async", new=AsyncMock()) as delete_mock,
+        ):
+            response = await async_client.request(method, f"/api/v1/printers/{printer.id}{path}", **kwargs)
+
+        assert response.status_code == 501
+        detail = response.json()["detail"]
+        assert "FlashForge" in detail
+        assert expected_detail in detail
+        download_mock.assert_not_awaited()
+        delete_mock.assert_not_awaited()
+
     # ========================================================================
     # Status endpoint
     # ========================================================================
@@ -352,6 +475,67 @@ class TestPrintersAPI:
         result = response.json()
         assert "connected" in result
         assert "state" in result
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_flashforge_status_reports_supported_capabilities(self, async_client: AsyncClient, printer_factory):
+        """FlashForge cards should only advertise controls backed by the local API."""
+        from backend.app.services.bambu_mqtt import PrinterState
+
+        printer = await printer_factory(model="Flashforge Creator 5 Pro")
+        state = PrinterState(connected=True, state="RUNNING")
+        state.current_print = "cow.gcode.3mf"
+        state.gcode_file = "cow.gcode.3mf"
+        state.subtask_name = "cow.gcode.3mf"
+
+        mock_pm = MagicMock()
+        mock_pm.get_status.return_value = state
+        mock_pm.is_awaiting_plate_clear.return_value = False
+
+        with patch("backend.app.api.routes.printers.printer_manager", mock_pm):
+            response = await async_client.get(f"/api/v1/printers/{printer.id}/status")
+
+        assert response.status_code == 200
+        capabilities = response.json()["capabilities"]
+        assert capabilities["can_pause"] is True
+        assert capabilities["can_resume"] is True
+        assert capabilities["can_stop"] is True
+        assert capabilities["can_upload_files"] is True
+        assert capabilities["can_list_files"] is True
+        assert capabilities["can_stream_camera"] is True
+        assert capabilities["can_chamber_light"] is True
+        assert capabilities["can_print_speed"] is True
+        assert capabilities["can_set_temperature"] is True
+        assert capabilities["can_bed_jog"] is False
+        assert capabilities["can_skip_objects"] is False
+        assert capabilities["can_download_files"] is False
+        assert capabilities["can_delete_files"] is False
+        assert "known LAN API" in capabilities["unsupported_reasons"]["can_skip_objects"]
+        assert "file listing/upload" in capabilities["unsupported_reasons"]["can_download_files"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_status_preserves_hms_error_message(self, async_client: AsyncClient, printer_factory):
+        """Plain-language error messages should survive status serialization for non-Bambu APIs."""
+        from backend.app.services.bambu_mqtt import HMSError, PrinterState
+
+        printer = await printer_factory(model="Flashforge Creator 5 Pro")
+        state = PrinterState(connected=True, state="FAILED")
+        state.hms_errors = [
+            HMSError(code="42", attr=42, module=0, severity=2, message="Platform blocked"),
+        ]
+
+        mock_pm = MagicMock()
+        mock_pm.get_status.return_value = state
+        mock_pm.is_awaiting_plate_clear.return_value = False
+
+        with patch("backend.app.api.routes.printers.printer_manager", mock_pm):
+            response = await async_client.get(f"/api/v1/printers/{printer.id}/status")
+
+        assert response.status_code == 200
+        assert response.json()["hms_errors"] == [
+            {"code": "42", "attr": 42, "module": 0, "severity": 2, "message": "Platform blocked"}
+        ]
 
     @pytest.mark.asyncio
     @pytest.mark.integration
@@ -741,6 +925,24 @@ class TestPrintControlAPI:
             assert response.json()["success"] is True
             mock_client.stop_print.assert_called_once()
 
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_stop_print_flashforge_uses_local_client(self, async_client: AsyncClient, printer_factory):
+        """FlashForge stop is supported by the local API client and must not be blocked."""
+        printer = await printer_factory(name="Creator", model="FlashForge Creator 5 Pro")
+
+        mock_client = MagicMock()
+        mock_client.stop_print.return_value = True
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/print/stop")
+
+            assert response.status_code == 200
+            assert response.json()["success"] is True
+            mock_client.stop_print.assert_called_once()
+
     # ========================================================================
     # Pause print endpoint
     # ========================================================================
@@ -771,6 +973,24 @@ class TestPrintControlAPI:
     async def test_pause_print_success(self, async_client: AsyncClient, printer_factory):
         """Verify successful pause print request."""
         printer = await printer_factory(name="Printing Printer")
+
+        mock_client = MagicMock()
+        mock_client.pause_print.return_value = True
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/print/pause")
+
+            assert response.status_code == 200
+            assert response.json()["success"] is True
+            mock_client.pause_print.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_pause_print_flashforge_uses_local_client(self, async_client: AsyncClient, printer_factory):
+        """FlashForge pause is supported by the local API client and must not be blocked."""
+        printer = await printer_factory(name="Creator", model="FlashForge Creator 5 Pro")
 
         mock_client = MagicMock()
         mock_client.pause_print.return_value = True
@@ -826,6 +1046,62 @@ class TestPrintControlAPI:
             assert response.status_code == 200
             assert response.json()["success"] is True
             mock_client.resume_print.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_resume_print_flashforge_uses_local_client(self, async_client: AsyncClient, printer_factory):
+        """FlashForge resume is supported by the local API client and must not be blocked."""
+        printer = await printer_factory(name="Creator", model="FlashForge Creator 5 Pro")
+
+        mock_client = MagicMock()
+        mock_client.resume_print.return_value = True
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/print/resume")
+
+            assert response.status_code == 200
+            assert response.json()["success"] is True
+            mock_client.resume_print.assert_called_once()
+
+
+class TestFlashForgeCapabilityRoutes:
+    """FlashForge route-level capability guards."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        ("method", "path", "kwargs", "expected_detail"),
+        [
+            ("POST", "/airduct-mode?mode=cooling", {}, "airduct"),
+            ("POST", "/bed-jog?distance=1", {}, "Z jog"),
+            ("POST", "/home-axes?axes=all", {}, "homing"),
+            ("GET", "/print/objects", {}, "object skipping"),
+            ("POST", "/print/skip-objects", {"json": [1]}, "object skipping"),
+            ("POST", "/drying/start?ams_id=0", {}, "filament drying"),
+            ("POST", "/drying/stop?ams_id=0", {}, "filament drying"),
+            ("POST", "/print-options?module_name=spaghetti_detector&enabled=true", {}, "AI print option"),
+            ("POST", "/calibration?bed_leveling=true", {}, "calibration"),
+        ],
+    )
+    async def test_bambu_only_routes_report_flashforge_unsupported(
+        self,
+        async_client: AsyncClient,
+        printer_factory,
+        method: str,
+        path: str,
+        kwargs: dict,
+        expected_detail: str,
+    ):
+        printer = await printer_factory(name="Creator", model="FlashForge Creator 5 Pro")
+
+        response = await async_client.request(method, f"/api/v1/printers/{printer.id}{path}", **kwargs)
+
+        assert response.status_code == 501
+        detail = response.json()["detail"]
+        assert "FlashForge" in detail
+        assert expected_detail in detail
 
 
 class TestAMSRefreshAPI:
@@ -1567,6 +1843,24 @@ class TestChamberLightAPI:
 
     @pytest.mark.asyncio
     @pytest.mark.integration
+    async def test_chamber_light_flashforge_success(self, async_client: AsyncClient, printer_factory):
+        """FlashForge chamber light should use its local HTTP control command."""
+        printer = await printer_factory(name="Creator", model="Flashforge Creator 5 Pro")
+
+        mock_client = MagicMock()
+        mock_client.set_chamber_light.return_value = True
+        mock_client.state = type("State", (), {"chamber_light": False})()
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/chamber-light?on=true")
+
+        assert response.status_code == 200
+        mock_client.set_chamber_light.assert_called_once_with(True)
+        assert mock_client.state.chamber_light is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
     async def test_chamber_light_on_success(self, async_client: AsyncClient, printer_factory):
         """Verify successful chamber light on request."""
         printer = await printer_factory(name="Test Printer")
@@ -1621,6 +1915,112 @@ class TestChamberLightAPI:
 
             assert response.status_code == 500
             assert "failed" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_print_speed_flashforge_success(self, async_client: AsyncClient, printer_factory):
+        """FlashForge print speed should use its local HTTP control command."""
+        printer = await printer_factory(name="Creator", model="Flashforge Creator 5 Pro")
+
+        mock_client = MagicMock()
+        mock_client.set_print_speed.return_value = True
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/print-speed?mode=3")
+
+        assert response.status_code == 200
+        mock_client.set_print_speed.assert_called_once_with(3)
+
+
+class TestTemperatureControlAPI:
+    """Integration tests for heater target control."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_temperature_not_found(self, async_client: AsyncClient):
+        response = await async_client.post("/api/v1/printers/99999/temperature?heater=nozzle&target=205")
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_temperature_rejects_unknown_heater(self, async_client: AsyncClient, printer_factory):
+        printer = await printer_factory(name="Creator", model="Flashforge Creator 5 Pro")
+
+        response = await async_client.post(f"/api/v1/printers/{printer.id}/temperature?heater=laser&target=205")
+
+        assert response.status_code == 400
+        assert "heater" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_temperature_rejects_out_of_range_target(self, async_client: AsyncClient, printer_factory):
+        printer = await printer_factory(name="Creator", model="Flashforge Creator 5 Pro")
+
+        response = await async_client.post(f"/api/v1/printers/{printer.id}/temperature?heater=nozzle&target=500")
+
+        assert response.status_code == 400
+        assert "between" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_temperature_rejects_non_flashforge_for_now(self, async_client: AsyncClient, printer_factory):
+        printer = await printer_factory(name="P1S", model="P1S")
+
+        response = await async_client.post(f"/api/v1/printers/{printer.id}/temperature?heater=nozzle&target=205")
+
+        assert response.status_code == 501
+        assert "FlashForge" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_temperature_not_connected(self, async_client: AsyncClient, printer_factory):
+        printer = await printer_factory(name="Creator", model="Flashforge Creator 5 Pro")
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = None
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/temperature?heater=bed&target=60")
+
+        assert response.status_code == 400
+        assert "not connected" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_temperature_flashforge_success_updates_cached_target(self, async_client: AsyncClient, printer_factory):
+        printer = await printer_factory(name="Creator", model="Flashforge Creator 5 Pro")
+
+        mock_client = MagicMock()
+        mock_client.set_temperature.return_value = True
+        mock_client.state = type(
+            "State",
+            (),
+            {"temperatures": {"nozzle": 180, "nozzle_target": 180, "nozzle_heating": False}},
+        )()
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/temperature?heater=nozzle&target=205")
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        mock_client.set_temperature.assert_called_once_with("nozzle", 205)
+        assert mock_client.state.temperatures["nozzle_target"] == 205
+        assert mock_client.state.temperatures["nozzle_heating"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_temperature_flashforge_failure(self, async_client: AsyncClient, printer_factory):
+        printer = await printer_factory(name="Creator", model="Flashforge Creator 5 Pro")
+
+        mock_client = MagicMock()
+        mock_client.set_temperature.return_value = False
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/temperature?heater=bed&target=60")
+
+        assert response.status_code == 500
+        assert "failed" in response.json()["detail"].lower()
 
 
 class TestAirductModeAPI:
@@ -1709,6 +2109,24 @@ class TestClearHMSErrorsAPI:
             result = response.json()
             assert result["success"] is True
             assert "cleared" in result["message"].lower()
+            mock_client.clear_hms_errors.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_clear_hms_errors_flashforge_uses_local_client(self, async_client: AsyncClient, printer_factory):
+        """FlashForge clear-errors is supported by the local API client and must not be blocked."""
+        printer = await printer_factory(name="Creator", model="FlashForge Creator 5 Pro")
+
+        mock_client = MagicMock()
+        mock_client.clear_hms_errors.return_value = True
+
+        with patch("backend.app.api.routes.printers.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+
+            response = await async_client.post(f"/api/v1/printers/{printer.id}/hms/clear")
+
+            assert response.status_code == 200
+            assert response.json()["success"] is True
             mock_client.clear_hms_errors.assert_called_once()
 
     @pytest.mark.asyncio

--- a/backend/tests/unit/services/test_bambu_ftp.py
+++ b/backend/tests/unit/services/test_bambu_ftp.py
@@ -15,11 +15,13 @@ Tests against a real mock implicit FTPS server, covering:
 
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from backend.app.services.bambu_ftp import (
     BambuFTPClient,
+    DeleteResult,
     FileNotOnPrinterError,
     cache_3mf_download,
     clear_3mf_cache,
@@ -27,6 +29,7 @@ from backend.app.services.bambu_ftp import (
     download_file_async,
     download_file_try_paths_async,
     get_cached_3mf,
+    get_storage_info_async,
     list_files_async,
     normalize_3mf_name,
     upload_file_async,
@@ -812,6 +815,133 @@ class TestAsyncWrappers:
             printer_model="A1",
         )
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_upload_file_async_routes_flashforge_to_http_uploader(self, tmp_path, monkeypatch):
+        content = b"flashforge upload"
+        local = tmp_path / "ff.3mf"
+        local.write_bytes(content)
+        seen = {}
+
+        def fake_upload(ip_address, serial_number, access_code, local_path, remote_path, **kwargs):
+            seen.update(
+                {
+                    "ip_address": ip_address,
+                    "serial_number": serial_number,
+                    "access_code": access_code,
+                    "local_path": local_path,
+                    "remote_path": remote_path,
+                    "kwargs": kwargs,
+                }
+            )
+            return True
+
+        monkeypatch.setattr("backend.app.services.flashforge_local.upload_flashforge_file", fake_upload)
+
+        result = await upload_file_async(
+            "192.0.2.211",
+            "ff-test-key",
+            local,
+            "/cache/ff.3mf",
+            timeout=30.0,
+            printer_model="FlashForge Creator 5 Pro",
+            serial_number="FF-TEST-SERIAL",
+        )
+
+        assert result is True
+        assert seen["ip_address"] == "192.0.2.211"
+        assert seen["serial_number"] == "FF-TEST-SERIAL"
+        assert seen["access_code"] == "ff-test-key"
+        assert seen["local_path"] == local
+        assert seen["remote_path"] == "/cache/ff.3mf"
+
+    @pytest.mark.asyncio
+    async def test_delete_file_async_reports_flashforge_unsupported(self):
+        result = await delete_file_async(
+            "192.0.2.211",
+            "ff-test-key",
+            "/cache/ff.3mf",
+            printer_model="FlashForge Creator 5 Pro",
+        )
+
+        assert result is DeleteResult.FAILED
+
+    @pytest.mark.asyncio
+    async def test_list_files_async_routes_flashforge_to_http_api(self, monkeypatch):
+        seen = {}
+
+        def fake_list(ip_address, serial_number, access_code, path):
+            seen.update(
+                {
+                    "ip_address": ip_address,
+                    "serial_number": serial_number,
+                    "access_code": access_code,
+                    "path": path,
+                }
+            )
+            return [{"name": "cube.gcode.3mf", "is_directory": False, "size": 0, "mtime": None}]
+
+        monkeypatch.setattr("backend.app.services.flashforge_local.list_flashforge_files", fake_list)
+
+        result = await list_files_async(
+            "192.0.2.211",
+            "ff-test-key",
+            "/",
+            printer_model="FlashForge Creator 5 Pro",
+            serial_number="FF-TEST-SERIAL",
+        )
+
+        assert result == [{"name": "cube.gcode.3mf", "is_directory": False, "size": 0, "mtime": None}]
+        assert seen == {
+            "ip_address": "192.0.2.211",
+            "serial_number": "FF-TEST-SERIAL",
+            "access_code": "ff-test-key",
+            "path": "/",
+        }
+
+    @pytest.mark.asyncio
+    async def test_storage_info_async_routes_flashforge_to_http_api(self, monkeypatch):
+        def fake_storage(ip_address, serial_number, access_code):
+            return {"used_bytes": None, "free_bytes": 1234}
+
+        monkeypatch.setattr("backend.app.services.flashforge_local.get_flashforge_storage_info", fake_storage)
+
+        result = await get_storage_info_async(
+            "192.0.2.211",
+            "ff-test-key",
+            printer_model="FlashForge Creator 5 Pro",
+            serial_number="FF-TEST-SERIAL",
+        )
+
+        assert result == {"used_bytes": None, "free_bytes": 1234}
+
+    @pytest.mark.asyncio
+    async def test_download_file_async_skips_flashforge_ftp(self, tmp_path):
+        with patch.object(BambuFTPClient, "connect") as connect:
+            result = await download_file_async(
+                "192.0.2.211",
+                "ff-test-key",
+                "/cube.gcode.3mf",
+                tmp_path / "cube.gcode.3mf",
+                printer_model="FlashForge Creator 5 Pro",
+            )
+
+        assert result is False
+        connect.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_download_file_try_paths_async_skips_flashforge_ftp(self, tmp_path):
+        with patch.object(BambuFTPClient, "connect") as connect:
+            result = await download_file_try_paths_async(
+                "192.0.2.211",
+                "ff-test-key",
+                ["/cube.gcode.3mf", "/cache/cube.gcode.3mf"],
+                tmp_path / "cube.gcode.3mf",
+                printer_model="FlashForge Creator 5 Pro",
+            )
+
+        assert result is False
+        connect.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_download_file_async_success(self, patch_ftp_port, tmp_path):

--- a/backend/tests/unit/services/test_camera_diagnose.py
+++ b/backend/tests/unit/services/test_camera_diagnose.py
@@ -223,6 +223,73 @@ class TestFirstFrameStage:
         assert all(s.status == "ok" for s in result.stages)
 
 
+class TestFlashForgeCameraDiagnose:
+    """FlashForge cameras use the local MJPEG endpoint, not Bambu RTSP/chamber capture."""
+
+    @pytest.mark.asyncio
+    async def test_flashforge_success_uses_mjpeg_reader(self):
+        async def _tcp_ok(*_a, **_kw):
+            writer = AsyncMock()
+            return AsyncMock(), writer
+
+        with (
+            patch("backend.app.services.camera_diagnose.asyncio.open_connection", new=_tcp_ok) as _open,
+            patch(
+                "backend.app.services.camera_diagnose.read_flashforge_mjpeg_frame",
+                new_callable=AsyncMock,
+                return_value=b"\xff\xd8\xff\xe0frame",
+            ) as flashforge_frame,
+            patch(
+                "backend.app.services.camera_diagnose.capture_camera_frame_bytes",
+                new_callable=AsyncMock,
+            ) as bambu_capture,
+        ):
+            result = await diagnose_camera(
+                ip_address="192.0.2.211",
+                access_code="code",
+                model="FlashForge Creator 5 Pro",
+                printer_id=5,
+            )
+
+        assert result.overall_status == "ok"
+        assert result.summary_code == "all_ok"
+        assert result.protocol == "flashforge_mjpeg"
+        assert result.port == 8080
+        assert result.profile == "default"
+        assert [stage.name for stage in result.stages] == ["tcp_reachable", "first_frame"]
+        assert all(stage.status == "ok" for stage in result.stages)
+        flashforge_frame.assert_awaited_once_with(ip_address="192.0.2.211", timeout=15)
+        bambu_capture.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_flashforge_no_frame_maps_to_no_frame(self):
+        async def _tcp_ok(*_a, **_kw):
+            writer = AsyncMock()
+            return AsyncMock(), writer
+
+        with (
+            patch("backend.app.services.camera_diagnose.asyncio.open_connection", new=_tcp_ok),
+            patch(
+                "backend.app.services.camera_diagnose.read_flashforge_mjpeg_frame",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await diagnose_camera(
+                ip_address="192.0.2.211",
+                access_code="code",
+                model="Creator5Pro",
+                printer_id=5,
+            )
+
+        assert result.overall_status == "failed"
+        assert result.summary_code == "no_frame"
+        assert result.protocol == "flashforge_mjpeg"
+        assert result.port == 8080
+        assert result.stages[1].name == "first_frame"
+        assert result.stages[1].code == "no_frame"
+
+
 class TestResultMetadata:
     """Surface fields the support triage relies on — protocol, port,
     profile name. The frontend renders these so we can ask the user

--- a/backend/tests/unit/services/test_flashforge_local.py
+++ b/backend/tests/unit/services/test_flashforge_local.py
@@ -5,8 +5,15 @@ import pytest
 
 from backend.app.services.flashforge_local import (
     FlashForgeLocalClient,
+    _remaining_minutes,
+    _seconds_to_minutes,
+    _speed_percent_to_level,
+    get_flashforge_current_thumbnail,
+    get_flashforge_storage_info,
     is_flashforge_model,
+    list_flashforge_files,
     probe_flashforge_connection,
+    upload_flashforge_file,
 )
 
 
@@ -21,22 +28,26 @@ def _detail_payload() -> dict:
             "printProgress": 0.25,
             "estimatedTime": 1234,
             "printDuration": 456,
+            "errorCode": 0,
             "printLayer": 12,
             "targetPrintLayer": 100,
             "firmwareVersion": "1.9.3",
             "camera": 1,
-            "cameraStreamUrl": "http://192.168.0.211:8080/?action=stream",
+            "cameraStreamUrl": "http://192.0.2.211:8080/?action=stream",
             "nozzleTemps": [120, 121, 180, 209],
             "nozzleTargetTemps": [120, 120, 130, 210],
             "platTemp": 59,
             "platTargetTemp": 60,
             "chamberTemp": 29,
+            "chamberTargetTemp": 45,
+            "printSpeedAdjust": 124,
             "coolingFanSpeed": 70,
             "chamberFanSpeed": 0,
             "lightStatus": "open",
             "doorStatus": "close",
             "matlStationInfo": {
                 "slotCnt": 4,
+                "currentSlot": 2,
                 "slotInfos": [
                     {"slotId": 1, "hasFilament": True, "materialName": "PLA", "materialColor": "#FCEBD7"},
                     {"slotId": 2, "hasFilament": True, "materialName": "PLA", "materialColor": "#FFFFFF"},
@@ -46,15 +57,99 @@ def _detail_payload() -> dict:
     }
 
 
-def test_is_flashforge_model():
-    assert is_flashforge_model("Creator 5 Pro")
-    assert is_flashforge_model("FlashForge Creator 5 Pro")
-    assert not is_flashforge_model("Bambu Lab P1S")
-    assert not is_flashforge_model(None)
+@pytest.mark.parametrize(
+    "model",
+    [
+        "Creator 5 Pro",
+        "Creator5Pro",
+        " FlashForge Creator 5 Pro ",
+        "flashforge creator 5 pro",
+    ],
+)
+def test_is_flashforge_model_accepts_supported_flashforge_names(model):
+    assert is_flashforge_model(model)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "Bambu Lab P1S",
+        "Flashforge Adventurer 5M",
+        "FlashForge AD5X",
+        "Creator Pro",
+        "Creator 5",
+        "SomeFuturePrinter",
+        "",
+        None,
+    ],
+)
+def test_is_flashforge_model_rejects_unconfirmed_models(model):
+    assert not is_flashforge_model(model)
+
+
+def test_flashforge_seconds_are_converted_to_bambuddy_minutes():
+    assert _seconds_to_minutes(5798) == 97
+    assert _seconds_to_minutes(30) == 1
+    assert _seconds_to_minutes(0) == 0
+
+
+def test_flashforge_remaining_time_prefers_total_estimate_over_stale_remaining_time():
+    detail = _detail_payload()["detail"]
+    detail.update(
+        {
+            "printProgress": 86,
+            "estimatedTime": 41979,
+            "printDuration": 35576,
+            "remainingTime": 358800,
+        }
+    )
+
+    assert _remaining_minutes(detail, "RUNNING") == 97
+
+
+def test_flashforge_remaining_time_uses_progress_when_estimate_is_missing():
+    detail = _detail_payload()["detail"]
+    detail.update(
+        {
+            "printProgress": 50,
+            "estimatedTime": 0,
+            "printDuration": 3600,
+            "remainingTime": 999999,
+        }
+    )
+
+    assert _remaining_minutes(detail, "RUNNING") == 60
+
+
+def test_flashforge_remaining_time_accepts_remaining_time_when_it_is_plausible():
+    detail = _detail_payload()["detail"]
+    detail.update(
+        {
+            "printProgress": 50,
+            "estimatedTime": 7200,
+            "printDuration": 3600,
+            "remainingTime": 3300,
+        }
+    )
+
+    assert _remaining_minutes(detail, "RUNNING") == 55
+
+
+@pytest.mark.parametrize(
+    ("percent", "level"),
+    [
+        (50, 1),
+        (100, 2),
+        (124, 3),
+        (166, 4),
+    ],
+)
+def test_flashforge_speed_percent_maps_to_bambuddy_speed_level(percent, level):
+    assert _speed_percent_to_level(percent) == level
 
 
 def test_apply_detail_maps_creator_5_pro_status():
-    client = FlashForgeLocalClient("192.168.0.211", "SN123", "code", model="Creator 5 Pro")
+    client = FlashForgeLocalClient("192.0.2.211", "SN123", "code", model="Creator 5 Pro")
 
     client._apply_detail(_detail_payload()["detail"])
 
@@ -63,7 +158,7 @@ def test_apply_detail_maps_creator_5_pro_status():
     assert client.state.current_print == "colored_cow.gcode.3mf"
     assert client.state.gcode_file == "colored_cow.gcode.3mf"
     assert client.state.progress == 25
-    assert client.state.remaining_time == 1234
+    assert client.state.remaining_time == 13
     assert client.state.layer_num == 12
     assert client.state.total_layers == 100
     assert client.state.firmware_version == "1.9.3"
@@ -71,17 +166,268 @@ def test_apply_detail_maps_creator_5_pro_status():
     assert client.state.temperatures == {
         "nozzle": 209,
         "nozzle_target": 210,
+        "nozzle_heating": False,
         "bed": 59,
         "bed_target": 60,
+        "bed_heating": False,
         "chamber": 29,
+        "chamber_target": 45,
+        "chamber_heating": True,
     }
     assert client.state.cooling_fan_speed == 70
+    assert client.state.speed_level == 3
     assert client.state.chamber_light is True
     assert client.state.door_open is False
+    assert client.state.sdcard is True
+    assert client.state.tray_now == 1
     assert client.state.raw_data["vendor"] == "flashforge"
+    assert client.state.raw_data["estimated_time_seconds"] == 1234
+    assert client.state.raw_data["print_duration_seconds"] == 456
     assert client.state.raw_data["ams"][0]["module_type"] == "flashforge_ifs"
     assert client.state.raw_data["ams"][0]["tray"][0]["tray_type"] == "PLA"
     assert client.state.raw_data["ams"][0]["tray"][0]["tray_color"] == "FCEBD7FF"
+    assert client.state.hms_errors == []
+
+
+def test_apply_detail_maps_flashforge_error_to_hms_error():
+    client = FlashForgeLocalClient("192.0.2.211", "SN123", "code", model="Creator 5 Pro")
+    detail = _detail_payload()["detail"]
+    detail["status"] = "error"
+    detail["errorCode"] = 42
+    detail["errorMessage"] = "Platform blocked"
+
+    client._apply_detail(detail)
+
+    assert client.state.state == "FAILED"
+    assert len(client.state.hms_errors) == 1
+    assert client.state.hms_errors[0].code == "42"
+    assert client.state.hms_errors[0].severity == 2
+    assert client.state.hms_errors[0].message == "Platform blocked"
+
+
+def test_flashforge_initial_running_poll_does_not_emit_print_start():
+    starts = []
+    client = FlashForgeLocalClient(
+        "192.0.2.211",
+        "SN123",
+        "code",
+        model="Creator 5 Pro",
+        on_print_start=lambda payload: starts.append(payload),
+    )
+
+    client._apply_detail(_detail_payload()["detail"])
+
+    assert starts == []
+
+
+def test_flashforge_idle_to_running_emits_print_start_after_initial_poll():
+    starts = []
+    client = FlashForgeLocalClient(
+        "192.0.2.211",
+        "SN123",
+        "code",
+        model="Creator 5 Pro",
+        on_print_start=lambda payload: starts.append(payload),
+    )
+    idle_detail = _detail_payload()["detail"]
+    idle_detail["status"] = "ready"
+    idle_detail["printFileName"] = None
+
+    client._apply_detail(idle_detail)
+    client._apply_detail(_detail_payload()["detail"])
+
+    assert len(starts) == 1
+    assert starts[0]["filename"] == "colored_cow.gcode.3mf"
+    assert starts[0]["subtask_name"] == "colored_cow.gcode.3mf"
+    assert starts[0]["remaining_time"] == 13 * 60
+    assert starts[0]["progress"] == 25
+    assert starts[0]["last_layer_num"] == 12
+    assert starts[0]["raw_data"]["vendor"] == "flashforge"
+
+
+def test_flashforge_finish_emits_completion_with_last_filename_when_terminal_payload_omits_file():
+    completions = []
+    client = FlashForgeLocalClient(
+        "192.0.2.211",
+        "SN123",
+        "code",
+        model="Creator 5 Pro",
+        on_print_complete=lambda payload: completions.append(payload),
+    )
+
+    running_detail = _detail_payload()["detail"]
+    idle_detail = _detail_payload()["detail"]
+    idle_detail["status"] = "ready"
+    idle_detail["printFileName"] = None
+    finish_detail = _detail_payload()["detail"]
+    finish_detail["status"] = "finish"
+    finish_detail["printFileName"] = None
+
+    client._apply_detail(idle_detail)
+    client._apply_detail(running_detail)
+    client._apply_detail(finish_detail)
+
+    assert len(completions) == 1
+    assert completions[0]["status"] == "completed"
+    assert completions[0]["filename"] == "colored_cow.gcode.3mf"
+    assert completions[0]["subtask_name"] == "colored_cow.gcode.3mf"
+    assert completions[0]["remaining_time"] is None
+
+
+def test_flashforge_completed_job_reports_done_even_when_estimate_remains():
+    client = FlashForgeLocalClient("192.0.2.211", "SN123", "code", model="Creator 5 Pro")
+    detail = _detail_payload()["detail"]
+    detail.update(
+        {
+            "status": "completed",
+            "printProgress": 0.0,
+            "estimatedTime": 41979,
+            "printDuration": 35576,
+            "printLayer": 750,
+            "targetPrintLayer": 750,
+        }
+    )
+
+    client._apply_detail(detail)
+
+    assert client.state.state == "FINISH"
+    assert client.state.progress == 100.0
+    assert client.state.remaining_time == 0
+    assert client.state.raw_data["estimated_time_seconds"] == 41979
+    assert client.state.raw_data["print_duration_seconds"] == 35576
+
+
+def test_flashforge_failure_event_includes_hms_errors():
+    completions = []
+    client = FlashForgeLocalClient(
+        "192.0.2.211",
+        "SN123",
+        "code",
+        model="Creator 5 Pro",
+        on_print_complete=lambda payload: completions.append(payload),
+    )
+    idle_detail = _detail_payload()["detail"]
+    idle_detail["status"] = "ready"
+    running_detail = _detail_payload()["detail"]
+    failed_detail = _detail_payload()["detail"]
+    failed_detail["status"] = "error"
+    failed_detail["errorCode"] = 42
+    failed_detail["errorMessage"] = "Platform blocked"
+
+    client._apply_detail(idle_detail)
+    client._apply_detail(running_detail)
+    client._apply_detail(failed_detail)
+
+    assert len(completions) == 1
+    assert completions[0]["status"] == "failed"
+    assert completions[0]["hms_errors"] == [
+        {"code": "42", "attr": 42, "module": 0, "severity": 2, "message": "Platform blocked"}
+    ]
+
+
+def test_flashforge_job_control_commands_use_local_control_endpoint():
+    client = FlashForgeLocalClient("192.0.2.211", "SN123", "code", model="Creator 5 Pro")
+    calls = []
+
+    def fake_post(path, payload, timeout=5):
+        calls.append((path, payload, timeout))
+        return {"code": 0}
+
+    client._post_json = fake_post
+
+    assert client.pause_print() is True
+    assert client.resume_print() is True
+    assert client.stop_print() is True
+
+    assert [call[0] for call in calls] == ["control", "control", "control"]
+    assert [call[1]["payload"]["args"]["action"] for call in calls] == ["pause", "continue", "cancel"]
+    assert all(call[1]["payload"]["cmd"] == "jobCtl_cmd" for call in calls)
+
+
+def test_flashforge_chamber_light_uses_local_control_endpoint():
+    client = FlashForgeLocalClient("192.0.2.211", "SN123", "code", model="Creator 5 Pro")
+    calls = []
+
+    def fake_post(path, payload, timeout=5):
+        calls.append((path, payload, timeout))
+        return {"code": 0}
+
+    client._post_json = fake_post
+
+    assert client.set_chamber_light(False) is True
+    assert client.set_chamber_light(True) is True
+
+    assert [call[0] for call in calls] == ["control", "control"]
+    assert [call[1]["payload"]["cmd"] for call in calls] == ["lightControl_cmd", "lightControl_cmd"]
+    assert [call[1]["payload"]["args"]["status"] for call in calls] == ["close", "open"]
+
+
+def test_flashforge_print_speed_uses_local_control_endpoint():
+    client = FlashForgeLocalClient("192.0.2.211", "SN123", "code", model="Creator 5 Pro")
+    calls = []
+
+    def fake_post(path, payload, timeout=5):
+        calls.append((path, payload, timeout))
+        return {"code": 0}
+
+    client._post_json = fake_post
+
+    assert client.set_print_speed(1) is True
+    assert client.set_print_speed(2) is True
+    assert client.set_print_speed(3) is True
+    assert client.set_print_speed(4) is True
+    assert client.set_print_speed(5) is False
+
+    assert [call[0] for call in calls] == ["control", "control", "control", "control"]
+    assert [call[1]["payload"]["cmd"] for call in calls] == ["printerCtl_cmd"] * 4
+    assert [call[1]["payload"]["args"]["speed"] for call in calls] == [50, 100, 124, 166]
+
+
+def test_flashforge_temperature_uses_local_control_endpoint():
+    client = FlashForgeLocalClient("192.0.2.211", "SN123", "code", model="Creator 5 Pro")
+    calls = []
+
+    def fake_post(path, payload, timeout=5):
+        calls.append((path, payload, timeout))
+        return {"code": 0}
+
+    client._post_json = fake_post
+
+    assert client.set_temperature("nozzle", 205) is True
+    assert client.set_temperature("bed", 60) is True
+    assert client.set_temperature("chamber", 35) is True
+    assert client.set_temperature("laser", 12) is False
+
+    assert [call[0] for call in calls] == ["control", "control", "control"]
+    assert [call[1]["payload"]["cmd"] for call in calls] == ["temperatureCtl_cmd"] * 3
+    assert [call[1]["payload"]["args"] for call in calls] == [
+        {"nozzle": 205},
+        {"platform": 60},
+        {"chamber": 35},
+    ]
+
+
+def test_flashforge_start_print_uses_print_gcode_endpoint():
+    client = FlashForgeLocalClient("192.0.2.211", "SN123", "code", model="Creator 5 Pro")
+    calls = []
+
+    def fake_post(path, payload, timeout=5):
+        calls.append((path, payload, timeout))
+        if path == "detail":
+            return {"code": 0, "detail": {"firmwareVersion": "1.9.3"}}
+        return {"code": 0}
+
+    client._post_json = fake_post
+
+    assert client.start_print("/cache/test_cube.gcode.3mf", bed_levelling=False) is True
+
+    assert calls[1][0] == "printGcode"
+    assert calls[1][1] == {
+        "serialNumber": "SN123",
+        "checkCode": "code",
+        "fileName": "test_cube.gcode.3mf",
+        "levelingBeforePrint": False,
+    }
 
 
 @pytest.mark.asyncio
@@ -90,9 +436,120 @@ async def test_flashforge_connection_probe_uses_detail_endpoint():
     response.__enter__.return_value.read.return_value = json.dumps(_detail_payload()).encode()
 
     with patch("backend.app.services.flashforge_local.urlopen", return_value=response) as urlopen_mock:
-        result = await probe_flashforge_connection("192.168.0.211", "SN123", "code")
+        result = await probe_flashforge_connection("192.0.2.211", "SN123", "code")
 
     assert result == {"success": True, "state": "RUNNING", "model": "Creator 5 Pro"}
     request = urlopen_mock.call_args.args[0]
-    assert request.full_url == "http://192.168.0.211:8898/detail"
+    assert request.full_url == "http://192.0.2.211:8898/detail"
     assert json.loads(request.data.decode()) == {"serialNumber": "SN123", "checkCode": "code"}
+
+
+def test_upload_flashforge_file_uses_upload_gcode_endpoint(tmp_path, monkeypatch):
+    source = tmp_path / "cube.gcode.3mf"
+    source.write_bytes(b"print data")
+    seen = {}
+
+    def fake_post(url, headers, files, timeout):
+        seen["url"] = url
+        seen["headers"] = headers
+        seen["files"] = files
+        seen["timeout"] = timeout
+        return MagicMock(json=lambda: {"code": 0})
+
+    monkeypatch.setattr("backend.app.services.flashforge_local.httpx.post", fake_post)
+
+    progress = []
+    result = upload_flashforge_file(
+        "192.0.2.211",
+        "SN123",
+        "code",
+        source,
+        "/cache/cube.gcode.3mf",
+        progress_callback=lambda uploaded, total: progress.append((uploaded, total)),
+    )
+
+    assert result is True
+    assert seen["url"] == "http://192.0.2.211:8898/uploadGcode"
+    assert seen["headers"]["serialNumber"] == "SN123"
+    assert seen["headers"]["checkCode"] == "code"
+    assert seen["headers"]["printNow"] == "false"
+    assert seen["headers"]["materialMappings"] == "W10="
+    assert seen["files"]["gcodeFile"][0] == "cube.gcode.3mf"
+    assert progress == [(0, len(b"print data")), (len(b"print data"), len(b"print data"))]
+
+
+def test_list_flashforge_files_maps_detail_entries(monkeypatch):
+    def fake_post(self, path, payload, timeout=5):
+        assert path == "gcodeList"
+        assert payload == {"serialNumber": "SN123", "checkCode": "code"}
+        return {
+            "code": 0,
+            "gcodeListDetail": [
+                {
+                    "gcodeFileName": "cube.gcode.3mf",
+                    "printingTime": 120,
+                    "totalFilamentWeight": 3.5,
+                    "useMatlStation": True,
+                },
+                {"gcodeFileName": "cube.gcode.3mf"},
+                {"gcodeFileName": "benchy.gcode"},
+            ],
+        }
+
+    monkeypatch.setattr(FlashForgeLocalClient, "_post_json", fake_post)
+
+    files = list_flashforge_files("192.0.2.211", "SN123", "code")
+
+    assert [file["name"] for file in files] == ["cube.gcode.3mf", "benchy.gcode"]
+    assert files[0]["printing_time"] == 120
+    assert files[0]["filament_weight"] == 3.5
+    assert files[0]["use_matl_station"] is True
+
+
+def test_list_flashforge_files_maps_string_entries(monkeypatch):
+    def fake_post(self, path, payload, timeout=5):
+        return {"code": 0, "gcodeList": ["/cache/cube.gcode.3mf", "benchy.gcode"]}
+
+    monkeypatch.setattr(FlashForgeLocalClient, "_post_json", fake_post)
+
+    files = list_flashforge_files("192.0.2.211", "SN123", "code", path="/cache")
+
+    assert files == [
+        {"name": "cube.gcode.3mf", "is_directory": False, "size": 0, "mtime": None},
+        {"name": "benchy.gcode", "is_directory": False, "size": 0, "mtime": None},
+    ]
+
+
+def test_list_flashforge_files_ignores_subdirectories(monkeypatch):
+    post = MagicMock()
+    monkeypatch.setattr(FlashForgeLocalClient, "_post_json", post)
+
+    assert list_flashforge_files("192.0.2.211", "SN123", "code", path="/model/subdir") == []
+    post.assert_not_called()
+
+
+def test_get_flashforge_current_thumbnail_prefers_gcode_thumbnail(monkeypatch):
+    png = b"\x89PNG\r\n\x1a\nimage"
+
+    def fake_post(self, path, payload, timeout=5):
+        assert path == "gcodeThumb"
+        return {"code": 0, "imageData": "iVBORw0KGgppbWFnZQ=="}
+
+    monkeypatch.setattr(FlashForgeLocalClient, "_post_json", fake_post)
+
+    assert get_flashforge_current_thumbnail("192.0.2.211", "SN123", "code", "cube.gcode.3mf") == (
+        png,
+        "image/png",
+    )
+
+
+def test_get_flashforge_storage_info_maps_remaining_disk_space(monkeypatch):
+    def fake_fetch(self):
+        return {"remainingDiskSpace": 1.5}
+
+    monkeypatch.setattr(FlashForgeLocalClient, "_fetch_detail", fake_fetch)
+
+    assert get_flashforge_storage_info("192.0.2.211", "SN123", "code") == {
+        "used_bytes": None,
+        "free_bytes": 1610612736,
+    }

--- a/backend/tests/unit/services/test_flashforge_local.py
+++ b/backend/tests/unit/services/test_flashforge_local.py
@@ -1,0 +1,98 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.app.services.flashforge_local import (
+    FlashForgeLocalClient,
+    is_flashforge_model,
+    probe_flashforge_connection,
+)
+
+
+def _detail_payload() -> dict:
+    return {
+        "code": 0,
+        "detail": {
+            "model": "Creator 5 Pro",
+            "name": "Creator 5 Pro",
+            "status": "printing",
+            "printFileName": "colored_cow.gcode.3mf",
+            "printProgress": 0.25,
+            "estimatedTime": 1234,
+            "printDuration": 456,
+            "printLayer": 12,
+            "targetPrintLayer": 100,
+            "firmwareVersion": "1.9.3",
+            "camera": 1,
+            "cameraStreamUrl": "http://192.168.0.211:8080/?action=stream",
+            "nozzleTemps": [120, 121, 180, 209],
+            "nozzleTargetTemps": [120, 120, 130, 210],
+            "platTemp": 59,
+            "platTargetTemp": 60,
+            "chamberTemp": 29,
+            "coolingFanSpeed": 70,
+            "chamberFanSpeed": 0,
+            "lightStatus": "open",
+            "doorStatus": "close",
+            "matlStationInfo": {
+                "slotCnt": 4,
+                "slotInfos": [
+                    {"slotId": 1, "hasFilament": True, "materialName": "PLA", "materialColor": "#FCEBD7"},
+                    {"slotId": 2, "hasFilament": True, "materialName": "PLA", "materialColor": "#FFFFFF"},
+                ],
+            },
+        },
+    }
+
+
+def test_is_flashforge_model():
+    assert is_flashforge_model("Creator 5 Pro")
+    assert is_flashforge_model("FlashForge Creator 5 Pro")
+    assert not is_flashforge_model("Bambu Lab P1S")
+    assert not is_flashforge_model(None)
+
+
+def test_apply_detail_maps_creator_5_pro_status():
+    client = FlashForgeLocalClient("192.168.0.211", "SN123", "code", model="Creator 5 Pro")
+
+    client._apply_detail(_detail_payload()["detail"])
+
+    assert client.state.connected is True
+    assert client.state.state == "RUNNING"
+    assert client.state.current_print == "colored_cow.gcode.3mf"
+    assert client.state.gcode_file == "colored_cow.gcode.3mf"
+    assert client.state.progress == 25
+    assert client.state.remaining_time == 1234
+    assert client.state.layer_num == 12
+    assert client.state.total_layers == 100
+    assert client.state.firmware_version == "1.9.3"
+    assert client.state.ipcam is True
+    assert client.state.temperatures == {
+        "nozzle": 209,
+        "nozzle_target": 210,
+        "bed": 59,
+        "bed_target": 60,
+        "chamber": 29,
+    }
+    assert client.state.cooling_fan_speed == 70
+    assert client.state.chamber_light is True
+    assert client.state.door_open is False
+    assert client.state.raw_data["vendor"] == "flashforge"
+    assert client.state.raw_data["ams"][0]["module_type"] == "flashforge_ifs"
+    assert client.state.raw_data["ams"][0]["tray"][0]["tray_type"] == "PLA"
+    assert client.state.raw_data["ams"][0]["tray"][0]["tray_color"] == "FCEBD7FF"
+
+
+@pytest.mark.asyncio
+async def test_flashforge_connection_probe_uses_detail_endpoint():
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = json.dumps(_detail_payload()).encode()
+
+    with patch("backend.app.services.flashforge_local.urlopen", return_value=response) as urlopen_mock:
+        result = await probe_flashforge_connection("192.168.0.211", "SN123", "code")
+
+    assert result == {"success": True, "state": "RUNNING", "model": "Creator 5 Pro"}
+    request = urlopen_mock.call_args.args[0]
+    assert request.full_url == "http://192.168.0.211:8898/detail"
+    assert json.loads(request.data.decode()) == {"serialNumber": "SN123", "checkCode": "code"}

--- a/backend/tests/unit/services/test_printer_diagnostic.py
+++ b/backend/tests/unit/services/test_printer_diagnostic.py
@@ -21,7 +21,7 @@ def _statuses(result):
 
 def _port_probe(overrides=None):
     """Sync side_effect for _check_port. Defaults: every port reachable."""
-    reachable = {8883: True, 990: True, 322: True}
+    reachable = {8883: True, 990: True, 322: True, 8898: True, 8080: True}
     reachable.update(overrides or {})
 
     def _probe(ip, port, timeout=3.0):
@@ -50,6 +50,7 @@ class _Env:
         host_ip="192.168.1.5",
         state=None,
         test_connection_success=True,
+        flashforge_connection_success=True,
         report_messages_since_connect: int | None = 5,
     ):
         self.ports = ports or _port_probe()
@@ -58,6 +59,7 @@ class _Env:
         self.host_ip = host_ip
         self.state = state
         self.test_connection_success = test_connection_success
+        self.flashforge_connection_success = flashforge_connection_success
         # ``None`` means get_client returns None (e.g. pre-add flow); an int
         # means there's a client with that counter value.
         self.report_messages_since_connect = report_messages_since_connect
@@ -78,6 +80,13 @@ class _Env:
         self._stack.enter_context(patch(f"{MOD}._detect_docker_network_mode", return_value=self.network_mode))
         self._stack.enter_context(patch(f"{MOD}._get_host_ip", return_value=self.host_ip))
         self._stack.enter_context(patch(f"{MOD}.printer_manager", manager))
+        self._stack.enter_context(
+            patch(
+                f"{MOD}.probe_flashforge_connection",
+                new_callable=AsyncMock,
+                return_value={"success": self.flashforge_connection_success},
+            )
+        )
         return self
 
     def __exit__(self, *exc):
@@ -86,7 +95,13 @@ class _Env:
 
 
 def _printer(ip="192.168.1.50", model=None):
-    return types.SimpleNamespace(id=1, ip_address=ip, model=model)
+    return types.SimpleNamespace(
+        id=1,
+        ip_address=ip,
+        model=model,
+        serial_number="FF-TEST-SERIAL",
+        access_code="ff-test-key",
+    )
 
 
 class TestSameSubnet:
@@ -244,6 +259,78 @@ class TestPreAddFlow:
         with _Env():
             result = await run_connection_diagnostic("192.168.1.50")
         assert _statuses(result)["mqtt_auth"] == "skip"
+
+
+class TestFlashForgePrinter:
+    async def test_flashforge_uses_local_api_checks(self):
+        with _Env(
+            state=_state(connected=True),
+            flashforge_connection_success=True,
+        ):
+            result = await run_connection_diagnostic(
+                "192.168.1.50",
+                printer=_printer(model="Flashforge Creator 5 Pro"),
+            )
+        s = _statuses(result)
+        assert result.overall == "ok"
+        assert s == {
+            "port_flashforge_api": "pass",
+            "port_flashforge_camera": "pass",
+            "network_mode": "pass",
+            "subnet": "pass",
+            "flashforge_auth": "pass",
+            "flashforge_polling": "pass",
+        }
+
+    async def test_flashforge_api_port_unreachable_is_a_problem(self):
+        with _Env(
+            ports=_port_probe({8898: False}),
+            state=_state(connected=True),
+        ):
+            result = await run_connection_diagnostic(
+                "192.168.1.50",
+                printer=_printer(model="Creator 5 Pro"),
+            )
+        s = _statuses(result)
+        assert result.overall == "problems"
+        assert s["port_flashforge_api"] == "fail"
+        assert s["flashforge_auth"] == "skip"
+
+    async def test_flashforge_camera_port_only_warns(self):
+        with _Env(
+            ports=_port_probe({8080: False}),
+            state=_state(connected=True),
+        ):
+            result = await run_connection_diagnostic(
+                "192.168.1.50",
+                printer=_printer(model="FlashForge Creator 5 Pro"),
+            )
+        s = _statuses(result)
+        assert result.overall == "warnings"
+        assert s["port_flashforge_camera"] == "warn"
+
+    async def test_flashforge_bad_device_key_fails_auth(self):
+        with _Env(
+            state=_state(connected=True),
+            flashforge_connection_success=False,
+        ):
+            result = await run_connection_diagnostic(
+                "192.168.1.50",
+                printer=_printer(model="FlashForge Creator 5 Pro"),
+            )
+        s = _statuses(result)
+        assert result.overall == "problems"
+        assert s["flashforge_auth"] == "fail"
+
+    async def test_flashforge_polling_fails_when_status_is_disconnected(self):
+        with _Env(state=_state(connected=False)):
+            result = await run_connection_diagnostic(
+                "192.168.1.50",
+                printer=_printer(model="FlashForge Creator 5 Pro"),
+            )
+        s = _statuses(result)
+        assert result.overall == "problems"
+        assert s["flashforge_polling"] == "fail"
 
 
 class TestExternalStorageCheck:

--- a/backend/tests/unit/services/test_printer_manager.py
+++ b/backend/tests/unit/services/test_printer_manager.py
@@ -1256,6 +1256,12 @@ class TestSupportsChamberTemp:
         """Verify P2 series printers support chamber temp."""
         assert supports_chamber_temp("P2S") is True
 
+    def test_flashforge_creator_5_pro_supported(self):
+        """Verify confirmed FlashForge models keep their real chamber sensor."""
+        assert supports_chamber_temp("Creator 5 Pro") is True
+        assert supports_chamber_temp("Creator5Pro") is True
+        assert supports_chamber_temp("FlashForge Creator 5 Pro") is True
+
     def test_h2_series_supported(self):
         """Verify H2 series printers support chamber temp."""
         assert supports_chamber_temp("H2C") is True
@@ -1388,6 +1394,11 @@ class TestSupportsDrying:
     def test_unsupported_models(self):
         """Verify models without AMS drying support return False regardless of firmware."""
         for model in ["A1", "A1MINI", "A1-MINI", "N1", "N2S"]:
+            assert supports_drying(model, "99.99.99.99") is False, f"Expected False for {model}"
+
+    def test_flashforge_models_do_not_report_ams_drying_support(self):
+        """FlashForge support has its own material station path, not Bambu AMS drying."""
+        for model in ["Creator 5 Pro", "FlashForge Creator 5 Pro", "FlashForge Adventurer 5M"]:
             assert supports_drying(model, "99.99.99.99") is False, f"Expected False for {model}"
 
     def test_unknown_models_allowed(self):

--- a/docs/flashforge-local-api.md
+++ b/docs/flashforge-local-api.md
@@ -1,0 +1,155 @@
+# FlashForge Local API Support
+
+Bambuddy can monitor and control supported FlashForge printers through the printer's LAN HTTP API. This path is intentionally separate from the Bambu MQTT/FTP path because FlashForge printers expose a different protocol and a smaller set of commands.
+
+## Supported Models
+
+The current model detection is conservative:
+
+- `Creator 5 Pro`
+- `FlashForge Creator 5 Pro`
+
+Add new models only after checking their `/detail` payload and confirming that the same upload, status, camera, and control endpoints behave the same way.
+
+## Implemented Features
+
+- Status polling through `/detail`
+- State mapping to Bambuddy states: idle, preparing, running, paused, finished, failed
+- Temperatures, targets, and heating flags for nozzle, bed, and chamber when
+  present
+- Fan percentages when present
+- Speed percentage mapped back to Bambuddy's print-speed level for UI state
+- Progress, layer count, filename, and remaining time. FlashForge reports
+  `estimatedTime` as a total job estimate, so Bambuddy derives remaining time
+  from `estimatedTime - printDuration`, uses progress and elapsed duration as
+  a sanity fallback, ignores stale/overflowed `remainingTime` values when they
+  disagree with the derived estimates, and forces completed jobs to `100%`
+  with `0` minutes remaining.
+- Material-station slots mapped to Bambuddy AMS-style tray data and labeled as
+  IFS in the frontend
+- Pause, resume, stop, and clear-error commands through local control endpoints
+- Chamber light on/off through `lightControl_cmd` with `status=open|close`
+- Print-speed mode control through `printerCtl_cmd`, mapped from Bambuddy's
+  Silent/Standard/Sport/Ludicrous modes to FlashForge speed percentages
+- Heater target control for nozzle, bed, and chamber through
+  `temperatureCtl_cmd`
+- Upload and start print through the local upload/start API
+- File listing through the local G-code list endpoint
+- File-row and current-print thumbnails when the printer exposes them
+- MJPEG camera stream and snapshot proxying through Bambuddy's normal camera
+  endpoints, including long-lived camera stream tokens
+- Camera diagnostics using the FlashForge MJPEG port (`8080`) and first-frame
+  reader instead of the Bambu RTSP/chamber-image pipeline
+- Connection diagnostics using FlashForge-specific checks for local API reachability,
+  camera reachability, saved device-key auth, and Bambuddy polling health
+- Print start, completion, failure, and stopped notifications
+- Plain-language error messages are preserved in `hms_errors[].message` when
+  the printer reports them
+
+## Known Capability Gaps
+
+FlashForge's known LAN API does not expose every Bambu feature. Bambuddy returns explicit capability booleans and unsupported reasons so the frontend can hide or disable unsupported controls instead of showing dead buttons.
+
+Currently unsupported for FlashForge:
+
+- Airduct mode control
+- Z jog / bed jog
+- Homing
+- Object skipping
+- Calibration control
+- Filament drying control
+- File download
+- File deletion
+- Full 3MF preview / plate metadata
+- Directory browsing beyond the local G-code list
+- Timelapse retrieval
+
+### Live Endpoint Probe Notes
+
+Read-only probes against a Creator 5 Pro confirmed the currently known local
+endpoints:
+
+- `POST /detail`
+- `POST /product`
+- `POST /gcodeList`
+- `POST /gcodeThumb` with `fileName`
+- `GET /getThum`
+
+The same probe found no working file-download or file-info endpoint among:
+
+- `downloadGcode`, `downloadGCode`, `gcodeDownload`
+- `getGcode`, `getGCode`, `getGcodeFile`
+- `downloadFile`, `fileDownload`, `getFile`
+- `gcodeFile`, `gcodeInfo`, `getFileInfo`, `gcodeDetail`, `getGcodeDetail`
+
+The probe also found no working timelapse/video list or download endpoint among:
+
+- `timelapseList`, `timeLapseList`, `getTimelapseList`, `getTimeLapseList`
+- `listTimelapse`, `listTimeLapse`, `timelapse`, `timeLapse`
+- `videoList`, `getVideoList`, `recordList`, `getRecordList`
+- `cameraRecordList`, `getCameraRecordList`, `movieList`, `getMovieList`
+- `mediaList`, `getMediaList`, `downloadTimelapse`, `downloadTimeLapse`
+- `getTimelapse`, `getTimeLapse`, `videoDownload`, `downloadVideo`, `getVideo`
+
+All probed download/info/timelapse candidates either returned HTTP 404 or no
+response, while the known endpoints above responded successfully. Treat the
+unsupported file-download/delete/preview/timelapse capabilities as confirmed
+gaps for this firmware unless a different endpoint is captured from FlashMaker
+or FlashPrint traffic.
+
+If a future firmware or model exposes one of these features, add the command in the FlashForge client first, then enable the corresponding capability only for the confirmed model/firmware combination.
+
+## Capability Contract
+
+The main printer status response includes `capabilities`, using `PrinterCapabilities` from `backend/app/schemas/printer.py`.
+
+For FlashForge printers, unsupported fields are set to `false` and include an explanation in `unsupported_reasons`.
+
+The file manager response also includes a smaller `capabilities` object:
+
+```json
+{
+  "can_download": false,
+  "can_delete": false,
+  "can_preview": false,
+  "can_browse_directories": false,
+  "unsupported_reason": "FlashForge's known LAN API exposes file listing/upload, but not direct file download, delete, preview, or directory browsing."
+}
+```
+
+## Code Map
+
+- Local API client: `backend/app/services/flashforge_local.py`
+- Printer status and capability responses: `backend/app/api/routes/printers.py`
+- Camera stream/snapshot proxy: `backend/app/api/routes/camera.py`
+- Camera diagnostics: `backend/app/services/camera_diagnose.py`
+- Connection diagnostics: `backend/app/services/printer_diagnostic.py`
+- File-list/upload routing: `backend/app/services/bambu_ftp.py`
+- Frontend capability gates: `frontend/src/pages/PrintersPage.tsx`
+- File manager read-only handling: `frontend/src/components/FileManagerModal.tsx`
+- Embedded camera gates: `frontend/src/components/EmbeddedCameraViewer.tsx`
+- Overlay camera token handling: `frontend/src/pages/StreamOverlayPage.tsx`
+
+## Test Coverage
+
+Focused FlashForge tests live in:
+
+- `backend/tests/unit/services/test_flashforge_local.py`
+- `backend/tests/unit/services/test_bambu_ftp.py`
+- `backend/tests/unit/services/test_camera_diagnose.py`
+- `backend/tests/unit/services/test_printer_diagnostic.py`
+- `backend/tests/integration/test_camera_api.py`
+- `backend/tests/integration/test_printers_api.py`
+- `frontend/src/__tests__/components/CameraDiagnoseModal.test.tsx`
+- `frontend/src/__tests__/components/EmbeddedCameraViewer.test.tsx`
+- `frontend/src/__tests__/components/FileManagerModal.test.tsx`
+- `frontend/src/__tests__/pages/PrintersPage.test.tsx`
+- `frontend/src/__tests__/pages/StreamOverlayPage.test.tsx`
+
+Useful focused checks:
+
+```bash
+.venv/bin/ruff check backend/app/services/flashforge_local.py backend/app/services/camera_diagnose.py backend/app/api/routes/camera.py backend/app/api/routes/printers.py backend/app/schemas/printer.py
+.venv/bin/python -m pytest -q backend/tests/unit/services/test_flashforge_local.py backend/tests/unit/services/test_bambu_ftp.py backend/tests/unit/services/test_camera_diagnose.py backend/tests/integration/test_camera_api.py backend/tests/integration/test_printers_api.py -k "flashforge or FlashForge"
+cd frontend && npm test -- --run src/__tests__/components/CameraDiagnoseModal.test.tsx src/__tests__/components/EmbeddedCameraViewer.test.tsx src/__tests__/components/FileManagerModal.test.tsx src/__tests__/pages/PrintersPage.test.tsx src/__tests__/pages/StreamOverlayPage.test.tsx
+```

--- a/frontend/public/img/printers/flashforge-creator5pro.svg
+++ b/frontend/public/img/printers/flashforge-creator5pro.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320" role="img" aria-labelledby="title desc">
+  <title id="title">FlashForge Creator 5 Pro</title>
+  <desc id="desc">Stylized enclosed dual-extruder 3D printer silhouette.</desc>
+  <defs>
+    <linearGradient id="case" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#4b5563"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="glass" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#1f2937"/>
+      <stop offset="1" stop-color="#020617"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#10b981"/>
+      <stop offset="1" stop-color="#0f766e"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="320" rx="40" fill="#0b1120"/>
+  <path d="M73 57h174c14 0 25 11 25 25v180H48V82c0-14 11-25 25-25Z" fill="url(#case)"/>
+  <path d="M83 83h154c8 0 14 6 14 14v127c0 8-6 14-14 14H83c-8 0-14-6-14-14V97c0-8 6-14 14-14Z" fill="url(#glass)" stroke="#6b7280" stroke-width="5"/>
+  <path d="M91 105h138v111H91z" fill="#020617"/>
+  <path d="M108 118h104v9H108z" fill="#9ca3af"/>
+  <path d="M119 126h34v24h-34z" fill="#374151"/>
+  <path d="M168 126h34v24h-34z" fill="#374151"/>
+  <path d="M129 150h14l-4 18h-6zM178 150h14l-4 18h-6z" fill="#d1d5db"/>
+  <path d="M100 210h120l-10 16H110z" fill="#111827" stroke="#4b5563" stroke-width="4"/>
+  <path d="M48 245h224v28c0 8-6 14-14 14H62c-8 0-14-6-14-14z" fill="#111827"/>
+  <path d="M72 258h48v10H72z" fill="url(#accent)"/>
+  <circle cx="238" cy="263" r="10" fill="#10b981"/>
+  <path d="M250 75v158" stroke="#111827" stroke-width="8" opacity=".5"/>
+  <path d="M69 97 250 86" stroke="#ffffff" stroke-width="7" opacity=".08"/>
+</svg>

--- a/frontend/src/__tests__/components/CameraDiagnoseModal.test.tsx
+++ b/frontend/src/__tests__/components/CameraDiagnoseModal.test.tsx
@@ -99,6 +99,30 @@ describe('CameraDiagnoseModal', () => {
     spy.mockRestore();
   });
 
+  it('renders FlashForge MJPEG diagnostic metadata', async () => {
+    const okResult: CameraDiagnoseResult = {
+      printer_id: 5,
+      protocol: 'flashforge_mjpeg',
+      port: 8080,
+      profile: 'default',
+      overall_status: 'ok',
+      stages: [
+        { name: 'tcp_reachable', status: 'ok', duration_ms: 10, code: null },
+        { name: 'first_frame', status: 'ok', duration_ms: 120, code: null },
+      ],
+      summary_code: 'all_ok',
+    };
+    const spy = vi.spyOn(api, 'diagnoseCamera').mockResolvedValue(okResult);
+
+    renderModal();
+
+    expect(await screen.findByText('flashforge_mjpeg')).toBeInTheDocument();
+    expect(screen.getByText('8080')).toBeInTheDocument();
+    expect(screen.getByText('default')).toBeInTheDocument();
+
+    spy.mockRestore();
+  });
+
   it('re-runs the diagnostic when the user clicks Run again', async () => {
     const okResult: CameraDiagnoseResult = {
       printer_id: 1,

--- a/frontend/src/__tests__/components/EmbeddedCameraViewer.test.tsx
+++ b/frontend/src/__tests__/components/EmbeddedCameraViewer.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import { EmbeddedCameraViewer } from '../../components/EmbeddedCameraViewer';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { ThemeProvider } from '../../contexts/ThemeContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import i18n from '../../i18n';
+import { server } from '../mocks/server';
+
+vi.stubGlobal('navigator', {
+  ...navigator,
+  sendBeacon: vi.fn().mockReturnValue(true),
+});
+
+function renderEmbeddedCameraViewer() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>
+      <I18nextProvider i18n={i18n}>
+        <MemoryRouter>
+          <AuthProvider>
+            <ThemeProvider>
+              <ToastProvider>
+                <EmbeddedCameraViewer
+                  printerId={2}
+                  printerName="Creator 5 Pro"
+                  onClose={() => {}}
+                />
+              </ToastProvider>
+            </ThemeProvider>
+          </AuthProvider>
+        </MemoryRouter>
+      </I18nextProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('EmbeddedCameraViewer', () => {
+  it('waits for a stream token before rendering the camera stream when auth is enabled', async () => {
+    let resolveToken!: () => void;
+    const tokenGate = new Promise<void>((resolve) => {
+      resolveToken = resolve;
+    });
+
+    server.use(
+      http.get('*/api/v1/auth/status', () =>
+        HttpResponse.json({ auth_enabled: true, requires_setup: false })
+      ),
+      http.get('/api/v1/printers/:id', () =>
+        HttpResponse.json({
+          id: 2,
+          name: 'Creator 5 Pro',
+          ip_address: '192.0.2.211',
+          serial_number: 'FF-TEST-SERIAL',
+          access_code: 'ff-test-key',
+          model: 'FlashForge Creator 5 Pro',
+          enabled: true,
+          camera_rotation: 0,
+        })
+      ),
+      http.get('/api/v1/printers/:id/status', () =>
+        HttpResponse.json({
+          connected: true,
+          state: 'IDLE',
+          progress: 0,
+          capabilities: {
+            can_chamber_light: false,
+            can_skip_objects: false,
+          },
+        })
+      ),
+      http.get('/api/v1/printers/:id/camera/status', () =>
+        HttpResponse.json({ active: false, stalled: false })
+      ),
+      http.post('/api/v1/printers/:id/camera/stop', () =>
+        HttpResponse.json({ success: true })
+      ),
+      http.post('*/api/v1/printers/camera/stream-token', async () => {
+        await tokenGate;
+        return HttpResponse.json({ token: 'embedded-token' });
+      })
+    );
+
+    renderEmbeddedCameraViewer();
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('Creator 5 Pro');
+    });
+    expect(document.querySelector('img[alt="Camera stream"]')).toBeNull();
+
+    resolveToken();
+
+    await waitFor(() => {
+      const img = document.querySelector('img[alt="Camera stream"]') as HTMLImageElement | null;
+      expect(img).not.toBeNull();
+      expect(img?.getAttribute('src')).toContain('/api/v1/printers/2/camera/stream');
+      expect(img?.getAttribute('src')).toContain('token=embedded-token');
+    });
+  });
+});

--- a/frontend/src/__tests__/components/FileManagerModal.test.tsx
+++ b/frontend/src/__tests__/components/FileManagerModal.test.tsx
@@ -250,6 +250,55 @@ describe('FileManagerModal', () => {
         expect(screen.getByText('Select All')).toBeInTheDocument();
       });
     });
+
+    it('renders FlashForge-style read-only printer files without bulk actions', async () => {
+      server.use(
+        http.get('/api/v1/printers/:id/files', () => {
+          return HttpResponse.json({
+            files: [
+              {
+                name: 'cube.gcode.3mf',
+                path: '/cube.gcode.3mf',
+                size: 0,
+                is_directory: false,
+                mtime: null,
+                printing_time: 7200,
+                filament_weight: 15.2,
+                thumbnail_url: '/api/v1/printers/2/files/thumbnail?path=/cube.gcode.3mf',
+              },
+            ],
+            capabilities: {
+              can_download: false,
+              can_delete: false,
+              can_preview: false,
+              can_browse_directories: false,
+              unsupported_reason: 'FlashForge local API exposes file listing only.',
+            },
+          });
+        })
+      );
+
+      render(
+        <FileManagerModal
+          printerId={2}
+          printerName="Creator 5 Pro"
+          onClose={mockOnClose}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('cube.gcode.3mf')).toBeInTheDocument();
+      });
+
+      expect(document.querySelector('img[src*="/files/thumbnail"]')).toBeInTheDocument();
+      expect(screen.getByText('2h · 15.2g')).toBeInTheDocument();
+      expect(screen.getByText('Size unavailable')).toBeInTheDocument();
+      expect(screen.queryByText('0 B')).not.toBeInTheDocument();
+      expect(screen.getByText('FlashForge local API exposes file listing only.')).toBeInTheDocument();
+      expect(screen.queryByText('Select All')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Download/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
+    });
   });
 
   describe('search and filter', () => {

--- a/frontend/src/__tests__/pages/CameraPage.test.tsx
+++ b/frontend/src/__tests__/pages/CameraPage.test.tsx
@@ -136,6 +136,31 @@ describe('CameraPage', () => {
       });
       expect(screen.getByTitle('Diagnose')).toBeInTheDocument();
     });
+
+    it('hides unsupported Bambu-only controls when capabilities say they are unavailable', async () => {
+      server.use(
+        http.get('/api/v1/printers/:id/status', () => {
+          return HttpResponse.json({
+            connected: true,
+            state: 'RUNNING',
+            printable_objects_count: 2,
+            capabilities: {
+              can_chamber_light: false,
+              can_skip_objects: false,
+            },
+          });
+        })
+      );
+
+      renderCameraPage(1);
+
+      await waitFor(() => {
+        expect(screen.getByText('X1 Carbon')).toBeInTheDocument();
+      });
+      expect(screen.queryByTitle('Chamber Light')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Skip objects')).not.toBeInTheDocument();
+      expect(screen.getByTitle('Diagnose')).toBeInTheDocument();
+    });
   });
 
   describe('stream token handling (#979)', () => {

--- a/frontend/src/__tests__/pages/PrintersPage.test.tsx
+++ b/frontend/src/__tests__/pages/PrintersPage.test.tsx
@@ -355,6 +355,168 @@ describe('PrintersPage', () => {
       expect(screen.queryByRole('button', { name: 'Mark plate as cleared' })).not.toBeInTheDocument();
     });
 
+    it('hides unsupported Bambu-only controls while keeping supported FlashForge controls', async () => {
+      server.use(
+        http.get('/api/v1/printers/', () => {
+          return HttpResponse.json([
+            {
+              ...mockPrinters[0],
+              id: 5,
+              name: 'Creator 5 Pro',
+              model: 'Flashforge Creator 5 Pro',
+            },
+          ]);
+        }),
+        http.get('/api/v1/printers/:id/status', () => {
+          return HttpResponse.json({
+            ...mockPrinterStatus,
+            state: 'RUNNING',
+            current_print: 'cow.gcode.3mf',
+            subtask_name: 'cow.gcode.3mf',
+            gcode_file: 'cow.gcode.3mf',
+            temperatures: {
+              nozzle: 209,
+              nozzle_target: 210,
+              nozzle_heating: false,
+              bed: 60,
+              bed_target: 60,
+              bed_heating: false,
+              chamber: 25,
+              chamber_target: 35,
+              chamber_heating: false,
+            },
+            printable_objects_count: 2,
+            ams: [
+              {
+                id: 0,
+                module_type: 'flashforge_ifs',
+                tray: [
+                  { id: 0, tray_type: 'PLA', tray_color: 'FCEBD7FF', remain: 100 },
+                  { id: 1, tray_type: 'PLA', tray_color: 'FFFFFFFF', remain: 100 },
+                  { id: 2, tray_type: 'PLA', tray_color: '805003FF', remain: 100 },
+                  { id: 3, tray_type: 'PLA', tray_color: '1B1B1BFF', remain: 100 },
+                ],
+              },
+            ],
+            capabilities: {
+              can_pause: true,
+              can_resume: true,
+              can_stop: true,
+              can_clear_errors: true,
+              can_chamber_light: true,
+              can_print_speed: true,
+              can_set_temperature: true,
+              can_airduct_mode: false,
+              can_bed_jog: false,
+              can_home_axes: false,
+              can_skip_objects: false,
+              can_dry_filament: false,
+              can_calibrate: false,
+              can_upload_files: true,
+              can_list_files: true,
+              can_download_files: false,
+              can_delete_files: false,
+              can_preview_files: false,
+              can_browse_files: false,
+              can_stream_camera: true,
+            },
+          });
+        })
+      );
+
+      render(<PrintersPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Creator 5 Pro')).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('cow.gcode.3mf')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('IFS-A')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+      expect(screen.getByTitle(/chamber light/i)).toBeInTheDocument();
+      expect(screen.getByTitle(/speed/i)).toBeInTheDocument();
+      expect(screen.getByTitle(/set nozzle temperature/i)).toBeInTheDocument();
+      expect(screen.queryByTitle(/skip/i)).not.toBeInTheDocument();
+    });
+
+    it('sets FlashForge target temperature from the printer card', async () => {
+      const user = userEvent.setup();
+      let requestedUrl = '';
+
+      server.use(
+        http.get('/api/v1/printers/', () => {
+          return HttpResponse.json([
+            {
+              ...mockPrinters[0],
+              id: 5,
+              name: 'Creator 5 Pro',
+              model: 'Flashforge Creator 5 Pro',
+            },
+          ]);
+        }),
+        http.get('/api/v1/printers/:id/status', () => {
+          return HttpResponse.json({
+            ...mockPrinterStatus,
+            state: 'RUNNING',
+            temperatures: {
+              nozzle: 209,
+              nozzle_target: 210,
+              nozzle_heating: false,
+              bed: 60,
+              bed_target: 60,
+              bed_heating: false,
+              chamber: 25,
+              chamber_target: 35,
+              chamber_heating: false,
+            },
+            capabilities: {
+              can_pause: true,
+              can_resume: true,
+              can_stop: true,
+              can_clear_errors: true,
+              can_chamber_light: true,
+              can_print_speed: true,
+              can_set_temperature: true,
+              can_airduct_mode: false,
+              can_bed_jog: false,
+              can_home_axes: false,
+              can_skip_objects: false,
+              can_dry_filament: false,
+              can_calibrate: false,
+              can_upload_files: true,
+              can_list_files: true,
+              can_download_files: false,
+              can_delete_files: false,
+              can_preview_files: false,
+              can_browse_files: false,
+              can_stream_camera: true,
+            },
+          });
+        }),
+        http.post('/api/v1/printers/:id/temperature', ({ request }) => {
+          requestedUrl = request.url;
+          return HttpResponse.json({ success: true, message: 'Nozzle target set to 205°C' });
+        })
+      );
+
+      render(<PrintersPage />);
+
+      await user.click(await screen.findByTitle(/set nozzle temperature/i));
+      const input = await screen.findByLabelText(/nozzle target temperature/i);
+      await user.clear(input);
+      await user.type(input, '205');
+      await user.click(screen.getByRole('button', { name: 'Set' }));
+
+      await waitFor(() => {
+        expect(requestedUrl).toContain('heater=nozzle');
+        expect(requestedUrl).toContain('target=205');
+      });
+    });
+
     it('hides plate status and action when plate-clear confirmation is disabled', async () => {
       server.use(
         http.get('/api/v1/settings/', () => {

--- a/frontend/src/__tests__/pages/StreamOverlayPage.test.tsx
+++ b/frontend/src/__tests__/pages/StreamOverlayPage.test.tsx
@@ -216,6 +216,38 @@ describe('StreamOverlayPage', () => {
   });
 
   describe('FPS configuration', () => {
+    it('does not render the stream image until a stream token arrives when auth is enabled', async () => {
+      let resolveToken!: () => void;
+      const tokenGate = new Promise<void>((resolve) => {
+        resolveToken = resolve;
+      });
+
+      server.use(
+        http.get('*/api/v1/auth/status', () =>
+          HttpResponse.json({ auth_enabled: true, requires_setup: false })
+        ),
+        http.post('*/api/v1/printers/camera/stream-token', async () => {
+          await tokenGate;
+          return HttpResponse.json({ token: 'overlay-token' });
+        })
+      );
+
+      renderOverlayPage(1);
+
+      await waitFor(() => {
+        expect(screen.getByText('Printer is idle')).toBeInTheDocument();
+      });
+      expect(screen.queryByAltText('Camera stream')).not.toBeInTheDocument();
+
+      resolveToken();
+
+      await waitFor(() => {
+        const img = screen.getByAltText('Camera stream') as HTMLImageElement;
+        expect(img.src).toContain('/api/v1/printers/1/camera/stream');
+        expect(img.src).toContain('token=overlay-token');
+      });
+    });
+
     it('uses default FPS of 15 when not specified', async () => {
       renderOverlayPage(1);
 

--- a/frontend/src/__tests__/utils/printer.test.ts
+++ b/frontend/src/__tests__/utils/printer.test.ts
@@ -11,6 +11,18 @@ import { describe, it, expect } from 'vitest';
 import { getPrinterImage } from '../../utils/printer';
 
 describe('getPrinterImage', () => {
+  describe('FlashForge Creator 5 Pro', () => {
+    it('resolves full FlashForge model names to the Creator 5 Pro artwork', () => {
+      expect(getPrinterImage('FlashForge Creator 5 Pro')).toBe('/img/printers/flashforge-creator5pro.svg');
+      expect(getPrinterImage('Flashforge Creator 5 Pro')).toBe('/img/printers/flashforge-creator5pro.svg');
+    });
+
+    it('resolves compact and printer-reported Creator 5 Pro variants', () => {
+      expect(getPrinterImage('Creator 5 Pro')).toBe('/img/printers/flashforge-creator5pro.svg');
+      expect(getPrinterImage('Creator5Pro')).toBe('/img/printers/flashforge-creator5pro.svg');
+    });
+  });
+
   describe('X2D (#988)', () => {
     it('resolves display name "X2D" to x2d.png', () => {
       expect(getPrinterImage('X2D')).toBe('/img/printers/x2d.png');

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -222,7 +222,7 @@ export interface CameraDiagnoseStage {
 
 export interface CameraDiagnoseResult {
   printer_id: number;
-  protocol: 'rtsp' | 'chamber_image';
+  protocol: 'rtsp' | 'chamber_image' | 'flashforge_mjpeg';
   port: number;
   // 'default' = historical X1/H2 tuning. Anything else = this model has
   // an override entry in backend/app/services/camera_profiles.py.
@@ -243,10 +243,16 @@ export interface DiagnosticCheck {
     | 'port_mqtt'
     | 'port_ftps'
     | 'port_rtsps'
+    | 'port_flashforge_api'
+    | 'port_flashforge_camera'
     | 'network_mode'
     | 'subnet'
+    | 'external_storage'
     | 'mqtt_auth'
-    | 'developer_mode';
+    | 'developer_mode'
+    | 'printer_publishing'
+    | 'flashforge_auth'
+    | 'flashforge_polling';
   status: DiagnosticStatus;
   params: Record<string, string | number>;
 }
@@ -330,6 +336,7 @@ export interface HMSError {
   attr: number;  // Attribute value for constructing wiki URL
   module: number;
   severity: number;  // 1=fatal, 2=serious, 3=common, 4=info
+  message?: string | null;
 }
 
 export interface AMSTray {
@@ -504,6 +511,31 @@ export interface PrinterStatus {
   awaiting_plate_clear: boolean;
   // AMS drying support
   supports_drying: boolean;
+  capabilities?: PrinterCapabilities;
+}
+
+export interface PrinterCapabilities {
+  can_pause: boolean;
+  can_resume: boolean;
+  can_stop: boolean;
+  can_clear_errors: boolean;
+  can_chamber_light: boolean;
+  can_print_speed: boolean;
+  can_set_temperature: boolean;
+  can_airduct_mode: boolean;
+  can_bed_jog: boolean;
+  can_home_axes: boolean;
+  can_skip_objects: boolean;
+  can_dry_filament: boolean;
+  can_calibrate: boolean;
+  can_upload_files: boolean;
+  can_list_files: boolean;
+  can_download_files: boolean;
+  can_delete_files: boolean;
+  can_preview_files: boolean;
+  can_browse_files: boolean;
+  can_stream_camera: boolean;
+  unsupported_reasons?: Record<string, string>;
 }
 
 export interface PrinterCreate {
@@ -3524,6 +3556,12 @@ export const api = {
       method: 'POST',
     }),
 
+  setTemperature: (printerId: number, heater: 'nozzle' | 'bed' | 'chamber', target: number) =>
+    request<{ success: boolean; message: string }>(
+      `/printers/${printerId}/temperature?heater=${heater}&target=${target}`,
+      { method: 'POST' }
+    ),
+
   setAirductMode: (printerId: number, mode: 'cooling' | 'heating') =>
     request<{ success: boolean; message: string }>(`/printers/${printerId}/airduct-mode?mode=${mode}`, {
       method: 'POST',
@@ -3629,7 +3667,18 @@ export const api = {
         size: number;
         path: string;
         mtime?: string;
+        printing_time?: number | null;
+        filament_weight?: number | null;
+        use_matl_station?: boolean | null;
+        thumbnail_url?: string | null;
       }>;
+      capabilities?: {
+        can_download: boolean;
+        can_delete: boolean;
+        can_preview: boolean;
+        can_browse_directories: boolean;
+        unsupported_reason?: string | null;
+      };
     }>(`/printers/${printerId}/files?path=${encodeURIComponent(path)}`),
   getPrinterFileDownloadUrl: (printerId: number, path: string) =>
     `${API_BASE}/printers/${printerId}/files/download?path=${encodeURIComponent(path)}`,
@@ -3660,6 +3709,8 @@ export const api = {
     }>(`/printers/${printerId}/files/plates?path=${encodeURIComponent(path)}`),
   getPrinterFilePlateThumbnail: (printerId: number, plateIndex: number, path: string) =>
     withStreamToken(`${API_BASE}/printers/${printerId}/files/plate-thumbnail/${plateIndex}?path=${encodeURIComponent(path)}`),
+  getPrinterFileThumbnailUrl: (printerId: number, path: string) =>
+    withStreamToken(`${API_BASE}/printers/${printerId}/files/thumbnail?path=${encodeURIComponent(path)}`),
   downloadPrinterFile: async (printerId: number, path: string): Promise<void> => {
     const headers: Record<string, string> = {};
     if (authToken) {

--- a/frontend/src/components/ConnectionDiagnostic.tsx
+++ b/frontend/src/components/ConnectionDiagnostic.tsx
@@ -17,6 +17,31 @@ import {
   type PrinterDiagnosticResult,
 } from '../api/client';
 
+const CHECK_FALLBACKS: Partial<Record<DiagnosticCheck['id'], { title: string } & Partial<Record<DiagnosticStatus, string>>>> = {
+  port_flashforge_api: {
+    title: 'FlashForge local API (8898)',
+    pass: 'Reachable — Bambuddy can talk to the printer over the FlashForge LAN API.',
+    fail: 'Port 8898 is unreachable. The printer is powered off, on a different IP address, or a firewall is blocking the FlashForge LAN API.',
+  },
+  port_flashforge_camera: {
+    title: 'FlashForge camera (MJPEG 8080)',
+    pass: 'Reachable — the camera stream should work.',
+    warn: 'Port 8080 is unreachable. Monitoring and printing may still work, but the live camera view will not.',
+  },
+  flashforge_auth: {
+    title: 'FlashForge device key',
+    pass: 'The printer accepted the saved serial number and device key.',
+    fail: 'The printer is reachable but rejected the saved credentials. Re-copy the device key from the printer LAN page and update this printer in Bambuddy.',
+    skip: 'Not checked — the FlashForge local API could not be reached.',
+  },
+  flashforge_polling: {
+    title: 'Bambuddy polling connection',
+    pass: 'Bambuddy is receiving printer status from the FlashForge local API.',
+    fail: 'Bambuddy is not receiving printer status right now. Check the saved IP address, serial number, and device key, then restart the printer monitor if needed.',
+    skip: 'Not checked — this printer monitor is not running yet.',
+  },
+};
+
 function StatusIcon({ status }: { status: DiagnosticStatus }) {
   if (status === 'pass') return <CheckCircle2 className="w-5 h-5 text-bambu-green flex-shrink-0" />;
   if (status === 'fail') return <XCircle className="w-5 h-5 text-red-400 flex-shrink-0" />;
@@ -40,9 +65,10 @@ export function DiagnosticChecklist({ result }: { result: PrinterDiagnosticResul
         : 'bg-red-500/10 border-red-500/30 text-red-300';
 
   const renderCheck = (check: DiagnosticCheck) => {
+    const fallback = CHECK_FALLBACKS[check.id];
     const detail = t(`diagnostic.check.${check.id}.${check.status}`, {
       ...check.params,
-      defaultValue: '',
+      defaultValue: fallback?.[check.status] ?? '',
     });
     return (
       <li
@@ -55,7 +81,9 @@ export function DiagnosticChecklist({ result }: { result: PrinterDiagnosticResul
           <StatusIcon status={check.status} />
         </div>
         <div className="flex-1 min-w-0">
-          <div className="text-sm text-white">{t(`diagnostic.check.${check.id}.title`)}</div>
+          <div className="text-sm text-white">
+            {t(`diagnostic.check.${check.id}.title`, { defaultValue: fallback?.title ?? check.id })}
+          </div>
           {detail && <div className="text-xs text-bambu-gray mt-0.5">{detail}</div>}
         </div>
       </li>

--- a/frontend/src/components/EmbeddedCameraViewer.tsx
+++ b/frontend/src/components/EmbeddedCameraViewer.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { X, RefreshCw, AlertTriangle, Maximize2, Minimize2, GripVertical, WifiOff, ZoomIn, ZoomOut, Fullscreen, Minimize, Stethoscope } from 'lucide-react';
-import { api, getAuthToken, withStreamToken } from '../api/client';
+import { api, getAuthToken, getStreamToken, withStreamToken } from '../api/client';
 import { useToast } from '../contexts/ToastContext';
 import { useAuth } from '../contexts/AuthContext';
 import { ChamberLight } from './icons/ChamberLight';
@@ -40,7 +40,7 @@ export function EmbeddedCameraViewer({ printerId, printerName, viewerIndex = 0, 
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { showToast } = useToast();
-  const { hasPermission } = useAuth();
+  const { hasPermission, authEnabled, user } = useAuth();
 
   // Printer-specific storage key
   const storageKey = `${STORAGE_KEY_PREFIX}${printerId}`;
@@ -118,6 +118,17 @@ export function EmbeddedCameraViewer({ printerId, printerName, viewerIndex = 0, 
     refetchInterval: 30000,
     enabled: printerId > 0,
   });
+  const { data: streamTokenData } = useQuery({
+    queryKey: ['camera-stream-token', user?.id ?? null],
+    queryFn: () => api.getCameraStreamToken(),
+    enabled: printerId > 0 && (authEnabled ? !!user : true),
+    staleTime: 50 * 60 * 1000,
+  });
+  const streamTokenValue = streamTokenData?.token ?? getStreamToken();
+  const capabilities = status?.capabilities ?? {
+    can_chamber_light: true,
+    can_skip_objects: true,
+  };
 
   // Chamber light mutation with optimistic update
   const chamberLightMutation = useMutation({
@@ -555,7 +566,12 @@ export function EmbeddedCameraViewer({ printerId, printerName, viewerIndex = 0, 
     }
   }, [isDragging, isResizing, dragOffset]);
 
-  const streamUrl = withStreamToken(`/api/v1/printers/${printerId}/camera/stream?fps=15&t=${imageKey}`);
+  const waitingForStreamToken = authEnabled && !streamTokenValue;
+  const appendStreamToken = (url: string) =>
+    streamTokenValue ? `${url}&token=${encodeURIComponent(streamTokenValue)}` : withStreamToken(url);
+  const streamUrl = waitingForStreamToken
+    ? ''
+    : appendStreamToken(`/api/v1/printers/${printerId}/camera/stream?fps=15&t=${imageKey}`);
 
   return (
     <div
@@ -580,28 +596,32 @@ export function EmbeddedCameraViewer({ printerId, printerName, viewerIndex = 0, 
           <span className="truncate">{printer?.name || printerName}</span>
         </div>
         <div className="flex items-center gap-1 no-drag">
-          <button
-            onClick={() => chamberLightMutation.mutate(!status?.chamber_light)}
-            disabled={!status?.connected || chamberLightMutation.isPending || !hasPermission('printers:control')}
-            className={`p-1 rounded disabled:opacity-50 ${status?.chamber_light ? 'bg-yellow-500/20 hover:bg-yellow-500/30' : 'hover:bg-bambu-dark-tertiary'}`}
-            title={!hasPermission('printers:control') ? t('printers.permission.noControl') : t('camera.chamberLight')}
-          >
-            <ChamberLight on={status?.chamber_light ?? false} className="w-3.5 h-3.5" />
-          </button>
-          <button
-            onClick={() => setShowSkipObjectsModal(true)}
-            disabled={!isPrintingWithObjects || !hasPermission('printers:control')}
-            className={`p-1 rounded disabled:opacity-50 ${isPrintingWithObjects && hasPermission('printers:control') ? 'hover:bg-bambu-dark-tertiary' : ''}`}
-            title={
-              !hasPermission('printers:control')
-                ? t('printers.permission.noControl')
-                : !isPrintingWithObjects
-                  ? t('printers.skipObjects.onlyWhilePrinting')
-                  : t('printers.skipObjects.tooltip')
-            }
-          >
-            <SkipObjectsIcon className="w-3.5 h-3.5 text-bambu-gray" />
-          </button>
+          {capabilities.can_chamber_light && (
+            <button
+              onClick={() => chamberLightMutation.mutate(!status?.chamber_light)}
+              disabled={!status?.connected || chamberLightMutation.isPending || !hasPermission('printers:control')}
+              className={`p-1 rounded disabled:opacity-50 ${status?.chamber_light ? 'bg-yellow-500/20 hover:bg-yellow-500/30' : 'hover:bg-bambu-dark-tertiary'}`}
+              title={!hasPermission('printers:control') ? t('printers.permission.noControl') : t('camera.chamberLight')}
+            >
+              <ChamberLight on={status?.chamber_light ?? false} className="w-3.5 h-3.5" />
+            </button>
+          )}
+          {capabilities.can_skip_objects && (
+            <button
+              onClick={() => setShowSkipObjectsModal(true)}
+              disabled={!isPrintingWithObjects || !hasPermission('printers:control')}
+              className={`p-1 rounded disabled:opacity-50 ${isPrintingWithObjects && hasPermission('printers:control') ? 'hover:bg-bambu-dark-tertiary' : ''}`}
+              title={
+                !hasPermission('printers:control')
+                  ? t('printers.permission.noControl')
+                  : !isPrintingWithObjects
+                    ? t('printers.skipObjects.onlyWhilePrinting')
+                    : t('printers.skipObjects.tooltip')
+              }
+            >
+              <SkipObjectsIcon className="w-3.5 h-3.5 text-bambu-gray" />
+            </button>
+          )}
           <button
             onClick={refresh}
             disabled={streamLoading || isReconnecting}
@@ -699,22 +719,24 @@ export function EmbeddedCameraViewer({ printerId, printerName, viewerIndex = 0, 
               </div>
             </div>
           )}
-          <img
-            ref={imgRef}
-            key={imageKey}
-            src={streamUrl}
-            alt="Camera stream"
-            className="max-w-full max-h-full object-contain select-none"
-            style={{
-              transform: `scale(${zoomLevel}) translate(${panOffset.x / zoomLevel}px, ${panOffset.y / zoomLevel}px) rotate(${printer?.camera_rotation || 0}deg)`,
-              ...(printer?.camera_rotation === 90 || printer?.camera_rotation === 270 ? { maxWidth: '100%', maxHeight: '100%' } : {}),
-              cursor: zoomLevel > 1 ? (isPanning ? 'grabbing' : 'grab') : 'default',
-            }}
-            onError={handleStreamError}
-            onLoad={handleStreamLoad}
-            onMouseDown={handleImageMouseDown}
-            draggable={false}
-          />
+          {!waitingForStreamToken && (
+            <img
+              ref={imgRef}
+              key={imageKey}
+              src={streamUrl}
+              alt="Camera stream"
+              className="max-w-full max-h-full object-contain select-none"
+              style={{
+                transform: `scale(${zoomLevel}) translate(${panOffset.x / zoomLevel}px, ${panOffset.y / zoomLevel}px) rotate(${printer?.camera_rotation || 0}deg)`,
+                ...(printer?.camera_rotation === 90 || printer?.camera_rotation === 270 ? { maxWidth: '100%', maxHeight: '100%' } : {}),
+                cursor: zoomLevel > 1 ? (isPanning ? 'grabbing' : 'grab') : 'default',
+              }}
+              onError={handleStreamError}
+              onLoad={handleStreamLoad}
+              onMouseDown={handleImageMouseDown}
+              draggable={false}
+            />
+          )}
 
           {/* Zoom controls */}
           <div className="absolute bottom-2 left-2 flex items-center gap-1 bg-black/60 rounded px-1.5 py-1 no-drag">

--- a/frontend/src/components/FileManagerModal.tsx
+++ b/frontend/src/components/FileManagerModal.tsx
@@ -38,6 +38,14 @@ interface FileManagerModalProps {
   onClose: () => void;
 }
 
+type PrinterFileCapabilities = {
+  can_download: boolean;
+  can_delete: boolean;
+  can_preview: boolean;
+  can_browse_directories: boolean;
+  unsupported_reason?: string | null;
+};
+
 type PrinterViewerTab = '3d' | 'gcode';
 
 interface PrinterFileViewerModalProps {
@@ -268,6 +276,23 @@ function getFileIcon(filename: string, isDirectory: boolean) {
   }
 }
 
+function formatPrintSeconds(seconds?: number | null) {
+  if (!seconds || seconds <= 0) return null;
+  const totalMinutes = Math.max(1, Math.round(seconds / 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${minutes}m`;
+}
+
+function formatDisplayedFileSize(size: number, capabilities: PrinterFileCapabilities, unavailableLabel: string) {
+  if (size === 0 && !capabilities.can_download) {
+    return unavailableLabel;
+  }
+  return formatFileSize(size);
+}
+
 type SortOption = 'name-asc' | 'name-desc' | 'size-asc' | 'size-desc' | 'date-asc' | 'date-desc';
 
 const SORT_OPTIONS: { value: SortOption; label: string }[] = [
@@ -317,6 +342,20 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
     staleTime: 30000, // Cache for 30 seconds
   });
 
+  const capabilities = data?.capabilities ?? {
+    can_download: true,
+    can_delete: true,
+    can_preview: true,
+    can_browse_directories: true,
+    unsupported_reason: null,
+  };
+  const limitedCapabilitiesReason = capabilities.unsupported_reason
+    || t(
+      'printerFiles.limitedCapabilities',
+      'This printer exposes a read-only file list over LAN. Download, delete, and preview actions are unavailable.'
+    );
+  const sizeUnavailableLabel = t('printerFiles.sizeUnavailable', 'Size unavailable');
+
   const deleteMutation = useMutation({
     mutationFn: async (paths: string[]) => {
       // Delete files one by one
@@ -363,6 +402,7 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
 
   const selectAllFiles = () => {
     if (!data?.files) return;
+    if (!capabilities.can_download && !capabilities.can_delete) return;
     const filePaths = data.files
       .filter(f => !f.is_directory && (!searchQuery || f.name.toLowerCase().includes(searchQuery.toLowerCase())))
       .map(f => f.path);
@@ -375,6 +415,10 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
 
   const handleDownload = async () => {
     if (selectedFiles.size === 0) return;
+    if (!capabilities.can_download) {
+      showToast(t('printerFiles.toast.downloadUnsupported', 'This printer does not support wireless file downloads.'), 'error');
+      return;
+    }
 
     const paths = Array.from(selectedFiles);
 
@@ -410,6 +454,10 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
 
   const handleDelete = () => {
     if (selectedFiles.size === 0) return;
+    if (!capabilities.can_delete) {
+      showToast(t('printerFiles.toast.deleteUnsupported', 'This printer does not support wireless file deletion.'), 'error');
+      return;
+    }
     setFilesToDelete(Array.from(selectedFiles));
   };
 
@@ -474,10 +522,13 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
                 navigateToFolder(dir.path);
                 setSearchQuery('');
               }}
+              disabled={!capabilities.can_browse_directories && dir.path !== '/'}
               className={`px-3 py-1 text-sm rounded-full transition-colors ${
                 currentPath === dir.path
                   ? 'bg-bambu-green text-white'
-                  : 'bg-bambu-dark-tertiary text-bambu-gray hover:text-white'
+                  : !capabilities.can_browse_directories && dir.path !== '/'
+                    ? 'bg-bambu-dark-tertiary text-bambu-gray/40 cursor-not-allowed'
+                    : 'bg-bambu-dark-tertiary text-bambu-gray hover:text-white'
               }`}
             >
               {dir.label}
@@ -524,7 +575,7 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
         <div className="flex items-center gap-2 px-4 py-2 bg-bambu-dark text-sm flex-shrink-0">
             <button
               onClick={navigateUp}
-              disabled={currentPath === '/'}
+              disabled={currentPath === '/' || !capabilities.can_browse_directories}
               className="p-1 rounded hover:bg-bambu-dark-tertiary disabled:opacity-50 disabled:cursor-not-allowed"
               title="Go to parent folder"
               aria-label="Go to parent folder"
@@ -533,6 +584,13 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
             </button>
             <span className="text-bambu-gray font-mono">{currentPath}</span>
           </div>
+
+        {(!capabilities.can_download || !capabilities.can_delete || !capabilities.can_preview) && (
+          <div className="px-4 py-2 bg-amber-500/10 border-b border-amber-500/20 text-xs text-amber-200 flex items-center gap-2">
+            <HardDrive className="w-3.5 h-3.5 flex-shrink-0" />
+            <span>{limitedCapabilitiesReason}</span>
+          </div>
+        )}
 
         {/* File list */}
         <div className="flex-1 overflow-y-auto p-2 min-h-0">
@@ -593,13 +651,13 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
                             : 'hover:bg-bambu-dark-tertiary'
                         }`}
                         onClick={() => {
-                          if (file.is_directory) {
+                          if (file.is_directory && capabilities.can_browse_directories) {
                             navigateToFolder(file.path);
                           }
                         }}
                       >
                         {/* Checkbox for files only */}
-                        {!file.is_directory ? (
+                        {!file.is_directory && (capabilities.can_download || capabilities.can_delete) ? (
                           <button
                             onClick={(e) => toggleFileSelection(file.path, e)}
                             className="flex-shrink-0 text-bambu-gray hover:text-white"
@@ -611,18 +669,35 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
                             )}
                           </button>
                         ) : null}
-                        <FileIcon
-                          className={`w-5 h-5 flex-shrink-0 ${
-                            file.is_directory ? 'text-bambu-green' : 'text-bambu-gray'
-                          }`}
-                        />
+                        {file.thumbnail_url ? (
+                          <img
+                            src={api.getPrinterFileThumbnailUrl(printerId, file.path)}
+                            alt=""
+                            className="w-10 h-10 rounded object-cover bg-bambu-dark-tertiary flex-shrink-0"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <FileIcon
+                            className={`w-5 h-5 flex-shrink-0 ${
+                              file.is_directory ? 'text-bambu-green' : 'text-bambu-gray'
+                            }`}
+                          />
+                        )}
                         <span className="flex-1 text-white truncate">{file.name}</span>
                         {!file.is_directory && (
                           <div className="flex items-center gap-3">
+                            {(file.printing_time || file.filament_weight) && (
+                              <span className="text-xs text-bambu-gray hidden sm:inline">
+                                {[
+                                  formatPrintSeconds(file.printing_time),
+                                  file.filament_weight ? `${Number(file.filament_weight).toFixed(1)}g` : null,
+                                ].filter(Boolean).join(' · ')}
+                              </span>
+                            )}
                             <span className="text-sm text-bambu-gray">
-                              {formatFileSize(file.size)}
+                              {formatDisplayedFileSize(file.size, capabilities, sizeUnavailableLabel)}
                             </span>
-                            {(file.name.toLowerCase().endsWith('.3mf') || file.name.toLowerCase().endsWith('.gcode') || file.name.toLowerCase().endsWith('.stl')) && (
+                            {capabilities.can_preview && (file.name.toLowerCase().endsWith('.3mf') || file.name.toLowerCase().endsWith('.gcode') || file.name.toLowerCase().endsWith('.stl')) && (
                               <button
                                 onClick={(e) => {
                                   e.stopPropagation();
@@ -636,7 +711,7 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
                             )}
                           </div>
                         )}
-                        {file.is_directory && (
+                        {file.is_directory && capabilities.can_browse_directories && (
                           <ChevronLeft className="w-4 h-4 text-bambu-gray rotate-180" />
                         )}
                       </div>
@@ -658,7 +733,7 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
               }
             </div>
             {/* Select All / Deselect All */}
-            {data?.files?.some(f => !f.is_directory) && (
+            {data?.files?.some(f => !f.is_directory) && (capabilities.can_download || capabilities.can_delete) && (
               <div className="flex items-center gap-2">
                 {selectedFiles.size > 0 ? (
                   <button
@@ -683,7 +758,7 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
           <div className="flex gap-2">
             <Button
               variant="secondary"
-              disabled={selectedFiles.size === 0 || downloadProgress !== null}
+              disabled={selectedFiles.size === 0 || downloadProgress !== null || !capabilities.can_download}
               onClick={handleDownload}
             >
               {downloadProgress ? (
@@ -700,7 +775,7 @@ export function FileManagerModal({ printerId, printerName, onClose }: FileManage
             </Button>
             <Button
               variant="secondary"
-              disabled={selectedFiles.size === 0 || deleteMutation.isPending}
+              disabled={selectedFiles.size === 0 || deleteMutation.isPending || !capabilities.can_delete}
               onClick={handleDelete}
               className="text-red-400 hover:text-red-300"
             >

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -2501,6 +2501,8 @@ export default {
     noFiles: 'Keine Dateien auf dem Drucker',
     loadingFiles: 'Dateien werden geladen...',
     failedToLoad: 'Dateien konnten nicht geladen werden',
+    sizeUnavailable: "Größe nicht verfügbar",
+    limitedCapabilities: "Dieser Drucker stellt über LAN nur eine schreibgeschützte Dateiliste bereit. Download, Löschen und Vorschau sind nicht verfügbar.",
     toast: {
       filesDeleted: '{{count}} Datei(en) gelöscht',
       deleteFailed: 'Löschen fehlgeschlagen: {{error}}',
@@ -5670,6 +5672,16 @@ export default {
         pass: 'Erreichbar — der Kamerastream funktioniert.',
         warn: 'Port 322 ist nicht erreichbar. Die Live-Kameraansicht funktioniert nicht. Dies betrifft das Drucken nicht.',
       },
+      port_flashforge_api: {
+        title: "FlashForge lokale API (8898)",
+        pass: "Erreichbar — Bambuddy kann über die FlashForge-LAN-API mit dem Drucker kommunizieren.",
+        fail: "Port 8898 ist nicht erreichbar. Der Drucker ist ausgeschaltet, hat eine andere IP-Adresse oder eine Firewall blockiert die FlashForge-LAN-API.",
+      },
+      port_flashforge_camera: {
+        title: "FlashForge-Kamera (MJPEG 8080)",
+        pass: "Erreichbar — der Kamerastream sollte funktionieren.",
+        warn: "Port 8080 ist nicht erreichbar. Überwachung und Drucken können weiter funktionieren, aber die Live-Kameraansicht nicht.",
+      },
       network_mode: {
         title: 'Docker-Netzwerkmodus',
         pass: 'Läuft im Host-Netzwerkmodus.',
@@ -5693,6 +5705,18 @@ export default {
         pass: 'Der Entwicklermodus ist aktiviert.',
         fail: 'Der Entwicklermodus ist am Drucker AUS. Aktivieren Sie ihn in den LAN-Einstellungen des Druckers — und bestätigen Sie mit OK. Ohne ihn starten Drucke nicht.',
         skip: 'Konnte nicht geprüft werden — erfordert eine aktive Verbindung zum Drucker.',
+      },
+      flashforge_auth: {
+        title: "FlashForge-Geräteschlüssel",
+        pass: "Der Drucker hat die gespeicherte Seriennummer und den Geräteschlüssel akzeptiert.",
+        fail: "Der Drucker ist erreichbar, hat die gespeicherten Zugangsdaten aber abgelehnt. Kopiere den Geräteschlüssel von der LAN-Seite des Druckers erneut und aktualisiere diesen Drucker in Bambuddy.",
+        skip: "Nicht geprüft — die lokale FlashForge-API konnte nicht erreicht werden.",
+      },
+      flashforge_polling: {
+        title: "Bambuddy-Abfrageverbindung",
+        pass: "Bambuddy empfängt Druckerstatus über die lokale FlashForge-API.",
+        fail: "Bambuddy empfängt derzeit keinen Druckerstatus. Prüfe gespeicherte IP-Adresse, Seriennummer und Geräteschlüssel und starte den Druckermonitor bei Bedarf neu.",
+        skip: "Nicht geprüft — dieser Druckermonitor läuft noch nicht.",
       },
       printer_publishing: {
         title: 'Drucker sendet Statusmeldungen',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2504,6 +2504,8 @@ export default {
     noFiles: 'No files on printer',
     loadingFiles: 'Loading files...',
     failedToLoad: 'Failed to load files',
+    sizeUnavailable: 'Size unavailable',
+    limitedCapabilities: 'This printer exposes a read-only file list over LAN. Download, delete, and preview actions are unavailable.',
     toast: {
       filesDeleted: 'Deleted {{count}} file(s)',
       deleteFailed: 'Delete failed: {{error}}',
@@ -5683,6 +5685,16 @@ export default {
         pass: 'Reachable — the camera stream will work.',
         warn: 'Port 322 is unreachable. The live camera view will not work. This does not affect printing.',
       },
+      port_flashforge_api: {
+        title: 'FlashForge local API (8898)',
+        pass: 'Reachable — Bambuddy can talk to the printer over the FlashForge LAN API.',
+        fail: 'Port 8898 is unreachable. The printer is powered off, on a different IP address, or a firewall is blocking the FlashForge LAN API.',
+      },
+      port_flashforge_camera: {
+        title: 'FlashForge camera (MJPEG 8080)',
+        pass: 'Reachable — the camera stream should work.',
+        warn: 'Port 8080 is unreachable. Monitoring and printing may still work, but the live camera view will not.',
+      },
       network_mode: {
         title: 'Docker network mode',
         pass: 'Running in host network mode.',
@@ -5706,6 +5718,18 @@ export default {
         pass: 'Developer Mode is enabled.',
         fail: 'Developer Mode is OFF on the printer. Enable it in the printer\'s LAN settings — and confirm with OK. Without it, prints will not start.',
         skip: 'Could not be checked — requires a live connection to the printer.',
+      },
+      flashforge_auth: {
+        title: 'FlashForge device key',
+        pass: 'The printer accepted the saved serial number and device key.',
+        fail: 'The printer is reachable but rejected the saved credentials. Re-copy the device key from the printer LAN page and update this printer in Bambuddy.',
+        skip: 'Not checked — the FlashForge local API could not be reached.',
+      },
+      flashforge_polling: {
+        title: 'Bambuddy polling connection',
+        pass: 'Bambuddy is receiving printer status from the FlashForge local API.',
+        fail: 'Bambuddy is not receiving printer status right now. Check the saved IP address, serial number, and device key, then restart the printer monitor if needed.',
+        skip: 'Not checked — this printer monitor is not running yet.',
       },
       printer_publishing: {
         title: 'Printer is publishing status',

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -2504,6 +2504,8 @@ export default {
     noFiles: 'No hay archivos en la impresora',
     loadingFiles: 'Cargando archivos...',
     failedToLoad: 'Error al cargar los archivos',
+    sizeUnavailable: "Tamaño no disponible",
+    limitedCapabilities: "Esta impresora expone por LAN una lista de archivos de solo lectura. Las acciones de descarga, eliminación y vista previa no están disponibles.",
     toast: {
       filesDeleted: 'Se eliminaron {{count}} archivo(s)',
       deleteFailed: 'Error al eliminar: {{error}}',
@@ -5679,6 +5681,16 @@ export default {
         pass: 'Accesible — la transmisión de la cámara funcionará.',
         warn: 'El puerto 322 no es accesible. La vista de la cámara en directo no funcionará. Esto no afecta a la impresión.',
       },
+      port_flashforge_api: {
+        title: "API local de FlashForge (8898)",
+        pass: "Accesible — Bambuddy puede comunicarse con la impresora mediante la API LAN de FlashForge.",
+        fail: "No se puede acceder al puerto 8898. La impresora está apagada, usa otra dirección IP o un firewall bloquea la API LAN de FlashForge.",
+      },
+      port_flashforge_camera: {
+        title: "Cámara FlashForge (MJPEG 8080)",
+        pass: "Accesible — la transmisión de la cámara debería funcionar.",
+        warn: "No se puede acceder al puerto 8080. La supervisión y la impresión podrían seguir funcionando, pero la vista de cámara en directo no.",
+      },
       network_mode: {
         title: 'Modo de red de Docker',
         pass: 'Ejecutándose en modo de red de host.',
@@ -5702,6 +5714,18 @@ export default {
         pass: 'El modo desarrollador está activado.',
         fail: 'El modo desarrollador está DESACTIVADO en la impresora. Actívelo en los ajustes de LAN de la impresora — y confirme con Aceptar. Sin él, las impresiones no comenzarán.',
         skip: 'No se pudo comprobar — requiere una conexión activa con la impresora.',
+      },
+      flashforge_auth: {
+        title: "Clave de dispositivo FlashForge",
+        pass: "La impresora aceptó el número de serie y la clave de dispositivo guardados.",
+        fail: "La impresora está accesible, pero rechazó las credenciales guardadas. Copia de nuevo la clave de dispositivo desde la página LAN de la impresora y actualiza esta impresora en Bambuddy.",
+        skip: "No comprobado — no se pudo acceder a la API local de FlashForge.",
+      },
+      flashforge_polling: {
+        title: "Conexión de sondeo de Bambuddy",
+        pass: "Bambuddy está recibiendo el estado de la impresora desde la API local de FlashForge.",
+        fail: "Bambuddy no está recibiendo el estado de la impresora ahora mismo. Comprueba la IP guardada, el número de serie y la clave de dispositivo, y reinicia el monitor de la impresora si hace falta.",
+        skip: "No comprobado — este monitor de impresora aún no está en ejecución.",
       },
       printer_publishing: {
         title: 'La impresora publica estado',

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -2490,6 +2490,8 @@ export default {
     noFiles: 'Aucun fichier sur l\'imprimante',
     loadingFiles: 'Chargement...',
     failedToLoad: 'Échec chargement fichiers',
+    sizeUnavailable: "Taille indisponible",
+    limitedCapabilities: "Cette imprimante expose uniquement une liste de fichiers en lecture seule sur le LAN. Le téléchargement, la suppression et l’aperçu ne sont pas disponibles.",
     toast: {
       filesDeleted: '{{count}} fichier(s) supprimé(s)',
       deleteFailed: 'Échec suppression : {{error}}',
@@ -5660,6 +5662,16 @@ export default {
         pass: 'Accessible — le flux de la caméra fonctionnera.',
         warn: 'Le port 322 est inaccessible. La vue caméra en direct ne fonctionnera pas. Cela n\'affecte pas l\'impression.',
       },
+      port_flashforge_api: {
+        title: "API locale FlashForge (8898)",
+        pass: "Accessible — Bambuddy peut communiquer avec l’imprimante via l’API LAN FlashForge.",
+        fail: "Le port 8898 est inaccessible. L’imprimante est éteinte, utilise une autre adresse IP ou un pare-feu bloque l’API LAN FlashForge.",
+      },
+      port_flashforge_camera: {
+        title: "Caméra FlashForge (MJPEG 8080)",
+        pass: "Accessible — le flux caméra devrait fonctionner.",
+        warn: "Le port 8080 est inaccessible. La surveillance et l’impression peuvent encore fonctionner, mais pas la vue caméra en direct.",
+      },
       network_mode: {
         title: 'Mode réseau Docker',
         pass: 'Fonctionne en mode réseau host.',
@@ -5683,6 +5695,18 @@ export default {
         pass: 'Le mode développeur est activé.',
         fail: 'Le mode développeur est DÉSACTIVÉ sur l\'imprimante. Activez-le dans les paramètres LAN de l\'imprimante — et confirmez avec OK. Sans lui, les impressions ne démarreront pas.',
         skip: 'Impossible à vérifier — nécessite une connexion active à l\'imprimante.',
+      },
+      flashforge_auth: {
+        title: "Clé d’appareil FlashForge",
+        pass: "L’imprimante a accepté le numéro de série et la clé d’appareil enregistrés.",
+        fail: "L’imprimante est accessible, mais a rejeté les identifiants enregistrés. Recopiez la clé d’appareil depuis la page LAN de l’imprimante et mettez cette imprimante à jour dans Bambuddy.",
+        skip: "Non vérifié — l’API locale FlashForge est inaccessible.",
+      },
+      flashforge_polling: {
+        title: "Connexion de sondage Bambuddy",
+        pass: "Bambuddy reçoit l’état de l’imprimante depuis l’API locale FlashForge.",
+        fail: "Bambuddy ne reçoit pas l’état de l’imprimante pour le moment. Vérifiez l’adresse IP, le numéro de série et la clé d’appareil enregistrés, puis redémarrez le moniteur de l’imprimante si nécessaire.",
+        skip: "Non vérifié — ce moniteur d’imprimante n’est pas encore en cours d’exécution.",
       },
       printer_publishing: {
         title: 'L\'imprimante publie son état',

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -2489,6 +2489,8 @@ export default {
     noFiles: 'Nessun file sulla stampante',
     loadingFiles: 'Caricamento file...',
     failedToLoad: 'Caricamento file fallito',
+    sizeUnavailable: "Dimensione non disponibile",
+    limitedCapabilities: "Questa stampante espone via LAN solo un elenco file in sola lettura. Download, eliminazione e anteprima non sono disponibili.",
     toast: {
       filesDeleted: 'Eliminati {{count}} file',
       deleteFailed: 'Eliminazione fallita: {{error}}',
@@ -5659,6 +5661,16 @@ export default {
         pass: 'Raggiungibile — lo streaming della fotocamera funzionerà.',
         warn: 'La porta 322 non è raggiungibile. La visualizzazione live della fotocamera non funzionerà. Questo non influisce sulla stampa.',
       },
+      port_flashforge_api: {
+        title: "API locale FlashForge (8898)",
+        pass: "Raggiungibile — Bambuddy può comunicare con la stampante tramite l’API LAN di FlashForge.",
+        fail: "La porta 8898 non è raggiungibile. La stampante è spenta, usa un indirizzo IP diverso o un firewall blocca l’API LAN di FlashForge.",
+      },
+      port_flashforge_camera: {
+        title: "Fotocamera FlashForge (MJPEG 8080)",
+        pass: "Raggiungibile — lo stream della fotocamera dovrebbe funzionare.",
+        warn: "La porta 8080 non è raggiungibile. Monitoraggio e stampa potrebbero funzionare comunque, ma la vista live della fotocamera no.",
+      },
       network_mode: {
         title: 'Modalità di rete Docker',
         pass: 'In esecuzione in modalità di rete host.',
@@ -5682,6 +5694,18 @@ export default {
         pass: 'La modalità sviluppatore è attivata.',
         fail: 'La modalità sviluppatore è DISATTIVATA sulla stampante. Attivala nelle impostazioni LAN della stampante — e conferma con OK. Senza di essa le stampe non verranno avviate.',
         skip: 'Impossibile verificare — richiede una connessione attiva alla stampante.',
+      },
+      flashforge_auth: {
+        title: "Chiave dispositivo FlashForge",
+        pass: "La stampante ha accettato il numero di serie e la chiave dispositivo salvati.",
+        fail: "La stampante è raggiungibile, ma ha rifiutato le credenziali salvate. Ricopia la chiave dispositivo dalla pagina LAN della stampante e aggiorna questa stampante in Bambuddy.",
+        skip: "Non verificato — l’API locale FlashForge non è raggiungibile.",
+      },
+      flashforge_polling: {
+        title: "Connessione di polling Bambuddy",
+        pass: "Bambuddy sta ricevendo lo stato della stampante dall’API locale FlashForge.",
+        fail: "Bambuddy non sta ricevendo lo stato della stampante in questo momento. Controlla indirizzo IP salvato, numero di serie e chiave dispositivo, quindi riavvia il monitor della stampante se necessario.",
+        skip: "Non verificato — questo monitor della stampante non è ancora in esecuzione.",
       },
       printer_publishing: {
         title: 'La stampante pubblica lo stato',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -2501,6 +2501,8 @@ export default {
     noFiles: 'このディレクトリにファイルがありません',
     loadingFiles: 'ファイルを読み込み中...',
     failedToLoad: 'ファイルの読み込みに失敗しました',
+    sizeUnavailable: "サイズを取得できません",
+    limitedCapabilities: "このプリンターはLAN経由で読み取り専用のファイル一覧のみを公開しています。ダウンロード、削除、プレビューは利用できません。",
     toast: {
       filesDeleted: '{{count}}件のファイルを削除しました',
       deleteFailed: '削除に失敗: {{error}}',
@@ -5671,6 +5673,16 @@ export default {
         pass: '到達可能 — カメラストリームは機能します。',
         warn: 'ポート322に到達できません。ライブカメラ表示は機能しません。これは印刷には影響しません。',
       },
+      port_flashforge_api: {
+        title: "FlashForge ローカルAPI (8898)",
+        pass: "到達可能 — Bambuddy は FlashForge LAN API 経由でプリンターと通信できます。",
+        fail: "ポート8898に到達できません。プリンターの電源が切れている、IPアドレスが異なる、またはファイアウォールが FlashForge LAN API をブロックしています。",
+      },
+      port_flashforge_camera: {
+        title: "FlashForge カメラ (MJPEG 8080)",
+        pass: "到達可能 — カメラストリームは動作するはずです。",
+        warn: "ポート8080に到達できません。監視と印刷は動作する場合がありますが、ライブカメラ表示は利用できません。",
+      },
       network_mode: {
         title: 'Dockerネットワークモード',
         pass: 'ホストネットワークモードで実行中です。',
@@ -5694,6 +5706,18 @@ export default {
         pass: '開発者モードは有効です。',
         fail: 'プリンターの開発者モードがオフです。プリンターのLAN設定で有効にし、OKで確定してください。これがないと印刷は開始されません。',
         skip: '確認できませんでした — プリンターへのアクティブな接続が必要です。',
+      },
+      flashforge_auth: {
+        title: "FlashForge デバイスキー",
+        pass: "プリンターは保存済みのシリアル番号とデバイスキーを受け入れました。",
+        fail: "プリンターには到達できますが、保存済みの認証情報が拒否されました。プリンターのLANページからデバイスキーを再度コピーし、Bambuddyでこのプリンターを更新してください。",
+        skip: "未確認 — FlashForge ローカルAPIに到達できませんでした。",
+      },
+      flashforge_polling: {
+        title: "Bambuddy ポーリング接続",
+        pass: "Bambuddy は FlashForge ローカルAPIからプリンター状態を受信しています。",
+        fail: "Bambuddy は現在プリンター状態を受信していません。保存済みのIPアドレス、シリアル番号、デバイスキーを確認し、必要に応じてプリンターモニターを再起動してください。",
+        skip: "未確認 — このプリンターモニターはまだ実行されていません。",
       },
       printer_publishing: {
         title: 'プリンターがステータスを送信中',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -2348,6 +2348,8 @@ export default {
     noFiles: '프린터에 파일 없음',
     loadingFiles: '파일 로딩 중...',
     failedToLoad: '파일 로드 실패',
+    sizeUnavailable: "크기를 사용할 수 없음",
+    limitedCapabilities: "이 프린터는 LAN에서 읽기 전용 파일 목록만 제공합니다. 다운로드, 삭제, 미리보기 작업은 사용할 수 없습니다.",
     toast: {
       filesDeleted: '{{count}}개 파일이 삭제되었습니다',
       deleteFailed: '삭제 실패: {{error}}'
@@ -5720,6 +5722,16 @@ export default {
         pass: '연결 가능 — 카메라 스트림이 작동합니다.',
         warn: '포트 322에 연결할 수 없습니다. 라이브 카메라 보기가 작동하지 않습니다. 인쇄에는 영향을 주지 않습니다.'
       },
+      port_flashforge_api: {
+        title: "FlashForge 로컬 API (8898)",
+        pass: "연결 가능 — Bambuddy가 FlashForge LAN API를 통해 프린터와 통신할 수 있습니다.",
+        fail: "포트 8898에 연결할 수 없습니다. 프린터가 꺼져 있거나 IP 주소가 다르거나 방화벽이 FlashForge LAN API를 차단하고 있습니다.",
+      },
+      port_flashforge_camera: {
+        title: "FlashForge 카메라 (MJPEG 8080)",
+        pass: "연결 가능 — 카메라 스트림이 작동해야 합니다.",
+        warn: "포트 8080에 연결할 수 없습니다. 모니터링과 인쇄는 계속 작동할 수 있지만 라이브 카메라 보기는 작동하지 않습니다.",
+      },
       network_mode: {
         title: 'Docker 네트워크 모드',
         pass: '호스트 네트워크 모드로 실행 중입니다.',
@@ -5743,6 +5755,18 @@ export default {
         pass: '개발자 모드가 활성화되어 있습니다.',
         fail: '프린터에서 개발자 모드가 꺼져 있습니다. 프린터의 LAN 설정에서 활성화하고 확인을 누르세요. 이 없으면 인쇄가 시작되지 않습니다.',
         skip: '확인할 수 없음 — 프린터에 연결되어 있어야 합니다.'
+      },
+      flashforge_auth: {
+        title: "FlashForge 장치 키",
+        pass: "프린터가 저장된 일련번호와 장치 키를 수락했습니다.",
+        fail: "프린터에는 연결되지만 저장된 자격 증명을 거부했습니다. 프린터 LAN 페이지에서 장치 키를 다시 복사하고 Bambuddy에서 이 프린터를 업데이트하세요.",
+        skip: "확인하지 않음 — FlashForge 로컬 API에 연결할 수 없습니다.",
+      },
+      flashforge_polling: {
+        title: "Bambuddy 폴링 연결",
+        pass: "Bambuddy가 FlashForge 로컬 API에서 프린터 상태를 수신하고 있습니다.",
+        fail: "Bambuddy가 현재 프린터 상태를 수신하지 못하고 있습니다. 저장된 IP 주소, 일련번호, 장치 키를 확인한 다음 필요하면 프린터 모니터를 다시 시작하세요.",
+        skip: "확인하지 않음 — 이 프린터 모니터가 아직 실행 중이 아닙니다.",
       },
       printer_publishing: {
         title: '프린터가 상태를 게시 중',

--- a/frontend/src/i18n/locales/pt-BR.ts
+++ b/frontend/src/i18n/locales/pt-BR.ts
@@ -2489,6 +2489,8 @@ export default {
     noFiles: 'Nenhum arquivo na impressora',
     loadingFiles: 'Carregando arquivos...',
     failedToLoad: 'Falha ao carregar arquivos',
+    sizeUnavailable: "Tamanho indisponível",
+    limitedCapabilities: "Esta impressora expõe pela LAN apenas uma lista de arquivos somente leitura. Download, exclusão e visualização não estão disponíveis.",
     toast: {
       filesDeleted: 'Arquivos excluídos: {{count}}',
       deleteFailed: 'Falha ao excluir: {{error}}',
@@ -5659,6 +5661,16 @@ export default {
         pass: 'Acessível — o streaming da câmera funcionará.',
         warn: 'A porta 322 está inacessível. A visualização ao vivo da câmera não funcionará. Isso não afeta a impressão.',
       },
+      port_flashforge_api: {
+        title: "API local FlashForge (8898)",
+        pass: "Acessível — o Bambuddy pode se comunicar com a impressora pela API LAN da FlashForge.",
+        fail: "A porta 8898 está inacessível. A impressora está desligada, em outro endereço IP ou um firewall está bloqueando a API LAN da FlashForge.",
+      },
+      port_flashforge_camera: {
+        title: "Câmera FlashForge (MJPEG 8080)",
+        pass: "Acessível — o stream da câmera deve funcionar.",
+        warn: "A porta 8080 está inacessível. Monitoramento e impressão ainda podem funcionar, mas a visualização ao vivo da câmera não.",
+      },
       network_mode: {
         title: 'Modo de rede Docker',
         pass: 'Executando no modo de rede host.',
@@ -5682,6 +5694,18 @@ export default {
         pass: 'O Modo Desenvolvedor está ativado.',
         fail: 'O Modo Desenvolvedor está DESLIGADO na impressora. Ative-o nas configurações de LAN da impressora — e confirme com OK. Sem ele, as impressões não iniciarão.',
         skip: 'Não foi possível verificar — requer uma conexão ativa com a impressora.',
+      },
+      flashforge_auth: {
+        title: "Chave do dispositivo FlashForge",
+        pass: "A impressora aceitou o número de série e a chave do dispositivo salvos.",
+        fail: "A impressora está acessível, mas rejeitou as credenciais salvas. Copie novamente a chave do dispositivo na página LAN da impressora e atualize esta impressora no Bambuddy.",
+        skip: "Não verificado — não foi possível acessar a API local da FlashForge.",
+      },
+      flashforge_polling: {
+        title: "Conexão de sondagem do Bambuddy",
+        pass: "O Bambuddy está recebendo o status da impressora pela API local da FlashForge.",
+        fail: "O Bambuddy não está recebendo o status da impressora agora. Verifique o IP salvo, o número de série e a chave do dispositivo, depois reinicie o monitor da impressora se necessário.",
+        skip: "Não verificado — este monitor de impressora ainda não está em execução.",
       },
       printer_publishing: {
         title: 'Impressora publicando status',

--- a/frontend/src/i18n/locales/tr.ts
+++ b/frontend/src/i18n/locales/tr.ts
@@ -2504,6 +2504,8 @@ export default {
     noFiles: 'Yazıcıda dosya yok',
     loadingFiles: 'Dosyalar yükleniyor...',
     failedToLoad: 'Dosyalar yüklenemedi',
+    sizeUnavailable: "Boyut kullanılamıyor",
+    limitedCapabilities: "Bu yazıcı LAN üzerinden yalnızca salt okunur bir dosya listesi sunuyor. İndirme, silme ve önizleme işlemleri kullanılamaz.",
     toast: {
       filesDeleted: '{{count}} dosya silindi',
       deleteFailed: 'Silme başarısız: {{error}}',
@@ -5609,6 +5611,16 @@ export default {
         pass: 'Erişilebilir — kamera akışı çalışacak.',
         warn: 'Port 322 erişilemez. Canlı kamera görünümü çalışmayacak. Bu, baskıyı etkilemez.',
       },
+      port_flashforge_api: {
+        title: "FlashForge yerel API (8898)",
+        pass: "Erişilebilir — Bambuddy, FlashForge LAN API üzerinden yazıcıyla konuşabiliyor.",
+        fail: "8898 numaralı porta ulaşılamıyor. Yazıcı kapalı, farklı bir IP adresinde ya da güvenlik duvarı FlashForge LAN API’yi engelliyor.",
+      },
+      port_flashforge_camera: {
+        title: "FlashForge kamera (MJPEG 8080)",
+        pass: "Erişilebilir — kamera akışı çalışmalıdır.",
+        warn: "8080 numaralı porta ulaşılamıyor. İzleme ve yazdırma çalışmaya devam edebilir, ancak canlı kamera görünümü çalışmaz.",
+      },
       network_mode: {
         title: 'Docker ağ modu',
         pass: 'Ana bilgisayar ağ modunda çalışıyor.',
@@ -5632,6 +5644,18 @@ export default {
         pass: 'Geliştirici Modu etkin.',
         fail: 'Yazıcıda Geliştirici Modu KAPALI. Yazıcının LAN ayarlarında etkinleştirin — ve OK ile onaylayın. Bu olmadan baskılar başlamayacak.',
         skip: 'Kontrol edilemedi — yazıcıya canlı bir bağlantı gerektirir.',
+      },
+      flashforge_auth: {
+        title: "FlashForge cihaz anahtarı",
+        pass: "Yazıcı kayıtlı seri numarasını ve cihaz anahtarını kabul etti.",
+        fail: "Yazıcıya ulaşılıyor, ancak kayıtlı kimlik bilgileri reddedildi. Cihaz anahtarını yazıcının LAN sayfasından yeniden kopyalayın ve bu yazıcıyı Bambuddy’de güncelleyin.",
+        skip: "Kontrol edilmedi — FlashForge yerel API’ye ulaşılamadı.",
+      },
+      flashforge_polling: {
+        title: "Bambuddy yoklama bağlantısı",
+        pass: "Bambuddy, FlashForge yerel API’den yazıcı durumunu alıyor.",
+        fail: "Bambuddy şu anda yazıcı durumunu almıyor. Kayıtlı IP adresini, seri numarasını ve cihaz anahtarını kontrol edin; gerekirse yazıcı izleyicisini yeniden başlatın.",
+        skip: "Kontrol edilmedi — bu yazıcı izleyicisi henüz çalışmıyor.",
       },
       printer_publishing: {
         title: 'Yazıcı durum yayını yapıyor',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2489,6 +2489,8 @@ export default {
     noFiles: '打印机上没有文件',
     loadingFiles: '加载文件中...',
     failedToLoad: '加载文件失败',
+    sizeUnavailable: "大小不可用",
+    limitedCapabilities: "此打印机通过 LAN 仅提供只读文件列表。下载、删除和预览操作不可用。",
     toast: {
       filesDeleted: '已删除 {{count}} 个文件',
       deleteFailed: '删除失败：{{error}}',
@@ -5658,6 +5660,16 @@ export default {
         pass: '可达 — 摄像头视频流将正常工作。',
         warn: '端口 322 不可达。实时摄像头视图将无法工作。这不影响打印。',
       },
+      port_flashforge_api: {
+        title: "FlashForge 本地 API（8898）",
+        pass: "可达 — Bambuddy 可以通过 FlashForge LAN API 与打印机通信。",
+        fail: "端口 8898 不可达。打印机可能已关机、IP 地址不同，或防火墙阻止了 FlashForge LAN API。",
+      },
+      port_flashforge_camera: {
+        title: "FlashForge 摄像头（MJPEG 8080）",
+        pass: "可达 — 摄像头视频流应可正常工作。",
+        warn: "端口 8080 不可达。监控和打印可能仍可工作，但实时摄像头视图不可用。",
+      },
       network_mode: {
         title: 'Docker 网络模式',
         pass: '正在以 host 网络模式运行。',
@@ -5681,6 +5693,18 @@ export default {
         pass: '开发者模式已启用。',
         fail: '打印机上的开发者模式已关闭。请在打印机的 LAN 设置中启用它 — 并按 OK 确认。否则打印将无法开始。',
         skip: '无法检查 — 需要与打印机的实时连接。',
+      },
+      flashforge_auth: {
+        title: "FlashForge 设备密钥",
+        pass: "打印机已接受保存的序列号和设备密钥。",
+        fail: "打印机可达，但拒绝了保存的凭据。请从打印机 LAN 页面重新复制设备密钥，并在 Bambuddy 中更新此打印机。",
+        skip: "未检查 — 无法访问 FlashForge 本地 API。",
+      },
+      flashforge_polling: {
+        title: "Bambuddy 轮询连接",
+        pass: "Bambuddy 正在从 FlashForge 本地 API 接收打印机状态。",
+        fail: "Bambuddy 当前未接收打印机状态。请检查保存的 IP 地址、序列号和设备密钥，必要时重启打印机监视器。",
+        skip: "未检查 — 此打印机监视器尚未运行。",
       },
       printer_publishing: {
         title: '打印机正在发布状态',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -2489,6 +2489,8 @@ export default {
     noFiles: '印表機上沒有檔案',
     loadingFiles: '載入檔案中...',
     failedToLoad: '載入檔案失敗',
+    sizeUnavailable: "大小無法使用",
+    limitedCapabilities: "此印表機透過 LAN 只提供唯讀檔案清單。下載、刪除和預覽操作無法使用。",
     toast: {
       filesDeleted: '已刪除 {{count}} 個檔案',
       deleteFailed: '刪除失敗：{{error}}',
@@ -5658,6 +5660,16 @@ export default {
         pass: '可達 — 攝影機串流將正常運作。',
         warn: '連接埠 322 無法連線。即時攝影機檢視將無法運作。這不影響列印。',
       },
+      port_flashforge_api: {
+        title: "FlashForge 本機 API（8898）",
+        pass: "可連線 — Bambuddy 可以透過 FlashForge LAN API 與印表機通訊。",
+        fail: "無法連線到連接埠 8898。印表機可能已關機、IP 位址不同，或防火牆封鎖了 FlashForge LAN API。",
+      },
+      port_flashforge_camera: {
+        title: "FlashForge 攝影機（MJPEG 8080）",
+        pass: "可連線 — 攝影機串流應可正常運作。",
+        warn: "無法連線到連接埠 8080。監控和列印可能仍可運作，但即時攝影機畫面無法使用。",
+      },
       network_mode: {
         title: 'Docker 網路模式',
         pass: '正在以 host 網路模式執行。',
@@ -5681,6 +5693,18 @@ export default {
         pass: '開發者模式已啟用。',
         fail: '印表機上的開發者模式已關閉。請在印表機的 LAN 設定中啟用它 — 並按 OK 確認。否則列印將無法開始。',
         skip: '無法檢查 — 需要與印表機的即時連線。',
+      },
+      flashforge_auth: {
+        title: "FlashForge 裝置金鑰",
+        pass: "印表機已接受儲存的序號和裝置金鑰。",
+        fail: "印表機可連線，但拒絕了儲存的認證。請從印表機 LAN 頁面重新複製裝置金鑰，並在 Bambuddy 中更新此印表機。",
+        skip: "未檢查 — 無法連線到 FlashForge 本機 API。",
+      },
+      flashforge_polling: {
+        title: "Bambuddy 輪詢連線",
+        pass: "Bambuddy 正在從 FlashForge 本機 API 接收印表機狀態。",
+        fail: "Bambuddy 目前未接收印表機狀態。請檢查儲存的 IP 位址、序號和裝置金鑰，必要時重新啟動印表機監視器。",
+        skip: "未檢查 — 此印表機監視器尚未執行。",
       },
       printer_publishing: {
         title: '印表機正在發佈狀態',

--- a/frontend/src/pages/CameraPage.tsx
+++ b/frontend/src/pages/CameraPage.tsx
@@ -101,6 +101,9 @@ export function CameraPage() {
   });
 
   const isPrintingWithObjects = (status?.state === 'RUNNING' || status?.state === 'PAUSE') && (status?.printable_objects_count ?? 0) >= 2;
+  const capabilities = status?.capabilities;
+  const canControlChamberLight = capabilities?.can_chamber_light ?? true;
+  const canSkipObjects = capabilities?.can_skip_objects ?? true;
 
   // Update document title
   useEffect(() => {
@@ -651,28 +654,32 @@ export function CameraPage() {
               {t('camera.snapshot')}
             </button>
           </div>
-          <button
-            onClick={() => chamberLightMutation.mutate(!status?.chamber_light)}
-            disabled={!status?.connected || chamberLightMutation.isPending || !hasPermission('printers:control')}
-            className={`p-1.5 rounded disabled:opacity-50 ${status?.chamber_light ? 'bg-yellow-500/20 hover:bg-yellow-500/30' : 'hover:bg-bambu-dark-tertiary'}`}
-            title={!hasPermission('printers:control') ? t('printers.permission.noControl') : t('camera.chamberLight')}
-          >
-            <ChamberLight on={status?.chamber_light ?? false} className="w-4 h-4" />
-          </button>
-          <button
-            onClick={() => setShowSkipObjectsModal(true)}
-            disabled={!isPrintingWithObjects || !hasPermission('printers:control')}
-            className={`p-1.5 rounded disabled:opacity-50 ${isPrintingWithObjects && hasPermission('printers:control') ? 'hover:bg-bambu-dark-tertiary' : ''}`}
-            title={
-              !hasPermission('printers:control')
-                ? t('printers.permission.noControl')
-                : !isPrintingWithObjects
-                  ? t('printers.skipObjects.onlyWhilePrinting')
-                  : t('printers.skipObjects.tooltip')
-            }
-          >
-            <SkipObjectsIcon className="w-4 h-4 text-bambu-gray" />
-          </button>
+          {canControlChamberLight && (
+            <button
+              onClick={() => chamberLightMutation.mutate(!status?.chamber_light)}
+              disabled={!status?.connected || chamberLightMutation.isPending || !hasPermission('printers:control')}
+              className={`p-1.5 rounded disabled:opacity-50 ${status?.chamber_light ? 'bg-yellow-500/20 hover:bg-yellow-500/30' : 'hover:bg-bambu-dark-tertiary'}`}
+              title={!hasPermission('printers:control') ? t('printers.permission.noControl') : t('camera.chamberLight')}
+            >
+              <ChamberLight on={status?.chamber_light ?? false} className="w-4 h-4" />
+            </button>
+          )}
+          {canSkipObjects && (
+            <button
+              onClick={() => setShowSkipObjectsModal(true)}
+              disabled={!isPrintingWithObjects || !hasPermission('printers:control')}
+              className={`p-1.5 rounded disabled:opacity-50 ${isPrintingWithObjects && hasPermission('printers:control') ? 'hover:bg-bambu-dark-tertiary' : ''}`}
+              title={
+                !hasPermission('printers:control')
+                  ? t('printers.permission.noControl')
+                  : !isPrintingWithObjects
+                    ? t('printers.skipObjects.onlyWhilePrinting')
+                    : t('printers.skipObjects.tooltip')
+              }
+            >
+              <SkipObjectsIcon className="w-4 h-4 text-bambu-gray" />
+            </button>
+          )}
           <button
             onClick={refresh}
             disabled={isDisabled}

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -786,14 +786,16 @@ function TemperatureIndicator({ temp, goodThreshold = 28, fairThreshold = 35, on
 }
 
 
-function getAmsLabel(amsId: number | string, trayCount: number): string {
+function getAmsLabel(amsId: number | string, trayCount: number, moduleType?: string | null): string {
   // Ensure amsId is a number (backend might send string)
   const id = typeof amsId === 'string' ? parseInt(amsId, 10) : amsId;
   const safeId = isNaN(id) ? 0 : id;
+  const isFlashForgeIfs = moduleType === 'flashforge_ifs';
   const isHt = trayCount === 1;
   // AMS-HT uses IDs starting at 128, regular AMS uses 0-3
   const normalizedId = safeId >= 128 ? safeId - 128 : safeId;
   const letter = String.fromCharCode(65 + normalizedId); // 0=A, 1=B, 2=C, 3=D
+  if (isFlashForgeIfs) return `IFS-${letter}`;
   return isHt ? `HT-${letter}` : `AMS-${letter}`;
 }
 
@@ -1578,12 +1580,36 @@ function PrinterCard({
   const [editingRoi, setEditingRoi] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
   const [isSavingRoi, setIsSavingRoi] = useState(false);
   const [plateCheckLightWasOff, setPlateCheckLightWasOff] = useState(false);
+  const [tempControl, setTempControl] = useState<'nozzle' | 'bed' | 'chamber' | null>(null);
+  const [tempTarget, setTempTarget] = useState('');
 
   const { data: status } = useQuery({
     queryKey: ['printerStatus', printer.id],
     queryFn: () => api.getPrinterStatus(printer.id),
     refetchInterval: 30000, // Fallback polling, WebSocket handles real-time
   });
+  const capabilities = status?.capabilities ?? {
+    can_pause: true,
+    can_resume: true,
+    can_stop: true,
+    can_clear_errors: true,
+    can_chamber_light: true,
+    can_print_speed: true,
+    can_set_temperature: false,
+    can_airduct_mode: true,
+    can_bed_jog: true,
+    can_home_axes: true,
+    can_skip_objects: true,
+    can_dry_filament: true,
+    can_calibrate: true,
+    can_upload_files: true,
+    can_list_files: true,
+    can_download_files: true,
+    can_delete_files: true,
+    can_preview_files: true,
+    can_browse_files: true,
+    can_stream_camera: true,
+  };
 
   // Check for firmware updates (cached for 5 minutes, can be disabled in settings)
   const { data: firmwareInfo } = useQuery({
@@ -2010,6 +2036,34 @@ function PrinterCard({
         queryClient.setQueryData(['printerStatus', printer.id], context.previousStatus);
       }
       showToast(error.message || t('printers.toast.failedToSetSpeed'), 'error');
+    },
+  });
+
+  const temperatureMutation = useMutation({
+    mutationFn: ({ heater, target }: { heater: 'nozzle' | 'bed' | 'chamber'; target: number }) =>
+      api.setTemperature(printer.id, heater, target),
+    onMutate: async ({ heater, target }) => {
+      await queryClient.cancelQueries({ queryKey: ['printerStatus', printer.id] });
+      const previousStatus = queryClient.getQueryData(['printerStatus', printer.id]);
+      queryClient.setQueryData(['printerStatus', printer.id], (old: PrinterStatus | undefined) => {
+        if (!old) return old;
+        const temperatures: Record<string, number | boolean | undefined> = { ...(old.temperatures || {}) };
+        const current = Number(temperatures[heater] || 0);
+        temperatures[`${heater}_target` as keyof typeof temperatures] = target;
+        temperatures[`${heater}_heating` as keyof typeof temperatures] = target > current + 1;
+        return { ...old, temperatures };
+      });
+      return { previousStatus };
+    },
+    onSuccess: (_, { heater, target }) => {
+      setTempControl(null);
+      showToast(`${heater[0].toUpperCase()}${heater.slice(1)} target set to ${target}°C`);
+    },
+    onError: (error: Error, _, context) => {
+      if (context?.previousStatus) {
+        queryClient.setQueryData(['printerStatus', printer.id], context.previousStatus);
+      }
+      showToast(error.message || t('printers.toast.failedToSendCommand'), 'error');
     },
   });
 
@@ -2893,32 +2947,34 @@ function PrinterCard({
                 {/* Current Print or Idle Placeholder */}
                 <div className="mb-4 p-3 bg-bambu-dark rounded-lg relative">
                   {/* Skip Objects button - top right corner, always visible */}
-                  <button
-                    onClick={() => setShowSkipObjectsModal(true)}
-                    disabled={!(status.state === 'RUNNING' || status.state === 'PAUSE') || (status.printable_objects_count ?? 0) < 2 || !hasPermission('printers:control')}
-                    className={`absolute top-2 right-2 p-1.5 rounded transition-colors z-10 ${
-                      (status.state === 'RUNNING' || status.state === 'PAUSE') && (status.printable_objects_count ?? 0) >= 2 && hasPermission('printers:control')
-                        ? 'text-bambu-gray hover:text-white hover:bg-white/10'
-                        : 'text-bambu-gray/30 cursor-not-allowed'
-                    }`}
-                    title={
-                      !hasPermission('printers:control')
-                        ? t('printers.permission.noControl')
-                        : !(status.state === 'RUNNING' || status.state === 'PAUSE')
-                          ? t('printers.skipObjects.onlyWhilePrinting')
-                          : (status.printable_objects_count ?? 0) >= 2
-                            ? t('printers.skipObjects.tooltip')
-                            : t('printers.skipObjects.requiresMultiple')
-                    }
-                  >
-                    <SkipObjectsIcon className="w-4 h-4" />
-                    {/* Badge showing skipped count */}
-                    {objectsData && objectsData.skipped_count > 0 && (
-                      <span className="absolute -top-1 -right-1 min-w-[16px] h-4 px-1 flex items-center justify-center text-[10px] font-bold bg-red-500 text-white rounded-full">
-                        {objectsData.skipped_count}
-                      </span>
-                    )}
-                  </button>
+                  {capabilities.can_skip_objects && (
+                    <button
+                      onClick={() => setShowSkipObjectsModal(true)}
+                      disabled={!(status.state === 'RUNNING' || status.state === 'PAUSE') || (status.printable_objects_count ?? 0) < 2 || !hasPermission('printers:control')}
+                      className={`absolute top-2 right-2 p-1.5 rounded transition-colors z-10 ${
+                        (status.state === 'RUNNING' || status.state === 'PAUSE') && (status.printable_objects_count ?? 0) >= 2 && hasPermission('printers:control')
+                          ? 'text-bambu-gray hover:text-white hover:bg-white/10'
+                          : 'text-bambu-gray/30 cursor-not-allowed'
+                      }`}
+                      title={
+                        !hasPermission('printers:control')
+                          ? t('printers.permission.noControl')
+                          : !(status.state === 'RUNNING' || status.state === 'PAUSE')
+                            ? t('printers.skipObjects.onlyWhilePrinting')
+                            : (status.printable_objects_count ?? 0) >= 2
+                              ? t('printers.skipObjects.tooltip')
+                              : t('printers.skipObjects.requiresMultiple')
+                      }
+                    >
+                      <SkipObjectsIcon className="w-4 h-4" />
+                      {/* Badge showing skipped count */}
+                      {objectsData && objectsData.skipped_count > 0 && (
+                        <span className="absolute -top-1 -right-1 min-w-[16px] h-4 px-1 flex items-center justify-center text-[10px] font-bold bg-red-500 text-white rounded-full">
+                          {objectsData.skipped_count}
+                        </span>
+                      )}
+                    </button>
+                  )}
                   <div className="flex gap-3">
                     {/* Cover Image */}
                     <CoverImage
@@ -3011,11 +3067,12 @@ function PrinterCard({
 
             {/* Temperatures */}
             {status.temperatures && viewMode === 'expanded' && (() => {
+              const temps = status.temperatures;
               // Use actual heater states from MQTT stream
-              const nozzleHeating = status.temperatures.nozzle_heating || status.temperatures.nozzle_2_heating || false;
-              const bedHeating = status.temperatures.bed_heating || false;
-              const chamberHeating = status.temperatures.chamber_heating || false;
-              const isDualNozzle = printer.nozzle_count === 2 || status.temperatures.nozzle_2 !== undefined;
+              const nozzleHeating = temps.nozzle_heating || temps.nozzle_2_heating || false;
+              const bedHeating = temps.bed_heating || false;
+              const chamberHeating = temps.chamber_heating || false;
+              const isDualNozzle = printer.nozzle_count === 2 || temps.nozzle_2 !== undefined;
               // active_extruder: 0=right, 1=left
               const activeNozzle = status.active_extruder === 1 ? 'L' : 'R';
               // Extended nozzle data from nozzle_rack (H2 series: wear, serial, max_temp, etc.)
@@ -3024,17 +3081,79 @@ function PrinterCard({
               const rightNozzleSlot = status.nozzle_rack?.find(s => s.id === 0);
               // Single-nozzle models (H2D, H2C): use the primary nozzle (id 0)
               const singleNozzleSlot = rightNozzleSlot || leftNozzleSlot;
+              const canSetTemperature = capabilities.can_set_temperature && hasPermission('printers:control');
+              const openTempControl = (heater: 'nozzle' | 'bed' | 'chamber', currentTarget?: number) => {
+                if (!canSetTemperature) return;
+                setTempControl(tempControl === heater ? null : heater);
+                setTempTarget(String(Math.round(currentTarget || 0)));
+              };
+              const submitTemperature = (heater: 'nozzle' | 'bed' | 'chamber', target: number) => {
+                temperatureMutation.mutate({ heater, target });
+              };
+              const renderTempPopover = (
+                heater: 'nozzle' | 'bed' | 'chamber',
+                label: string,
+                current?: number,
+                target?: number,
+              ) => tempControl === heater && canSetTemperature ? (
+                <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 z-30 w-44 rounded-lg border border-bambu-dark-tertiary bg-bambu-dark-secondary p-2 shadow-xl text-left">
+                  <div className="flex items-center justify-between text-[10px] text-bambu-gray mb-2">
+                    <span>{label}</span>
+                    <span>{Math.round(current || 0)}° / {Math.round(target || 0)}°</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min="0"
+                      max={heater === 'nozzle' ? 280 : heater === 'bed' ? 120 : 70}
+                      value={tempTarget}
+                      onChange={(event) => setTempTarget(event.target.value)}
+                      onClick={(event) => event.stopPropagation()}
+                      className="w-20 rounded bg-bambu-dark-tertiary px-2 py-1 text-xs text-white border border-bambu-dark-tertiary focus:outline-none focus:border-bambu-green"
+                      aria-label={`${label} target temperature`}
+                    />
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        submitTemperature(heater, Math.max(0, Number.parseInt(tempTarget || '0', 10) || 0));
+                      }}
+                      disabled={temperatureMutation.isPending}
+                      className="flex-1 rounded bg-bambu-green/20 px-2 py-1 text-xs text-bambu-green hover:bg-bambu-green/30 disabled:opacity-50"
+                    >
+                      Set
+                    </button>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      submitTemperature(heater, 0);
+                    }}
+                    disabled={temperatureMutation.isPending}
+                    className="mt-2 w-full rounded bg-bambu-dark px-2 py-1 text-xs text-bambu-gray hover:text-white disabled:opacity-50"
+                  >
+                    Off
+                  </button>
+                </div>
+              ) : null;
 
               return (
                 <div className="flex items-stretch gap-1.5 flex-wrap">
                   {/* Nozzle temp - combined for dual nozzle */}
-                  <div className="text-center px-2 py-1.5 bg-bambu-dark rounded-lg flex-1 flex flex-col justify-center items-center">
+                  <button
+                    type="button"
+                    onClick={() => openTempControl('nozzle', temps.nozzle_target)}
+                    disabled={!canSetTemperature}
+                    className={`relative text-center px-2 py-1.5 bg-bambu-dark rounded-lg flex-1 flex flex-col justify-center items-center ${canSetTemperature ? 'hover:bg-bambu-dark-tertiary transition-colors cursor-pointer' : 'cursor-default'}`}
+                    title={canSetTemperature ? 'Set nozzle temperature' : undefined}
+                  >
                     <HeaterThermometer className="w-3.5 h-3.5 mb-0.5" color="text-orange-400" isHeating={nozzleHeating} />
-                    {status.temperatures.nozzle_2 !== undefined ? (
+                    {temps.nozzle_2 !== undefined ? (
                       <>
                         <p className="text-[9px] text-bambu-gray">L / R</p>
                         <p className="text-[11px] text-white">
-                          {Math.round(status.temperatures.nozzle || 0)}° / {Math.round(status.temperatures.nozzle_2 || 0)}°
+                          {Math.round(temps.nozzle || 0)}° / {Math.round(temps.nozzle_2 || 0)}°
                         </p>
                       </>
                     ) : singleNozzleSlot ? (
@@ -3042,7 +3161,7 @@ function PrinterCard({
                         <div className="cursor-default">
                           <p className="text-[9px] text-bambu-gray">{t('printers.temperatures.nozzle')}</p>
                           <p className="text-[11px] text-white">
-                            {Math.round(status.temperatures.nozzle || 0)}°C
+                            {Math.round(temps.nozzle || 0)}°C
                           </p>
                         </div>
                       </NozzleSlotHoverCard>
@@ -3050,26 +3169,41 @@ function PrinterCard({
                       <>
                         <p className="text-[9px] text-bambu-gray">{t('printers.temperatures.nozzle')}</p>
                         <p className="text-[11px] text-white">
-                          {Math.round(status.temperatures.nozzle || 0)}°C
+                          {Math.round(temps.nozzle || 0)}°C
                         </p>
                       </>
                     )}
-                  </div>
-                  <div className="text-center px-2 py-1.5 bg-bambu-dark rounded-lg flex-1 flex flex-col justify-center items-center">
+                    {renderTempPopover('nozzle', t('printers.temperatures.nozzle'), temps.nozzle, temps.nozzle_target)}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openTempControl('bed', temps.bed_target)}
+                    disabled={!canSetTemperature}
+                    className={`relative text-center px-2 py-1.5 bg-bambu-dark rounded-lg flex-1 flex flex-col justify-center items-center ${canSetTemperature ? 'hover:bg-bambu-dark-tertiary transition-colors cursor-pointer' : 'cursor-default'}`}
+                    title={canSetTemperature ? 'Set bed temperature' : undefined}
+                  >
                     <HeaterThermometer className="w-3.5 h-3.5 mb-0.5" color="text-blue-400" isHeating={bedHeating} />
                     <p className="text-[9px] text-bambu-gray">{t('printers.temperatures.bed')}</p>
                     <p className="text-[11px] text-white">
-                      {Math.round(status.temperatures.bed || 0)}°C
+                      {Math.round(temps.bed || 0)}°C
                     </p>
-                  </div>
-                  {status.temperatures.chamber !== undefined && (
-                    <div className="text-center px-2 py-1.5 bg-bambu-dark rounded-lg flex-1 flex flex-col justify-center items-center">
+                    {renderTempPopover('bed', t('printers.temperatures.bed'), temps.bed, temps.bed_target)}
+                  </button>
+                  {temps.chamber !== undefined && (
+                    <button
+                      type="button"
+                      onClick={() => openTempControl('chamber', temps.chamber_target)}
+                      disabled={!canSetTemperature}
+                      className={`relative text-center px-2 py-1.5 bg-bambu-dark rounded-lg flex-1 flex flex-col justify-center items-center ${canSetTemperature ? 'hover:bg-bambu-dark-tertiary transition-colors cursor-pointer' : 'cursor-default'}`}
+                      title={canSetTemperature ? 'Set chamber temperature' : undefined}
+                    >
                       <HeaterThermometer className="w-3.5 h-3.5 mb-0.5" color="text-green-400" isHeating={chamberHeating} />
                       <p className="text-[9px] text-bambu-gray">{t('printers.temperatures.chamber')}</p>
                       <p className="text-[11px] text-white">
-                        {Math.round(status.temperatures.chamber || 0)}°C
+                        {Math.round(temps.chamber || 0)}°C
                       </p>
-                    </div>
+                      {renderTempPopover('chamber', t('printers.temperatures.chamber'), temps.chamber, temps.chamber_target)}
+                    </button>
                   )}
                   {/* Active nozzle indicator for dual-nozzle printers */}
                   {isDualNozzle && (
@@ -3182,7 +3316,7 @@ function PrinterCard({
                       <div className="w-px h-5 bg-bambu-gray/30" />
 
                       {/* Airduct Mode (P2S / X2D / H2*) */}
-                      {(['P2S', 'X2D', 'H2D', 'H2C', 'H2S'].includes(printer.model ?? '')) && (() => {
+                      {capabilities.can_airduct_mode && (['P2S', 'X2D', 'H2D', 'H2C', 'H2S'].includes(printer.model ?? '')) && (() => {
                         const isHeating = status.airduct_mode === 1;
                         const Icon = isHeating ? Flame : Snowflake;
                         const color = isHeating ? 'text-orange-400' : 'text-sky-400';
@@ -3232,7 +3366,7 @@ function PrinterCard({
                       })()}
 
                       {/* Print Speed */}
-                      {(() => {
+                      {capabilities.can_print_speed && (() => {
                         const speedLabels: Record<number, string> = { 1: '50%', 2: '100%', 3: '124%', 4: '166%' };
                         const speedPct = speedLabels[status.speed_level] || '100%';
                         return (
@@ -3292,7 +3426,7 @@ function PrinterCard({
                       <div className="w-px h-5 bg-bambu-gray/30" />
 
                       {/* Bed Jog (Z-axis) — compact badge, popover holds the actual controls */}
-                      {(() => {
+                      {capabilities.can_bed_jog && (() => {
                         const canControl = hasPermission('printers:control');
                         const disabled = isPrinting || !canControl;
                         const bambuIsPlateBelow = true; // positive Z moves plate away from nozzle
@@ -3382,11 +3516,11 @@ function PrinterCard({
                       {/* Stop button */}
                       <button
                         onClick={() => setShowStopConfirm(true)}
-                        disabled={!isPrinting || isControlBusy || !hasPermission('printers:control')}
+                        disabled={!isPrinting || isControlBusy || !hasPermission('printers:control') || !capabilities.can_stop}
                         className={`
                           flex items-center justify-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium
                           transition-colors
-                          ${isPrinting && hasPermission('printers:control')
+                          ${isPrinting && hasPermission('printers:control') && capabilities.can_stop
                             ? 'bg-red-500/20 text-red-400 hover:bg-red-500/30'
                             : 'bg-bambu-dark text-bambu-gray/50 cursor-not-allowed'
                           }
@@ -3400,11 +3534,11 @@ function PrinterCard({
                       {/* Pause/Resume button */}
                       <button
                         onClick={() => isPaused ? setShowResumeConfirm(true) : setShowPauseConfirm(true)}
-                        disabled={!isPrinting || isControlBusy || !hasPermission('printers:control')}
+                        disabled={!isPrinting || isControlBusy || !hasPermission('printers:control') || (isPaused ? !capabilities.can_resume : !capabilities.can_pause)}
                         className={`
                           flex items-center justify-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium
                           transition-colors
-                          ${isPrinting && hasPermission('printers:control')
+                          ${isPrinting && hasPermission('printers:control') && (isPaused ? capabilities.can_resume : capabilities.can_pause)
                             ? isPaused
                               ? 'bg-bambu-green/20 text-bambu-green hover:bg-bambu-green/30'
                               : 'bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30'
@@ -3460,13 +3594,13 @@ function PrinterCard({
                                 <AmsNameHoverCard
                                   ams={ams}
                                   printerId={printer.id}
-                                  label={getAmsLabel(ams.id, ams.tray.length)}
+                                  label={getAmsLabel(ams.id, ams.tray.length, ams.module_type)}
                                   amsLabels={amsLabels}
                                   canEdit={hasPermission('printers:update')}
                                   onSaved={refetchAmsLabels}
                                 >
                                   <span className="text-[10px] text-white font-medium cursor-default select-none">
-                                    {amsLabels?.[ams.id] || getAmsLabel(ams.id, ams.tray.length)}
+                                    {amsLabels?.[ams.id] || getAmsLabel(ams.id, ams.tray.length, ams.module_type)}
                                   </span>
                                 </AmsNameHoverCard>
                                 {isDualNozzle && (isLeftNozzle || isRightNozzle) && (
@@ -3482,7 +3616,7 @@ function PrinterCard({
                                       fairThreshold={amsThresholds?.humidityFair}
                                       onClick={() => setAmsHistoryModal({
                                         amsId: ams.id,
-                                        amsLabel: getAmsLabel(ams.id, ams.tray.length),
+                                        amsLabel: getAmsLabel(ams.id, ams.tray.length, ams.module_type),
                                         mode: 'humidity',
                                       })}
                                       compact
@@ -3495,7 +3629,7 @@ function PrinterCard({
                                       fairThreshold={amsThresholds?.tempFair}
                                       onClick={() => setAmsHistoryModal({
                                         amsId: ams.id,
-                                        amsLabel: getAmsLabel(ams.id, ams.tray.length),
+                                        amsLabel: getAmsLabel(ams.id, ams.tray.length, ams.module_type),
                                         mode: 'temperature',
                                       })}
                                       compact
@@ -3807,7 +3941,7 @@ function PrinterCard({
                                                   material: tray?.tray_type ?? undefined,
                                                   profile: filamentData.profile,
                                                   color: filamentData.colorHex || '',
-                                                  location: `${getAmsLabel(ams.id, ams.tray.length)} Slot ${slotIdx + 1}`,
+                                                  location: `${getAmsLabel(ams.id, ams.tray.length, ams.module_type)} Slot ${slotIdx + 1}`,
                                                 },
                                               }),
                                               onUnassignSpool: (spoolmanSpool && !isBambuLabSpool(tray)) ? () => onUnassignSpoolmanSpool?.(spoolmanSpool.id) : undefined,
@@ -3832,7 +3966,7 @@ function PrinterCard({
                                                 material: tray?.tray_type ?? undefined,
                                                 profile: filamentData.profile,
                                                 color: filamentData.colorHex || '',
-                                                location: `${getAmsLabel(ams.id, ams.tray.length)} Slot ${slotIdx + 1}`,
+                                                location: `${getAmsLabel(ams.id, ams.tray.length, ams.module_type)} Slot ${slotIdx + 1}`,
                                               },
                                             }),
                                             onUnassignSpool: (assignment && !isBambuLabSpool(tray)) ? () => onUnassignSpool?.(printer.id, ams.id, slotIdx) : undefined,
@@ -3878,7 +4012,7 @@ function PrinterCard({
                                             material: undefined,
                                             profile: '',
                                             color: '',
-                                            location: `${getAmsLabel(ams.id, ams.tray.length)} Slot ${slotIdx + 1}`,
+                                            location: `${getAmsLabel(ams.id, ams.tray.length, ams.module_type)} Slot ${slotIdx + 1}`,
                                           },
                                         })}
                                       >
@@ -4005,13 +4139,13 @@ function PrinterCard({
                               <AmsNameHoverCard
                                 ams={ams}
                                 printerId={printer.id}
-                                label={getAmsLabel(ams.id, ams.tray.length)}
+                                label={getAmsLabel(ams.id, ams.tray.length, ams.module_type)}
                                 amsLabels={amsLabels}
                                 canEdit={hasPermission('printers:update')}
                                 onSaved={refetchAmsLabels}
                               >
                                 <span className="text-[10px] text-white font-medium cursor-default select-none">
-                                  {amsLabels?.[ams.id] || getAmsLabel(ams.id, ams.tray.length)}
+                                  {amsLabels?.[ams.id] || getAmsLabel(ams.id, ams.tray.length, ams.module_type)}
                                 </span>
                               </AmsNameHoverCard>
                               {isDualNozzle && (isLeftNozzle || isRightNozzle) && (
@@ -4206,7 +4340,7 @@ function PrinterCard({
                                               material: tray?.tray_type ?? undefined,
                                               profile: filamentData.profile,
                                               color: filamentData.colorHex || '',
-                                              location: getAmsLabel(ams.id, ams.tray.length),
+                                              location: getAmsLabel(ams.id, ams.tray.length, ams.module_type),
                                             },
                                           }),
                                           onUnassignSpool: (spoolmanSpool && !isBambuLabSpool(tray)) ? () => onUnassignSpoolmanSpool?.(spoolmanSpool.id) : undefined,
@@ -4231,7 +4365,7 @@ function PrinterCard({
                                             material: tray?.tray_type ?? undefined,
                                             profile: filamentData.profile,
                                             color: filamentData.colorHex || '',
-                                            location: getAmsLabel(ams.id, ams.tray.length),
+                                            location: getAmsLabel(ams.id, ams.tray.length, ams.module_type),
                                           },
                                         }),
                                         onUnassignSpool: (assignment && !isBambuLabSpool(tray)) ? () => onUnassignSpool?.(printer.id, ams.id, htSlotId) : undefined,
@@ -4277,7 +4411,7 @@ function PrinterCard({
                                         material: undefined,
                                         profile: '',
                                         color: '',
-                                        location: getAmsLabel(ams.id, ams.tray.length),
+                                        location: getAmsLabel(ams.id, ams.tray.length, ams.module_type),
                                       },
                                     })}
                                   >
@@ -4295,7 +4429,7 @@ function PrinterCard({
                                       fairThreshold={amsThresholds?.tempFair}
                                       onClick={() => setAmsHistoryModal({
                                         amsId: ams.id,
-                                        amsLabel: getAmsLabel(ams.id, ams.tray.length),
+                                        amsLabel: getAmsLabel(ams.id, ams.tray.length, ams.module_type),
                                         mode: 'temperature',
                                       })}
                                       compact
@@ -4308,7 +4442,7 @@ function PrinterCard({
                                       fairThreshold={amsThresholds?.humidityFair}
                                       onClick={() => setAmsHistoryModal({
                                         amsId: ams.id,
-                                        amsLabel: getAmsLabel(ams.id, ams.tray.length),
+                                        amsLabel: getAmsLabel(ams.id, ams.tray.length, ams.module_type),
                                         mode: 'humidity',
                                       })}
                                       compact
@@ -4741,16 +4875,18 @@ function PrinterCard({
         {viewMode === 'expanded' && (
           <div className="mt-4 pt-4 border-t border-bambu-dark-tertiary flex items-center justify-end gap-2 flex-wrap">
               {/* Chamber Light */}
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => chamberLightMutation.mutate(!status?.chamber_light)}
-                disabled={!status?.connected || chamberLightMutation.isPending || !hasPermission('printers:control')}
-                title={!hasPermission('printers:control') ? t('printers.permission.noControl') : (status?.chamber_light ? t('printers.chamberLightOff') : t('printers.chamberLightOn'))}
-                className={status?.chamber_light ? '!border-yellow-500 !text-yellow-400 hover:!bg-yellow-500/20' : ''}
-              >
-                <ChamberLight on={status?.chamber_light ?? false} className={`w-4 h-4 ${status?.chamber_light ? 'text-yellow-400' : ''}`} />
-              </Button>
+              {capabilities.can_chamber_light && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => chamberLightMutation.mutate(!status?.chamber_light)}
+                  disabled={!status?.connected || chamberLightMutation.isPending || !hasPermission('printers:control')}
+                  title={!hasPermission('printers:control') ? t('printers.permission.noControl') : (status?.chamber_light ? t('printers.chamberLightOff') : t('printers.chamberLightOn'))}
+                  className={status?.chamber_light ? '!border-yellow-500 !text-yellow-400 hover:!bg-yellow-500/20' : ''}
+                >
+                  <ChamberLight on={status?.chamber_light ?? false} className={`w-4 h-4 ${status?.chamber_light ? 'text-yellow-400' : ''}`} />
+                </Button>
+              )}
               {/* Camera Button */}
               <Button
                 variant="secondary"

--- a/frontend/src/pages/StreamOverlayPage.tsx
+++ b/frontend/src/pages/StreamOverlayPage.tsx
@@ -3,9 +3,10 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Layers, Clock, Timer, Printer } from 'lucide-react';
-import { api, withStreamToken } from '../api/client';
+import { api, getStreamToken, withStreamToken } from '../api/client';
 import type { PrinterStatus } from '../api/client';
 import { formatDuration, formatETA, type TimeFormat } from '../utils/date';
+import { useAuth } from '../contexts/AuthContext';
 
 type TFunction = (key: string, options?: Record<string, unknown>) => string;
 
@@ -111,6 +112,7 @@ export function StreamOverlayPage() {
   const [searchParams] = useSearchParams();
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const { authEnabled, user } = useAuth();
   const id = parseInt(printerId || '0', 10);
   const [imageKey, setImageKey] = useState(Date.now());
 
@@ -137,6 +139,13 @@ export function StreamOverlayPage() {
     queryKey: ['settings'],
     queryFn: api.getSettings,
   });
+  const { data: streamTokenData } = useQuery({
+    queryKey: ['camera-stream-token', user?.id ?? null],
+    queryFn: () => api.getCameraStreamToken(),
+    enabled: id > 0 && config.showCamera && (authEnabled ? !!user : true),
+    staleTime: 50 * 60 * 1000,
+  });
+  const streamTokenValue = streamTokenData?.token ?? getStreamToken();
 
   const timeFormat: TimeFormat = settings?.time_format || 'system';
 
@@ -225,12 +234,17 @@ export function StreamOverlayPage() {
 
   const isPrinting = status.state === 'RUNNING' || status.state === 'PAUSE';
   const progress = status.progress || 0;
-  const streamUrl = withStreamToken(`/api/v1/printers/${id}/camera/stream?fps=${config.fps}&t=${imageKey}`);
+  const waitingForStreamToken = authEnabled && config.showCamera && !streamTokenValue;
+  const appendStreamToken = (url: string) =>
+    streamTokenValue ? `${url}&token=${encodeURIComponent(streamTokenValue)}` : withStreamToken(url);
+  const streamUrl = waitingForStreamToken
+    ? ''
+    : appendStreamToken(`/api/v1/printers/${id}/camera/stream?fps=${config.fps}&t=${imageKey}`);
 
   return (
     <div className="min-h-screen bg-black relative overflow-hidden">
       {/* Camera feed - fullscreen background (optional) */}
-      {config.showCamera && (
+      {config.showCamera && !waitingForStreamToken && (
         <img
           key={imageKey}
           src={streamUrl}

--- a/frontend/src/utils/printer.ts
+++ b/frontend/src/utils/printer.ts
@@ -1,6 +1,9 @@
 export function getPrinterImage(model: string | null | undefined): string {
   if (!model) return '/img/printers/default.png';
   const m = model.toLowerCase().replace(/\s+/g, '');
+  if (m.includes('flashforgecreator5pro') || m.includes('creator5pro')) {
+    return '/img/printers/flashforge-creator5pro.svg';
+  }
   if (m.includes('x1e')) return '/img/printers/x1e.png';
   if (m.includes('x1c') || m.includes('x1carbon')) return '/img/printers/x1c.png';
   if (m.includes('x1')) return '/img/printers/x1c.png';


### PR DESCRIPTION
## Summary

Adds experimental FlashForge Creator 5 Pro LAN monitoring and control support alongside the existing Bambu flow. The integration uses the printer local HTTP API for status, controls, file listing, G-code upload, thumbnails, diagnostics, and MJPEG camera access.

The UI now exposes printer capability flags so FlashForge printers show the controls that are known to work while hiding or disabling Bambu-only actions such as drying, bed jog, object skipping, calibration, airduct, and unsupported file operations.

## Details

- Adds conservative Creator 5 Pro model detection and FlashForge local API helpers.
- Maps print state, progress, temperatures, fans, chamber light, material slots, errors, and ETA/remaining-time values.
- Fixes bogus long remaining-time displays by deriving remaining time from total estimate and elapsed print duration when needed.
- Adds camera snapshot/stream support through the existing Bambuddy tokenized camera flow.
- Adds FlashForge-specific diagnostics for API auth, polling, camera port reachability, network mode, and subnet hints.
- Adds source docs covering supported features, known endpoint gaps, and live probe notes.

## Known gaps

FlashForge endpoints for file download/delete, full preview browsing, timelapse retrieval, bed jog, homing, object skipping, calibration, and drying were not found during LAN probing, so those actions are intentionally unsupported for this printer family.

## Validation

- `.venv/bin/python -m pytest backend/tests/unit/services/test_flashforge_local.py backend/tests/unit/services/test_printer_manager.py backend/tests/unit/services/test_printer_diagnostic.py backend/tests/unit/services/test_camera_diagnose.py backend/tests/integration/test_camera_api.py backend/tests/integration/test_printers_api.py -q`
- `.venv/bin/python -m ruff check backend/app/api/routes/camera.py backend/app/api/routes/printers.py backend/app/services/background_dispatch.py backend/app/services/bambu_ftp.py backend/app/services/camera_diagnose.py backend/app/services/flashforge_local.py backend/app/services/print_scheduler.py backend/app/services/printer_diagnostic.py backend/app/services/printer_manager.py backend/tests/integration/test_camera_api.py backend/tests/integration/test_printers_api.py backend/tests/unit/services/test_bambu_ftp.py backend/tests/unit/services/test_camera_diagnose.py backend/tests/unit/services/test_flashforge_local.py backend/tests/unit/services/test_printer_diagnostic.py backend/tests/unit/services/test_printer_manager.py`
- `cd frontend && npm run check:i18n && npm test -- --run src/__tests__/components/FileManagerModal.test.tsx src/__tests__/components/CameraDiagnoseModal.test.tsx src/__tests__/components/EmbeddedCameraViewer.test.tsx src/__tests__/pages/PrintersPage.test.tsx src/__tests__/pages/CameraPage.test.tsx src/__tests__/pages/StreamOverlayPage.test.tsx src/__tests__/utils/printer.test.ts`

Also live-tested against a Creator 5 Pro for local API connectivity, status polling, diagnostics, camera stream/snapshot, and corrected ETA behavior during an active print.
