### PR TITLE
fix(plate-detection): use Pillow+numpy instead of cv2 (segfaults on musl/Alpine)

### DIFF
--- a/backend/app/services/plate_detection.py
+++ b/backend/app/services/plate_detection.py
@@ -24,6 +24,84 @@ except ImportError:
     logger.info("OpenCV not available - plate detection feature disabled")
 
 
+# --- Pillow + numpy image helpers ------------------------------------------
+# OpenCV's JPEG codec AND image-processing ops (imdecode/imread/imencode/
+# imwrite, cvtColor/GaussianBlur/normalize/absdiff) segfault under the
+# musl/gcompat shim used to run the manylinux cv2 wheel on Alpine/musl add-ons,
+# on images >= ~512px. Pillow ships its own libjpeg and uses its own (or numpy)
+# kernels, handling real camera frames (1280x720) fine, so all image I/O and
+# processing in this module is routed through Pillow + numpy instead of cv2.
+# cv2 is still imported above so the OPENCV_AVAILABLE gate (and the 503 route
+# guard / availability automation) keep their existing semantics, but it is no
+# longer called for any image operation.
+def _pil_decode(image_data: bytes):
+    """Decode JPEG/PNG bytes into a BGR uint8 HxWx3 array (cv2 convention).
+
+    Drop-in replacement for ``cv2.imdecode(np.frombuffer(buf, np.uint8), cv2.IMREAD_COLOR)``.
+    Returns None on failure (mirrors cv2's None-on-failure contract).
+    """
+    try:
+        from PIL import Image
+        import io
+
+        img = Image.open(io.BytesIO(image_data)).convert("RGB")
+        arr = np.asarray(img)  # RGB HxWx3 uint8
+        return arr[:, :, ::-1].copy()  # RGB -> BGR for cv2 consumers
+    except Exception as e:
+        logger.warning("Pillow decode failed: %s", e)
+        return None
+
+
+def _pil_read(path):
+    """Read a JPEG/PNG file into a BGR uint8 HxWx3 array.
+
+    Drop-in replacement for ``cv2.imread(str(path), cv2.IMREAD_COLOR)``.
+    """
+    try:
+        from PIL import Image
+
+        img = Image.open(str(path)).convert("RGB")
+        arr = np.asarray(img)
+        return arr[:, :, ::-1].copy()
+    except Exception as e:
+        logger.warning("Pillow read failed for %s: %s", path, e)
+        return None
+
+
+def _pil_encode(frame_bgr, quality: int = 95) -> bytes:
+    """Encode a BGR uint8 HxWx3 array to JPEG bytes.
+
+    Drop-in replacement for ``cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, q])``.
+    """
+    import io
+
+    from PIL import Image
+
+    rgb = np.ascontiguousarray(frame_bgr[:, :, ::-1])  # BGR -> RGB, contiguous
+    img = Image.fromarray(rgb)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=quality)
+    return buf.getvalue()
+
+
+def _pil_resize_bgr(frame_bgr, size, resample=None) -> np.ndarray:
+    """Resize a BGR uint8 array to (width, height).
+
+    Drop-in replacement for ``cv2.resize(frame, (w, h), interpolation=...)``.
+    ``resample`` accepts PIL resample constants (e.g. ``1``/LANCZOS for
+    downscaling, ``2``/BILINEAR for the cv2 INTER_LINEAR default).
+    """
+    from PIL import Image
+
+    if resample is None:
+        resample = Image.BILINEAR  # matches cv2.resize default (INTER_LINEAR)
+    rgb = np.ascontiguousarray(frame_bgr[:, :, ::-1])  # BGR -> RGB
+    img = Image.fromarray(rgb).resize((int(size[0]), int(size[1])), resample)
+    out = np.asarray(img)  # RGB
+    return out[:, :, ::-1].copy()  # RGB -> BGR
+# ---------------------------------------------------------------------------
+
+
 def _get_calibration_dir() -> Path:
     """Get the calibration directory from settings (ensures persistence in Docker)."""
     from backend.app.core.config import settings
@@ -259,7 +337,7 @@ class PlateDetector:
             return None
 
         try:
