### PR TITLE
fix(hms): surface uncataloged HMS errors that carry actions (#1840)

### DIFF
--- a/frontend/src/__tests__/components/HMSErrorModal.test.tsx
+++ b/frontend/src/__tests__/components/HMSErrorModal.test.tsx
@@ -25,6 +25,16 @@ const unknownError: HMSError = {
   severity: 1,
 };
 
+// Unknown code (not in the database) that nonetheless carries user actions —
+// e.g. H2C 0500_809C "Build plate not properly positioned". Must NOT be hidden. (#1840)
+const actionableUnknownError: HMSError = {
+  attr: 0x0500809C,
+  code: '0x809C',
+  severity: 3,
+  actions: ['IGNORE_RESUME', 'PROBLEM_SOLVED_RESUME'],
+  full_code: '0500809C',
+};
+
 describe('HMSErrorModal', () => {
   const defaultProps = {
     printerName: 'Test Printer',
@@ -58,6 +68,21 @@ describe('HMSErrorModal', () => {
     it('shows no errors message when errors array is empty', () => {
       render(<HMSErrorModal {...defaultProps} errors={[]} />);
       expect(screen.getByText('No errors')).toBeInTheDocument();
+    });
+
+    it('shows unknown errors that carry actions (never hides an actionable fault)', () => {
+      render(<HMSErrorModal {...defaultProps} errors={[actionableUnknownError]} />);
+      expect(screen.queryByText('No errors')).not.toBeInTheDocument();
+      expect(screen.getByText('[0500-809C]')).toBeInTheDocument();
+      expect(screen.getByText('Ignore this and Resume')).toBeInTheDocument();
+      expect(screen.getByText('Problem Solved and Resume')).toBeInTheDocument();
+    });
+
+    it('shows a fallback description for actionable codes missing from the catalog', () => {
+      render(<HMSErrorModal {...defaultProps} errors={[actionableUnknownError]} />);
+      expect(
+        screen.getByText('Unrecognized HMS code — open the Bambu Lab Wiki for details.'),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/HMSErrorModal.tsx
+++ b/frontend/src/components/HMSErrorModal.tsx
@@ -896,13 +896,20 @@ function getShortCode(attr: number, code: number): string {
   return `${module.toString(16).padStart(4, '0').toUpperCase()}_${codeNum.toString(16).padStart(4, '0').toUpperCase()}`;
 }
 
-// Helper to filter only known HMS errors (exported for use in badge counts)
+// An HMS error is worth surfacing if we have a local description for it OR it
+// carries user actions (e.g. Ignore/Resume). Hiding an actionable fault leaves
+// the user looking at a silently paused printer with no way to respond to the
+// warning from the UI — the firmware still expects an answer. See #1840.
+function isDisplayableHMSError(error: HMSError): boolean {
+  const codeNum = parseInt(error.code.replace('0x', ''), 16) || 0;
+  const shortCode = getShortCode(error.attr, codeNum);
+  return ERROR_DESCRIPTIONS[shortCode] !== undefined || (error.actions?.length ?? 0) > 0;
+}
+
+// Filter HMS errors down to the ones we should surface (described or actionable).
+// Exported for use in badge counts / status classification.
 export function filterKnownHMSErrors(errors: HMSError[]): HMSError[] {
-  return errors.filter((error) => {
-    const codeNum = parseInt(error.code.replace('0x', ''), 16) || 0;
-    const shortCode = getShortCode(error.attr, codeNum);
-    return ERROR_DESCRIPTIONS[shortCode] !== undefined;
-  });
+  return errors.filter(isDisplayableHMSError);
 }
 
 function getHMSHomeUrl(): string {
@@ -925,12 +932,9 @@ export function HMSErrorModal({ printerName, errors, onClose, printerId, hasPerm
     },
   });
 
-  // Filter to only show errors we have descriptions for (skip unknown codes)
-  const knownErrors = errors.filter((error) => {
-    const codeNum = parseInt(error.code.replace('0x', ''), 16) || 0;
-    const shortCode = getShortCode(error.attr, codeNum);
-    return ERROR_DESCRIPTIONS[shortCode] !== undefined;
-  });
+  // Surface errors we can describe OR that carry actions — never hide an
+  // actionable fault just because its code isn't in our local catalog (#1840).
+  const knownErrors = errors.filter(isDisplayableHMSError);
 
   // Close on Escape key
   useEffect(() => {
@@ -998,7 +1002,8 @@ export function HMSErrorModal({ printerName, errors, onClose, printerId, hasPerm
                 const { label, color, bgColor, buttonHoverColor, Icon } = getSeverityInfo(error.severity);
                 const codeNum = parseInt(error.code.replace('0x', ''), 16) || 0;
                 const shortCode = getShortCode(error.attr, codeNum);
-                const description = ERROR_DESCRIPTIONS[shortCode];
+                const description = ERROR_DESCRIPTIONS[shortCode]
+                  ?? t('hmsErrors.unknownCode', 'Unrecognized HMS code — open the Bambu Lab Wiki for details.');
                 const hmsHomeUrl = getHMSHomeUrl();
                 const displayCode = shortCode.replace('_', '-');
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2744,6 +2744,7 @@ export default {
   hmsErrors: {
     title: 'Errors - {{name}}',
     noErrors: 'No errors',
+    unknownCode: 'Unrecognized HMS code — open the Bambu Lab Wiki for details.',
     viewOnWiki: 'View on Bambu Lab Wiki',
     clearInstructions: 'Clear errors on the printer to dismiss them here.',
     clearErrors: 'Clear Errors',


### PR DESCRIPTION
Fixes #1840.

### Problem

HMS errors whose `MMMM_EEEE` code isn't in the local `ERROR_DESCRIPTIONS` catalog are filtered out in **two** places in `HMSErrorModal.tsx`:

- `filterKnownHMSErrors()` — drives the badge count, status classification and the "view HMS" affordance across `PrintersPage`/`BulkPrinterToolbar`;
- the modal's internal `knownErrors` filter — drives what the modal lists.

Both keep only `ERROR_DESCRIPTIONS[shortCode] !== undefined`. So an HMS error that the backend has **actions** for, but whose code we don't describe locally, renders **nothing**: no badge, no count, no modal entry, and therefore none of the new #1830 action buttons. The user just sees a silently paused printer with no way to respond from the UI.

### Fix

Surface an error when it is **described OR carries actions** (`isDisplayableHMSError`), used by both filter sites, and fall back to a generic description for uncataloged codes:

- actionable faults always render (badge + modal + Ignore/Resume buttons);
- uncataloged **action-less** codes stay hidden, so no new noise is introduced;
- uncataloged actionable codes get a fallback description + the existing "View on Bambu Lab Wiki" link instead of an empty line.

### Testing

- `npm run build` (`tsc -b` typecheck + `vite build`) — clean
- `eslint` on the changed files — clean
- `vitest src/__tests__/components/HMSErrorModal.test.tsx` — 14 passed, incl. two new cases (an uncataloged error with actions now renders its `[code]`, both action buttons, and the fallback description)
- **Validated live on an H2C (fw 01.02.00.00):** `0500_809C` *"Build plate not properly positioned"* — a false positive from a markerless third-party build plate — previously rendered nothing in the UI and now shows correctly with its `IGNORE_RESUME` / `PROBLEM_SOLVED_RESUME` buttons.

### Notes

Complements #1830 (which fixed the action **dispatch**): without this, the action buttons that #1830 wired up are never reachable for any code missing from the frontend catalog — including safety-relevant warnings like build-plate collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
