### PR TITLE
Add the ability to specify a sound for PushOver notifications

### DIFF
--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -242,6 +242,7 @@ class PushoverConfig(BaseModel):
     # Pushover requires retry >= 30s and expire <= 10800s (3h).
     retry: int = Field(default=60, ge=30, le=10800, description="Emergency re-alert interval in seconds (priority 2)")
     expire: int = Field(default=3600, ge=30, le=10800, description="Emergency alert expiry in seconds (priority 2)")
+    sound: str | None = Field(default=None, description="Pushover notification sound (built-in sound name, blank = user's default)")
 
 
 class TelegramConfig(BaseModel):

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -432,7 +432,7 @@ class NotificationService:
         """Send notification via Pushover.
 
         Args:
-            config: Provider configuration with user_key, app_token, priority
+            config: Provider configuration with user_key, app_token, priority, sound
             title: Notification title
             message: Notification body
             image_data: Optional JPEG image bytes to attach (max 2.5MB)
@@ -455,6 +455,10 @@ class NotificationService:
             "message": message,
             "priority": priority,
         }
+
+        sound = (config.get("sound") or "").strip()
+        if sound:
+            data["sound"] = sound
 
         # Emergency priority (2) keeps re-alerting until acknowledged, so
         # Pushover *requires* retry (how often, >= 30s) and expire (when to

--- a/backend/tests/unit/test_pushover_priority.py
+++ b/backend/tests/unit/test_pushover_priority.py
@@ -81,3 +81,20 @@ async def test_non_emergency_priority_omits_retry_and_expire(service_with_captur
     assert ok
     assert "retry" not in client.last_data
     assert "expire" not in client.last_data
+
+
+@pytest.mark.asyncio
+async def test_sound_included_when_set(service_with_capture):
+    service, client = service_with_capture
+    ok, _ = await service._send_pushover({**BASE_CONFIG, "sound": "siren"}, "T", "M")
+    assert ok
+    assert client.last_data["sound"] == "siren"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sound", [None, "", "   "])
+async def test_sound_omitted_when_blank(service_with_capture, sound):
+    service, client = service_with_capture
+    ok, _ = await service._send_pushover({**BASE_CONFIG, "sound": sound}, "T", "M")
+    assert ok
+    assert "sound" not in client.last_data

--- a/frontend/src/components/AddNotificationModal.tsx
+++ b/frontend/src/components/AddNotificationModal.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { X, Save, Loader2, Send, CheckCircle, XCircle } from 'lucide-react';
+import { X, Save, Loader2, Send, CheckCircle, XCircle, Info } from 'lucide-react';
 import { api } from '../api/client';
 import type { NotificationProvider, NotificationProviderCreate, NotificationProviderUpdate, ProviderType } from '../api/client';
 import { Button } from './Button';
@@ -75,6 +75,21 @@ export function AddNotificationModal({ provider, onClose }: AddNotificationModal
 
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // Click-to-toggle field-tooltip popover (e.g. Pushover's sound list).
+  // Native `title` attributes don't work on touch devices, so this uses a
+  // click/tap-driven popover instead — closed by clicking outside it.
+  const [openTooltipKey, setOpenTooltipKey] = useState<string | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (tooltipRef.current && !tooltipRef.current.contains(e.target as Node)) {
+        setOpenTooltipKey(null);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
 
   // Fetch printers for linking
   const { data: printers } = useQuery({
@@ -231,6 +246,18 @@ export function AddNotificationModal({ provider, onClose }: AddNotificationModal
           { key: 'user_key', label: 'User Key', placeholder: 'Your Pushover user key', type: 'text', required: true },
           { key: 'app_token', label: 'App Token', placeholder: 'Your Pushover app token', type: 'text', required: true },
           { key: 'priority', label: 'Priority', placeholder: '0 (normal)', type: 'number', required: false },
+          {
+            key: 'sound',
+            label: t('notifications.pushoverSound'),
+            placeholder: 'Leave empty for default',
+            type: 'text',
+            required: false,
+            tooltip:
+              'Built-in sounds: pushover, bike, bugle, cashregister, classical, cosmic, falling, gamelan, ' +
+              'incoming, intermission, magic, mechanical, pianobar, siren, spacealarm, tugboat, alien, climb, ' +
+              'persistent, echo, updown, vibrate, none. Leave blank to use your device default. You can also ' +
+              'enter the name of a custom sound you configured on your phone.',
+          },
           // Emergency priority (2) requires retry/expire — Pushover rejects the
           // message otherwise. Only shown when priority is set to 2.
           {
@@ -400,10 +427,24 @@ export function AddNotificationModal({ provider, onClose }: AddNotificationModal
             {configFields
               .filter((field) => !('showIf' in field) || (field as { showIf?: (cfg: Record<string, string>) => boolean }).showIf?.(config) !== false)
               .map((field) => (
-              <div key={field.key}>
-                <label className="block text-sm text-bambu-gray mb-1">
+              <div key={field.key} ref={openTooltipKey === field.key ? tooltipRef : undefined}>
+                <label className="flex items-center gap-1 text-sm text-bambu-gray mb-1">
                   {field.label} {field.required && '*'}
+                  {'tooltip' in field && field.tooltip && (
+                    <button
+                      type="button"
+                      onClick={() => setOpenTooltipKey(openTooltipKey === field.key ? null : field.key)}
+                      className="text-bambu-gray hover:text-white transition-colors"
+                    >
+                      <Info className="w-3.5 h-3.5" />
+                    </button>
+                  )}
                 </label>
+                {'tooltip' in field && field.tooltip && openTooltipKey === field.key && (
+                  <div className="mb-2 p-2 text-xs text-bambu-gray bg-bambu-dark-secondary border border-bambu-dark-tertiary rounded-lg">
+                    {field.tooltip}
+                  </div>
+                )}
                 {field.type === 'select' && 'options' in field && field.options ? (
                   <select
                     value={config[field.key] || field.options[0]?.value || ''}

--- a/frontend/src/i18n/locales/de.ts
+++ b/frontend/src/i18n/locales/de.ts
@@ -5650,6 +5650,7 @@ export default {
     priority: 'Priorität',
     pushoverRetry: 'Notfall-Wiederholung (s)',
     pushoverExpire: 'Notfall-Ablauf (s)',
+    pushoverSound: 'Ton',
     botToken: 'Bot-Token',
     chatId: 'Chat-ID',
     telegramThreadId: 'Forum-Themen-ID',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5694,6 +5694,7 @@ export default {
     priority: 'Priority',
     pushoverRetry: 'Emergency Retry (s)',
     pushoverExpire: 'Emergency Expire (s)',
+    pushoverSound: 'Sound',
     botToken: 'Bot Token',
     chatId: 'Chat ID',
     telegramThreadId: 'Forum Topic ID',

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -5659,6 +5659,7 @@ export default {
     priority: 'Prioridad',
     pushoverRetry: 'Reintento de emergencia (s)',
     pushoverExpire: 'Expiración de emergencia (s)',
+    pushoverSound: 'Sonido',
     botToken: 'Token del bot',
     chatId: 'ID del chat',
     telegramThreadId: 'ID del tema del foro',

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -5640,6 +5640,7 @@ export default {
     priority: 'Priorité',
     pushoverRetry: 'Réessai urgence (s)',
     pushoverExpire: 'Expiration urgence (s)',
+    pushoverSound: 'Son',
     botToken: 'Jeton du bot',
     chatId: 'ID du chat',
     telegramThreadId: 'ID du sujet de forum',

--- a/frontend/src/i18n/locales/it.ts
+++ b/frontend/src/i18n/locales/it.ts
@@ -5639,6 +5639,7 @@ export default {
     priority: 'Priorità',
     pushoverRetry: 'Ripetizione emergenza (s)',
     pushoverExpire: 'Scadenza emergenza (s)',
+    pushoverSound: 'Suono',
     botToken: 'Token del bot',
     chatId: 'ID chat',
     telegramThreadId: 'ID argomento forum',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -5651,6 +5651,7 @@ export default {
     priority: '優先度',
     pushoverRetry: '緊急再通知 (秒)',
     pushoverExpire: '緊急有効期限 (秒)',
+    pushoverSound: 'サウンド',
     botToken: 'ボットトークン',
     chatId: 'チャットID',
     telegramThreadId: 'フォーラムトピック ID',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -5363,6 +5363,7 @@ export default {
     priority: '우선순위',
     pushoverRetry: '긴급 재알림 (초)',
     pushoverExpire: '긴급 만료 (초)',
+    pushoverSound: '사운드',
     botToken: '봇 토큰',
     chatId: '채팅 ID',
     telegramThreadId: '포럼 주제 ID',

--- a/frontend/src/i18n/locales/pt-BR.ts
+++ b/frontend/src/i18n/locales/pt-BR.ts
@@ -5639,6 +5639,7 @@ export default {
     priority: 'Prioridade',
     pushoverRetry: 'Repetição de emergência (s)',
     pushoverExpire: 'Expiração de emergência (s)',
+    pushoverSound: 'Som',
     botToken: 'Token do Bot',
     chatId: 'ID do Chat',
     telegramThreadId: 'ID do tópico do fórum',

--- a/frontend/src/i18n/locales/ru.ts
+++ b/frontend/src/i18n/locales/ru.ts
@@ -5350,6 +5350,7 @@ export default {
     priority: "Приоритет",
     pushoverRetry: "Повтор экстренного уведомления (с)",
     pushoverExpire: "Срок действия экстренного уведомления (с)",
+    pushoverSound: "Звук",
     botToken: "Токен бота",
     chatId: "ID чата",
     telegramThreadId: "ID темы форума",

--- a/frontend/src/i18n/locales/tr.ts
+++ b/frontend/src/i18n/locales/tr.ts
@@ -5599,6 +5599,7 @@ export default {
     priority: 'Öncelik',
     pushoverRetry: 'Acil yeniden deneme (sn)',
     pushoverExpire: 'Acil sona erme (sn)',
+    pushoverSound: 'Ses',
     botToken: 'Bot Belirteci',
     chatId: 'Sohbet ID',
     telegramThreadId: 'Forum Konu Kimliği',

--- a/frontend/src/i18n/locales/uk.ts
+++ b/frontend/src/i18n/locales/uk.ts
@@ -5694,6 +5694,7 @@ export default {
     priority: "Пріоритет",
     pushoverRetry: "Інтервал повторення екстреного сповіщення (с)",
     pushoverExpire: "Термін дії екстреного сповіщення (с)",
+    pushoverSound: "Звук",
     botToken: "Токен бота",
     chatId: "Ідентифікатор чату",
     telegramThreadId: "ID теми форуму",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -5639,6 +5639,7 @@ export default {
     priority: '优先级',
     pushoverRetry: '紧急重试 (秒)',
     pushoverExpire: '紧急过期 (秒)',
+    pushoverSound: '声音',
     botToken: '机器人令牌',
     chatId: '聊天 ID',
     telegramThreadId: '论坛话题 ID',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -5639,6 +5639,7 @@ export default {
     priority: '優先順序',
     pushoverRetry: '緊急重試 (秒)',
     pushoverExpire: '緊急逾時 (秒)',
+    pushoverSound: '聲音',
     botToken: '機器人權杖',
     chatId: '聊天 ID',
     telegramThreadId: '論壇主題 ID',


### PR DESCRIPTION
## Description

Added the ability to specify a sound for pushover notifications. The user can enter any sound that's available in the pushover library as well as custom configured sounds on their phone.

## Related Issue

https://github.com/maziggy/bambuddy/issues/1637

I opened this issue two months ago, but seeing as I am the only one that cares about it, I went ahead and resolved the issue myself. 

## Documentation

I also updated the wiki documentation. 

https://github.com/maziggy/bambuddy-wiki/pull/66

**Pick one**:
- [X] Docs PR(s) linked above
- [ ] No docs update required — reason: ___

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

- Added a new text box so the user can enter a sound.
- Added a tool tip so the user can see what sounds are available. 
- Added sound to the push over API request. 

## Screenshots

<!-- If applicable, add screenshots to demonstrate your changes -->

## Testing

I ran the website locally and verified that the sound worked and saving the configuration worked upon reload.

- [X] I have tested this on my local machine
- [ ] I have tested with my printer model: <!-- e.g., X1C, P1S, A1 -->

## Checklist

- [X] My code follows the project's coding style
- [X] I have commented my code where necessary
- [X] My changes generate no new warnings
- [X] I have tested my changes thoroughly

## Additional Notes

<!-- Add any additional information that reviewers should know -->
