### PR TITLE
fix(install): check node/npm as the service user that runs the build

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -423,14 +423,41 @@ setup_virtualenv() {
     log_success "Virtual environment configured"
 }
 
+# Run a command in the same account/PATH the frontend build uses: the current
+# user on macOS, the service user on Linux (via `sudo -H -u`, whose PATH is
+# sudo's secure_path — NOT the installing user's). Keep this in lockstep with
+# how build_frontend invokes npm, or the node check and the build disagree.
+as_build_user() {
+    if [[ "$OS_TYPE" == "macos" ]]; then
+        "$@"
+    else
+        sudo -H -u "$SERVICE_USER" "$@"
+    fi
+}
+
 check_node_version() {
-    # Returns 0 if Node.js 20+ is available, 1 otherwise
-    if ! command -v node &>/dev/null; then
+    # Returns 0 if Node.js 20+ AND npm are available *to the account that will
+    # run the build*, 1 otherwise.
+    #
+    # The build runs `sudo -H -u "$SERVICE_USER" npm ci`, which resolves commands
+    # via sudo's secure_path and ignores the installing user's PATH. So node/npm
+    # installed under the installing user's home (nvm, asdf, fnm, Homebrew) are
+    # invisible to the build user. Probing `node` on the installing user's PATH
+    # here would falsely pass and then die later with "npm: command not found";
+    # probe as the same user the build uses instead. (`command -v` is a shell
+    # builtin, so run it through `sh -c`.)
+    if ! as_build_user sh -c 'command -v node >/dev/null 2>&1'; then
+        return 1
+    fi
+
+    # node without npm still fails `npm ci` — require both.
+    if ! as_build_user sh -c 'command -v npm >/dev/null 2>&1'; then
+        log_warn "Node.js is present but npm is not available to the build user; reinstalling Node.js"
         return 1
     fi
 
     local version
-    version=$(node --version 2>/dev/null | sed 's/^v//')
+    version=$(as_build_user sh -c 'node --version' 2>/dev/null | sed 's/^v//')
     local major
     major=$(echo "$version" | cut -d'.' -f1)
 


### PR DESCRIPTION
## Problem

`check_node_version` probes `node` in the **installing user's** environment:

```bash
if ! command -v node &>/dev/null; then
```

But `build_frontend` runs the actual build as the **service user**:

```bash
sudo -H -u "$SERVICE_USER" npm ci
```

`sudo -u bambuddy …` resolves commands via sudo's `secure_path` and does **not** inherit the installing user's `PATH`. So when the operator installed Node via **nvm / asdf / fnm / Homebrew-in-home** (shims under `$HOME`):

1. `check_node_version` finds `node` on the installing user's PATH → returns 0 → `install_nodejs` is **skipped**.
2. `sudo -H -u bambuddy npm ci` runs with `secure_path`, where that node/npm does not exist → **`npm: command not found`**, and the install dies at the last major step.

A second, smaller gap: the check only looks for `node`, never `npm` — but `npm ci` is what actually runs.

## Fix

- Add an `as_build_user` helper that runs a command in the exact context the build uses — the current user on macOS, `sudo -H -u "$SERVICE_USER"` on Linux — so the version check and the build can't disagree.
- `check_node_version` now probes `node` **through that helper** (`sh -c 'command -v node'`, since `command -v` is a builtin), and reads the version as that same user.
- It also now checks `npm`, not just `node`. If npm isn't resolvable to the build user, it returns 1 so `install_nodejs` runs and lays down a system-wide Node on `secure_path`.

Net effect: on a machine where the operator's Node lives only under their home dir, the check now correctly reports it unavailable to the build user, triggers the system install, and `npm ci` succeeds as the service user.

`bash -n` passes. macOS path is unchanged in behavior (still runs as the current user).