-            img = cv2.imread(str(path))
+            img = _pil_read(path)
             if img is None:
                 return None
 
@@ -272,9 +350,9 @@ class PlateDetector:
                 new_h = max_size
                 new_w = int(w * max_size / h)
 
-            thumb = cv2.resize(img, (new_w, new_h), interpolation=cv2.INTER_AREA)
-            _, buffer = cv2.imencode(".jpg", thumb, [cv2.IMWRITE_JPEG_QUALITY, 80])
-            return buffer.tobytes()
+            # LANCZOS (=1) gives clean downscaling (cv2.INTER_AREA equivalent)
+            thumb = _pil_resize_bgr(img, (new_w, new_h), 1)
+            return _pil_encode(thumb, 80)
         except Exception as e:
             logger.error("Error creating thumbnail: %s", e)
             return None
@@ -300,11 +378,25 @@ class PlateDetector:
         and noise while preserving large objects. Then normalizes brightness
         to reduce lighting sensitivity.
         """
-        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        # Implemented with Pillow + numpy (not cv2): OpenCV's image-processing ops
+        # (cvtColor/GaussianBlur/normalize) segfault on large images (>=512px)
+        # under the musl/gcompat shim on Alpine. Pillow uses its own kernels and
+        # handles real frames (1280x720) fine.
+        from PIL import Image, ImageFilter
+
+        # BGR (cv2 convention) -> RGB for Pillow
+        rgb = np.ascontiguousarray(frame[:, :, ::-1])
+        gray = np.asarray(Image.fromarray(rgb).convert("L"))
         # Very heavy blur to smooth texture, keep only large shapes
-        blurred = cv2.GaussianBlur(gray, (51, 51), 0)
+        # (PIL radius ~= cv2 (51,51) sigma ~= 8)
+        blurred = np.asarray(Image.fromarray(gray).filter(ImageFilter.GaussianBlur(radius=8)))
         # Normalize to 0-255 range to reduce brightness sensitivity
-        normalized = cv2.normalize(blurred, None, 0, 255, cv2.NORM_MINMAX)
+        mn = float(blurred.min())
+        mx = float(blurred.max())
+        if mx - mn > 1e-6:
+            normalized = ((blurred.astype(np.float32) - mn) / (mx - mn) * 255.0).astype(np.uint8)
+        else:
+            normalized = np.zeros_like(blurred)
         return normalized
 
     def calibrate(self, image_data: bytes, printer_id: int, label: str | None = None) -> tuple[bool, str, int]:
@@ -324,9 +416,12 @@ class PlateDetector:
         from datetime import datetime
 
         try:
-            # Decode image
-            nparr = np.frombuffer(image_data, np.uint8)
-            frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+            # Validate the image is decodable (rejects corrupt input). The
+            # decoded frame itself is not used further — the original JPEG
+            # bytes are written verbatim below to avoid a lossy decode/re-encode
+            # cycle. Implemented via Pillow (not cv2.imdecode) because OpenCV's
+            # JPEG codec segfaults on large images under the musl/gcompat shim.
+            frame = _pil_decode(image_data)
 
             if frame is None:
                 return False, "Failed to decode image", -1
@@ -343,10 +438,13 @@ class PlateDetector:
             # Save to next available slot
             slot_index = num_existing
             reference_path = _get_calibration_dir() / f"printer_{printer_id}_ref_{slot_index}.jpg"
-            write_success = cv2.imwrite(str(reference_path), frame, [cv2.IMWRITE_JPEG_QUALITY, 95])
-
-            if not write_success:
-                logger.error("cv2.imwrite failed for %s", reference_path)
+            # Write the original JPEG bytes verbatim — no decode/re-encode.
+            # (cv2.imwrite would re-encode at quality 95, adding generation loss
+            # and segfaulting under the musl/gcompat shim on large images.)
+            try:
+                reference_path.write_bytes(image_data)
+            except OSError as write_err:
+                logger.error("Failed to write reference image %s: %s", reference_path, write_err)
                 return False, "Failed to save reference image", -1
 
             # Verify the file actually exists and has content
@@ -430,9 +528,9 @@ class PlateDetector:
                     needs_calibration=True,
                 )
 
-            # Decode current image
-            nparr = np.frombuffer(image_data, np.uint8)
-            current_frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+            # Decode current image (via Pillow — cv2.imdecode segfaults on large
+            # images under the musl/gcompat shim)
+            current_frame = _pil_decode(image_data)
 
             if current_frame is None:
                 return PlateDetectionResult(
@@ -452,21 +550,23 @@ class PlateDetector:
             best_diff = None
 
             for idx, ref_path in enumerate(reference_paths):
-                # Load reference image
-                reference_frame = cv2.imread(str(ref_path), cv2.IMREAD_COLOR)
+                # Load reference image (via Pillow — cv2.imread segfaults on
+                # large images under the musl/gcompat shim)
+                reference_frame = _pil_read(ref_path)
                 if reference_frame is None:
                     continue
 
                 # Ensure same dimensions
                 if current_frame.shape != reference_frame.shape:
-                    reference_frame = cv2.resize(reference_frame, (current_frame.shape[1], current_frame.shape[0]))
+                    reference_frame = _pil_resize_bgr(reference_frame, (current_frame.shape[1], current_frame.shape[0]))
 
                 # Extract ROI and preprocess
                 reference_roi, _, _, _, _ = self._extract_roi(reference_frame)
                 reference_processed = self._preprocess_for_comparison(reference_roi)
 
-                # Calculate absolute difference
-                diff = cv2.absdiff(current_processed, reference_processed)
+                # Calculate absolute difference (numpy — cv2.absdiff segfaults
+                # under the musl shim on large arrays)
+                diff = np.abs(current_processed.astype(np.int16) - reference_processed.astype(np.int16)).astype(np.uint8)
 
                 # Calculate mean difference as percentage
                 mean_diff = np.mean(diff)
@@ -508,59 +608,52 @@ class PlateDetector:
             else:
                 message = f"Objects detected on plate (difference: {difference_percent:.1f}%, best ref {best_ref_idx + 1}/{num_refs})"
 
-            # Generate debug image if requested
+            # Generate debug image if requested (via Pillow — cv2 drawing/encode
+            # ops segfault under the musl/gcompat shim on large frames)
             debug_image = None
             if include_debug_image and best_diff is not None:
-                debug_frame = current_frame.copy()
+                from PIL import Image, ImageDraw, ImageFont
 
-                # Draw ROI rectangle
-                cv2.rectangle(
-                    debug_frame,
-                    (x_start, y_start),
-                    (x_start + roi_width, y_start + roi_height),
-                    (0, 255, 0),
-                    2,
+                # Work in RGB for Pillow; debug_frame is BGR (cv2 convention)
+                debug_rgb = np.ascontiguousarray(current_frame[:, :, ::-1])
+                img = Image.fromarray(debug_rgb)
+                draw = ImageDraw.Draw(img)
+
+                # Draw ROI rectangle (green)
+                draw.rectangle(
+                    [x_start, y_start, x_start + roi_width, y_start + roi_height],
+                    outline=(0, 255, 0),
+                    width=2,
                 )
 
-                # Create colored difference overlay
-                # Red = areas that are different from reference
-                # Amplify diff for visibility (multiply by 3, cap at 255)
+                # Colored difference overlay: red where the frame differs from
+                # the best reference. Amplify diff for visibility (x3, cap 255).
                 diff_amplified = np.minimum(best_diff * 3, 255).astype(np.uint8)
-                diff_colored = cv2.cvtColor(diff_amplified, cv2.COLOR_GRAY2BGR)
-                diff_colored[:, :, 0] = 0  # Remove blue
-                diff_colored[:, :, 1] = 0  # Remove green
-                # Red channel has the diff
+                overlay = np.zeros((roi_height, roi_width, 3), dtype=np.uint8)
+                overlay[:, :, 0] = diff_amplified  # red channel (RGB)
+                # Blend overlay 0.5 with the ROI, write back onto the image
+                roi_rgb = np.ascontiguousarray(
+                    current_frame[y_start : y_start + roi_height, x_start : x_start + roi_width, ::-1]
+                )
+                blended = (overlay.astype(np.float32) * 0.5 + roi_rgb.astype(np.float32) * 0.5).astype(np.uint8)
+                img.paste(Image.fromarray(blended), (x_start, y_start))
 
-                # Overlay difference on ROI
-                roi_overlay = debug_frame[y_start : y_start + roi_height, x_start : x_start + roi_width]
-                cv2.addWeighted(diff_colored, 0.5, roi_overlay, 0.5, 0, roi_overlay)
-
-                # Add status text
+                # Add status text (red = objects detected, green = empty)
                 status_text = "EMPTY" if is_empty else "OBJECTS DETECTED"
-                color = (0, 255, 0) if is_empty else (0, 0, 255)
-                cv2.putText(debug_frame, status_text, (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 1, color, 2)
-                cv2.putText(
-                    debug_frame,
-                    f"Diff: {difference_percent:.1f}% (ref {best_ref_idx + 1}/{num_refs})",
-                    (10, 60),
-                    cv2.FONT_HERSHEY_SIMPLEX,
-                    0.7,
-                    color,
-                    2,
-                )
-                cv2.putText(
-                    debug_frame,
-                    f"Confidence: {confidence:.0%}",
-                    (10, 90),
-                    cv2.FONT_HERSHEY_SIMPLEX,
-                    0.7,
-                    color,
-                    2,
-                )
+                color = (0, 255, 0) if is_empty else (255, 0, 0)
+                try:
+                    font_lg = ImageFont.truetype("DejaVuSans.ttf", 24)
+                    font_sm = ImageFont.truetype("DejaVuSans.ttf", 17)
+                except OSError:
+                    font_lg = ImageFont.load_default()
+                    font_sm = font_lg
+                draw.text((10, 4), status_text, fill=color, font=font_lg)
+                draw.text((10, 32), f"Diff: {difference_percent:.1f}% (ref {best_ref_idx + 1}/{num_refs})", fill=color, font=font_sm)
+                draw.text((10, 56), f"Confidence: {confidence:.0%}", fill=color, font=font_sm)
 
                 # Encode debug image as JPEG
-                _, buffer = cv2.imencode(".jpg", debug_frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
-                debug_image = buffer.tobytes()
+                debug_bgr = np.ascontiguousarray(np.asarray(img)[:, :, ::-1])  # RGB -> BGR
+                debug_image = _pil_encode(debug_bgr, 85)
 
             return PlateDetectionResult(
                 is_empty=is_empty,


### PR DESCRIPTION
## Problem

On **Alpine/musl** add-ons (notably Home Assistant OS, e.g. Raspberry Pi aarch64), the OpenCV wheel has to be installed via a `gcompat` (glibc→musl) shim because PyPI ships no `musllinux` wheel. Under that shim, OpenCV's **JPEG codec** *and* **image-processing ops** segfault (SIGSEGV, exit 139) on images **≥ ~512px**, while working fine on small arrays.

Reproduced deterministically (same shim, same image):

| Operation | ≤256×256 | ≥512×512 |
| --- | --- | --- |
| `cv2.imdecode` / `cv2.imread` | OK | **SEGV** |
| `cv2.imwrite` / `cv2.imencode` | OK | **SEGV** |
| `cv2.cvtColor` | OK | **SEGV** |
| `cv2.GaussianBlur` / `cv2.normalize` / `cv2.absdiff` | OK | **SEGV** |

None of the usual knobs help: `setNumThreads(0)`, `setUseOptimized(False)`, `OMP_NUM_THREADS=1`, `cv2.ocl.setUseOpenCL(False)` — all still segfault at ≥512px.

Because plate detection runs every image op through cv2, the crash kills the **uvicorn worker mid-request**. In the UI this surfaces as:

- **Calibrate Empty Plate** → `failed to fetch`, reference counter stuck at **0/5**
- no `uvicorn.access` log line for the calibrate POST (response never sent)
- no error/exception log — it's a segfault, not a Python exception (so it's invisible to normal logging and looks like "the request never arrived")

The camera capture itself (chamber-image protocol on TLS 6000) works fine — the failure is purely in OpenCV's image ops.

## Solution

Route **all** image I/O and processing in `plate_detection.py` through **Pillow + numpy**, which ship their own libjpeg and use their own / numpy kernels and handle real camera frames (1280×720) fine. cv2 is still imported so `OPENCV_AVAILABLE` (and the 503 route guard / `is_plate_detection_available()`) keep their existing semantics — but it is no longer called for any image operation. Plate detection's real runtime dependency is now Pillow.

### Changes

- New helpers `_pil_decode` / `_pil_read` / `_pil_encode` / `_pil_resize_bgr` (BGR uint8 convention, drop-ins for `cv2.imdecode` / `cv2.imread` / `cv2.imencode` / `cv2.resize`).
- `_preprocess_for_comparison`: `PIL.Image.convert("L")` + `ImageFilter.GaussianBlur(radius=8)` (≈ cv2 `(51,51)` sigma ≈ 8) + numpy MINMAX normalization, instead of `cv2.cvtColor` / `GaussianBlur` / `normalize`.
- `cv2.absdiff` → `np.abs(a.astype(int16) - b.astype(int16)).astype(uint8)`.
- Debug image: `PIL.ImageDraw` (rectangle, blended red overlay via numpy, text via `ImageFont.truetype("DejaVuSans.ttf", …)` with `load_default()` fallback) + `_pil_encode`, instead of `cv2.rectangle` / `cvtColor` / `addWeighted` / `putText` / `imencode`.
- **`calibrate()` writes the original JPEG bytes verbatim** (`reference_path.write_bytes(image_data)`) instead of `cv2.imdecode` then `cv2.imwrite` at quality 95. The captured `image_data` is already a valid JPEG; decoding only to re-encode added a lossy generation-loss step (and the segfault). `_pil_decode` is still called once to validate the input is decodable (rejects corrupt bytes, mirroring the old `if frame is None` guard) — the decoded array isn't used further. On-disk format is unchanged (plain JPEGs + metadata JSON), so existing calibrations and the analyze path keep working.

### What did NOT change

- HTTP routes (`backend/app/api/routes/camera.py`) — untouched.
- Calibration on-disk format — untouched.
- `OPENCV_AVAILABLE` / `is_plate_detection_available()` semantics — untouched.
- Public method signatures and `PlateDetectionResult` — untouched.

## Verification

End-to-end on HAOS (RPi 5, aarch64, musl, the same gcompat shim that segfaulted):

```
calibrate empty1.jpg -> True  (1/5 references)
calibrate empty2.jpg -> True  (2/5 references)

GET /api/v1/printers/1/camera/check-plate?use_external=false&include_debug_image=true
HTTP 200 in 3.18s
{'is_empty': False, 'confidence': 1.0, 'difference_percent': 8.33,
 'message': 'Objects detected on plate (difference: 8.3%, best ref 1/2)'}
```

No segfault, no `failed to fetch`, counter 2/5. The "Objects detected" result is correct — the printer was mid-print, so the plate was not empty; this validated the whole capture → decode → preprocess → compare → debug-image pipeline that previously crashed.

## Notes / discussion

- The cv2 segfault is **platform-specific** (musl + gcompat shim). On standard glibc installs (the manylinux wheel running natively) cv2 works fine, so this change is a no-op in behavior there — it just uses Pillow instead of cv2. Pillow is already a common dependency; if it isn't currently declared as a hard requirement of the backend, it may need to be added/gated. I'd be happy to adjust based on the maintainer's preferred dependency story.
- An alternative the maintainer may prefer is keeping cv2 as the primary path and falling back to Pillow only on musl (platform detection). I went with the simpler single-path approach because it's what's verified working and keeps one code path; happy to refactor to a conditional if that's preferred.
- A natural follow-up (kept out of this PR to stay minimal): make `OPENCV_AVAILABLE` / `is_plate_detection_available()` depend on Pillow rather than cv2, and drop the cv2 import entirely from this module. Plate detection no longer needs cv2 at all once this lands.

Happy to split/adjust commits as needed. Thanks for the add-on!