### PR TITLE
fix(queue): dispatch use_ams=true when Any-[model] resolves a real AMS slot (#2595)

### DIFF
--- a/backend/app/services/bambu_mqtt.py
+++ b/backend/app/services/bambu_mqtt.py
@@ -3715,6 +3715,19 @@ class BambuMQTTClient:
                         self.serial_number,
                     )
 
+            # Symmetric to the gate above: if the resolved mapping targets a real
+            # AMS tray, force use_ams=True even when the incoming/stored value was
+            # False. Queue 'Any [model]' jobs arrive external-only from the VP (the
+            # slicer sees no AMS on the virtual printer) and are colour-matched to a
+            # real slot at dispatch — the stale False must not override that (#2595).
+            if ams_mapping and not use_ams and not is_dual_nozzle:
+                if any(t is not None and 0 <= int(t) < 254 for t in ams_mapping):
+                    use_ams = True
+                    logger.info(
+                        "[%s] Resolved AMS slot in mapping — setting use_ams=True",
+                        self.serial_number,
+                    )
+
             # Unique per-submission identity fields. Hardcoded "0" values caused
             # third-party MQTT observers (OctoEverywhere, etc.) to see reprints as
             # continuations of the same job: the printer reuses gcode_start_time


### PR DESCRIPTION
**I tested this locally in my container and was able to finally successfully print to my Bambu X1C printers _without_ selecting a target printer just like the docs say.**

## Summary

Queue jobs dispatched to a **Virtual Printer** with an **"Any [model]"** target (no specific printer) are sent to the matched printer with `use_ams: false` **even when the colour-match resolved a real, loaded AMS slot**. The printer then ignores the AMS, falls back to the (empty) external spool, and aborts at layer 0 with **"not enough filament"** despite the mapped slot being loaded. Selecting a **specific** printer works, which is what masks the bug.

Fixes #2595.

## Root cause

1. A slicer only ever sees the VP's **external spool** (a virtual printer advertises no AMS), so on intake the queue item is stamped `use_ams=False` (`virtual_printer/manager.py`, the `("use_ams", "use_ams")` field copy).
2. At dispatch the scheduler passes `use_ams=item.use_ams` (the stale `False`) alongside a freshly colour-matched `ams_mapping` that points at a **real AMS tray** (`print_scheduler.py`).
3. In `_build_print_command` (`bambu_mqtt.py`) the only `use_ams` gate turns it **off** (all-external case) and never back **on**:

```python
if ams_mapping and use_ams and not is_dual_nozzle:
    if all(t is None or int(t) < 0 or int(t) >= 254 for t in ams_mapping):
        use_ams = False   # all external -> off (never turned back on)
```

So a job with `ams_mapping=[…, <real tray>]` but `use_ams=False` is dispatched verbatim → printer uses the external spool → "not enough filament."

## Reproduction

- VP in **Queue** mode, **Auto-dispatch on**, target **Any X1C** (no specific printer).
- Slice/send a normal AMS print from a slicer to the VP.
- The matched printer aborts at layer 0 with insufficient/no filament even though the slot is loaded.

I have three BambuLab X1C printers. **Every `use_ams=False` queue item failed**; the only ones that printed had `use_ams=True` (the specific-printer path).

**Before (stock 0.2.4.9):**
```
[<printer-serial>] Sending print command: {… "use_ams": false … "ams_mapping": [4] …}
→ printer falls back to the empty external spool → "not enough filament"
```

**After (this patch):**
```
[<printer-serial>] Resolved AMS slot in mapping — setting use_ams=True
[<printer-serial>] Sending print command: {… "use_ams": true … "ams_mapping": […, 3],
                    "ams_mapping2": [… {"ams_id": 0, "slot_id": 3}]}
[<printer-serial>] PRINT START detected — subtask: shell
```

## Fix

Add the symmetric gate directly below the existing all-external guard: if `ams_mapping` contains any real AMS tray (`0..253`) and the printer is single-nozzle, force `use_ams=True`. Dual-nozzle is intentionally skipped. `use_ams` encodes nozzle routing which matches the existing guard's `not is_dual_nozzle` condition.

Tested on X1C (X1Plus firmware `01.11.02.00`, network plugin `v02.03.00.62`): the same "Any X1C" job that previously aborted now dispatches `use_ams:true` and prints from the matched AMS slot.
