### PR TITLE
Update auto-drying stop threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Optional but recommended — drop the [`slicer-api/` Compose stack](slicer-api/R
 - AMS slot configuration (model-filtered presets, K profiles, color picker, pre-population for configured slots)
 - AMS info card (hover for serial number, firmware version) with custom friendly names that persist across printers
 - **AMS remote drying** — Start, monitor, and stop drying sessions for AMS 2 Pro and AMS-HT directly from the Printers page with filament-based temperature/duration presets, optional spool rotation; automatic PSU detection and HMS power error reporting. Rotate-spool toggle is disabled per-AMS when any tray has filament threaded into the feed tube (the AMS mechanism is locked there — rotating would jam the filament)
-- **Queue auto-drying** — Automatically dry filament between scheduled prints when humidity exceeds threshold; configurable presets per filament type, optional blocking mode
+- **Queue auto-drying** — Automatically dry filament between scheduled prints when humidity exceeds the fair threshold, then continue for the configured drying duration; configurable presets per filament type, optional blocking mode
 - **Ambient drying** — Automatically keep filament dry on idle printers based on humidity, regardless of whether prints are queued
 - **Continue drying while printing** — On capable hardware (H2D 01.03.00.00+, H2C / H2S / P2S / H2D Pro 01.02.00.00+, X2D / A2L 01.01.00.00+, X1C 01.11.02.00+), auto-drying can keep running during a print. Default off, opt-in toggle in Settings → Print Queue. Drying temperature is automatically capped 5°C below the idle preset (floor 40°C) to protect spools inside the hot enclosure
 - Configurable drying presets per filament type (temperature & duration for AMS 2 Pro and AMS-HT)

--- a/backend/tests/unit/test_scheduler_auto_drying.py
+++ b/backend/tests/unit/test_scheduler_auto_drying.py
@@ -3,7 +3,7 @@
 Covers:
 - Conservative drying parameter selection (mixed filaments)
 - Drying preset loading (user-configured vs defaults)
-- Auto-drying lifecycle: start, humidity stop, minimum drying time
+- Auto-drying lifecycle: start threshold, running dries continue to configured duration
 - Auto-drying stop conditions: feature disabled, no scheduled items, per-printer
 - Sync drying state after restart
 """


### PR DESCRIPTION
## Description

Updates auto-drying so the fair humidity threshold still triggers drying, but an active drying cycle continues until the good humidity threshold is reached or the configured drying duration completes.

## Related Issue

https://github.com/maziggy/bambuddy/issues/1861

## Documentation

- [ ] Docs PR(s) linked above
- [X] No docs update required — reason:  README updated; wiki update pending maintainer guidance. I can create a wiki PR if requested.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (Readme)
- [ ] Code refactoring
- [ ] Performance improvement
- [X] Test addition or update

## Changes Made

- Load `ams_humidity_fair` as the auto-drying start threshold.
- Load `ams_humidity_good` as the humidity-based auto-stop threshold.
- Keep per-filament humidity overrides as trigger thresholds.
- Add regression tests for the fair-to-good drying.
- Update README auto-drying wording.

## Screenshots

<!-- If applicable, add screenshots to demonstrate your changes -->

## Testing

- [X] I have tested this on my local machine
- [X] I have tested with my printer model: H2D

## Checklist

- [X ] My code follows the project's coding style
- [x] I have commented my code where necessary
- [X] My changes generate no new warnings
- [X] I have tested my changes thoroughly

## Additional Notes

<!-- Add any additional information that reviewers should know -->
