### PR TITLE
Serve a library file's geometry as STL so clients can show it in 3D

### DIFF
--- a/backend/app/api/routes/library.py
+++ b/backend/app/api/routes/library.py
@@ -1,5 +1,6 @@
 """API routes for File Manager (Library) functionality."""
 
+import asyncio
 import base64
 import binascii
 import contextlib
@@ -70,6 +71,7 @@ from backend.app.services.design_settings import (
     overrides_from_config,
 )
 from backend.app.services.filament_requirements import annotate_rack_groups
+from backend.app.services.mesh_export import MeshExportError, export_mesh_stl, is_exportable
 from backend.app.services.plate_thumbnail import inject_plate_thumbnails_if_missing
 from backend.app.services.process_overrides import apply_process_overrides
 from backend.app.services.slice_output_check import missing_start_gcode_message, start_gcode_is_missing
@@ -5036,6 +5038,74 @@ async def download_file(
         str(abs_path),
         filename=file.filename,
         media_type="application/octet-stream",
+    )
+
+
+@router.get("/files/{file_id}/mesh")
+async def get_file_mesh(
+    file_id: int,
+    db: AsyncSession = Depends(get_db),
+    auth_result: tuple[User | None, bool] = Depends(
+        require_ownership_permission(
+            Permission.LIBRARY_READ_ALL,
+            Permission.LIBRARY_READ_OWN,
+        )
+    ),
+):
+    """Return the file's geometry as a binary STL.
+
+    Lets a client show a model in 3D without implementing a container parser. A
+    `.3mf` is a ZIP holding an XML mesh, and Bambuddy already reads it to render
+    thumbnails — so serving the mesh here saves every client from shipping its own
+    ZIP and 3MF handling to reach geometry the server can already load.
+
+    Sliced `.gcode.3mf` files are refused with a 400: they carry toolpaths, which a
+    G-code viewer shows properly, and trimesh cannot read their scene graph anyway.
+    """
+    user, can_read_all = auth_result
+    result = await db.execute(LibraryFile.active().where(LibraryFile.id == file_id))
+    file = _ensure_library_file_visible(result.scalar_one_or_none(), user, can_read_all)
+
+    # Refused on the NAME before touching disk, so a caller asking for the mesh of a
+    # sliced file or a text file gets a specific status rather than a generic failure.
+    if not is_exportable(file.filename):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This file is not a model container Bambuddy can export a mesh from. "
+                "Sliced files carry toolpaths — use the G-code viewer for those."
+            ),
+        )
+
+    abs_path = to_absolute_path(file.file_path)
+    if not abs_path or not abs_path.exists():
+        raise HTTPException(status_code=404, detail="File not found on disk")
+
+    # Off the event loop: parsing a 3MF and decimating it is CPU-bound and can take
+    # seconds on a dense model, which would otherwise stall every other request.
+    # `asyncio.to_thread` is how this codebase offloads blocking work elsewhere
+    # (`system.py`, `support.py`), so this follows suit rather than adding a second way.
+    try:
+        blob = await asyncio.to_thread(export_mesh_stl, abs_path)
+    except MeshExportError as e:
+        # 422 rather than 500: the request was well formed and the server is healthy —
+        # this particular file has no geometry to give, and the message says which.
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    stem = Path(file.filename).stem
+    if stem.lower().endswith(".gcode"):  # defensive; is_exportable already refused
+        stem = stem[: -len(".gcode")]
+
+    return Response(
+        content=blob,
+        media_type="model/stl",
+        headers={
+            "Content-Disposition": f'inline; filename="{stem}.stl"',
+            # The mesh is a pure function of the stored file, which is immutable once
+            # uploaded — so a client may keep it. Private because the bytes are behind
+            # a per-user permission check and must not land in a shared cache.
+            "Cache-Control": "private, max-age=86400",
+        },
     )
 
 

--- a/backend/app/services/mesh_export.py
+++ b/backend/app/services/mesh_export.py
@@ -1,0 +1,159 @@
+"""Export a library file's geometry as an STL mesh.
+
+Bambuddy can already turn a model into a *picture* — `stl_thumbnail` and
+`plate_thumbnail` both load a mesh and render it server-side. What it cannot do is
+hand the geometry itself to a client, so any UI that wants to let a user orbit a
+model has to parse the container on its own. For a `.3mf` that means shipping a ZIP
+reader and a 3MF XML parser into every client, which is a lot of duplicated work to
+reach a mesh the server can already read.
+
+This service exports that mesh as a binary STL, which is the most widely readable
+mesh format there is, so a client needs no container handling at all.
+
+Deliberately STL rather than a bespoke JSON vertex payload: STL is roughly half the
+bytes of an equivalent JSON array, every 3D toolkit already reads it, and it makes
+this endpoint's output the same shape as the `.stl` files already in the library —
+so a caller has one code path rather than two.
+"""
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Deliberately HALF of `stl_thumbnail.MAX_VERTICES` (100k), because the two are not
+# solving the same problem. The thumbnail budget bounds a render that happens once, on
+# the server, and is then a 256px PNG. This budget bounds bytes that cross a network
+# and get parsed by a client.
+#
+# STL is an unavoidably wasteful transport — 50 bytes per triangle, every vertex
+# duplicated three times — so the export is LARGER than the container it came from.
+# Measured on a real 3.9 MB project 3MF: at 100k vertices the STL is 10.0 MB, which
+# gzips to 4.8 MB, and this app installs no GZipMiddleware, so a client would fetch
+# the full ten. At 50k it is about five, which is a reasonable thing to hand a phone
+# for a model you want to spin around. Detail lost at that density is not visible
+# when orbiting.
+MAX_VERTICES = 50000
+
+# Extensions this can export from.
+#
+# A SLICED `.gcode.3mf` is deliberately absent, and not for lack of trying:
+# trimesh's 3MF loader raises `KeyError: 'world'` on Bambu Studio's sliced output,
+# whose scene graph does not carry the root node the loader expects. That file has
+# toolpaths anyway, so a G-code viewer is the right way to look at it — exporting a
+# mesh from it would be answering a question nobody asked, badly.
+SUPPORTED_SUFFIXES = (".3mf", ".stl", ".obj", ".ply")
+
+# Below this a file cannot hold a usable mesh — same reasoning as
+# `stl_thumbnail.MIN_USABLE_STL_BYTES`, which see. Pre-skipping keeps trimesh's
+# parser warnings out of the log for stub and placeholder uploads.
+MIN_USABLE_BYTES = 200
+
+
+class MeshExportError(Exception):
+    """Raised when a file cannot be turned into a mesh.
+
+    Carries a sentence fit to show a user rather than a stack trace: the caller is
+    an HTTP route, and "this file has no geometry" and "this file is not a model" are
+    different things a person can act on.
+    """
+
+
+def is_exportable(filename: str) -> bool:
+    """Whether `filename` names a container this service can export a mesh from.
+
+    Checked on the NAME rather than by opening the file, so a route can refuse early
+    without touching disk. `.gcode.3mf` is excluded before `.3mf` matches it, which
+    is why the test is on the full lowered name and not on `Path.suffix`.
+    """
+    name = filename.lower()
+    if name.endswith(".gcode.3mf"):
+        return False
+    return name.endswith(SUPPORTED_SUFFIXES)
+
+
+def export_mesh_stl(model_path: Path) -> bytes:
+    """Load `model_path` and return its geometry as a binary STL.
+
+    Raises:
+        MeshExportError: the file is missing, too small to hold a mesh, of a type
+            this cannot read, or parses to no geometry.
+    """
+    model_path = Path(model_path)
+
+    if not is_exportable(model_path.name):
+        raise MeshExportError(
+            f"{model_path.suffix or 'This file type'} is not a model container Bambuddy can export a mesh from."
+        )
+
+    if not model_path.exists():
+        raise MeshExportError("File not found on disk.")
+
+    if model_path.stat().st_size < MIN_USABLE_BYTES:
+        raise MeshExportError("This file is too small to contain a mesh.")
+
+    # Imported here rather than at module scope, matching `stl_thumbnail`: trimesh
+    # pulls in numpy, networkx and lxml, and a module that is merely imported by the
+    # route table should not pay for them.
+    try:
+        import trimesh
+    except ImportError as e:  # pragma: no cover - dependency is pinned
+        raise MeshExportError("Mesh export is unavailable on this server.") from e
+
+    try:
+        # `force="mesh"` collapses a multi-object scene into one mesh. A 3MF
+        # routinely holds several objects, and a viewer wants the whole plate as one
+        # thing; the alternative is a Scene, whose geometry a caller would then have
+        # to concatenate itself.
+        mesh = trimesh.load(str(model_path), force="mesh")
+    except Exception as e:
+        # trimesh raises a wide variety of errors on malformed containers. The
+        # message is logged for an operator and NOT forwarded to the client, which
+        # gets a sentence instead of a parser internal.
+        logger.info("Mesh load failed for %s: %s", model_path.name, e)
+        raise MeshExportError("This file could not be read as a 3D model.") from e
+
+    if mesh is None or not hasattr(mesh, "vertices") or len(mesh.vertices) == 0:
+        raise MeshExportError("This file contains no 3D geometry.")
+
+    mesh = _decimate_if_needed(mesh)
+
+    try:
+        blob = mesh.export(file_type="stl")
+    except Exception as e:
+        logger.warning("Mesh export failed for %s: %s", model_path.name, e)
+        raise MeshExportError("This model could not be converted to STL.") from e
+
+    # trimesh returns `bytes` for binary STL, but has historically returned `str`
+    # for some export paths. Normalise so the route can always set a byte length.
+    if isinstance(blob, str):
+        blob = blob.encode()
+    return blob
+
+
+def _decimate_if_needed(mesh):
+    """Reduce a very dense mesh, returning the original if reduction fails.
+
+    Same budget and same failure posture as `stl_thumbnail`: a mesh too big to
+    simplify is still better delivered whole than refused, because the client can
+    decide for itself whether to render it.
+    """
+    vertex_count = len(mesh.vertices)
+    if vertex_count <= MAX_VERTICES:
+        return mesh
+
+    logger.info("Simplifying mesh from %s vertices for export", vertex_count)
+    try:
+        keep_ratio = MAX_VERTICES / vertex_count
+        target_reduction = max(0.01, min(0.99, 1.0 - keep_ratio))
+        simplified = mesh.simplify_quadric_decimation(target_reduction)
+    except Exception as e:
+        logger.warning("Mesh simplification failed, exporting original: %s", e)
+        return mesh
+
+    if simplified is None or len(getattr(simplified, "vertices", [])) == 0:
+        logger.warning("Mesh simplification produced no geometry, exporting original")
+        return mesh
+
+    logger.info("Simplified mesh to %s vertices", len(simplified.vertices))
+    return simplified

--- a/backend/tests/unit/services/test_mesh_export.py
+++ b/backend/tests/unit/services/test_mesh_export.py
@@ -1,0 +1,211 @@
+"""Unit tests for the mesh export service."""
+
+import struct
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from backend.app.services.mesh_export import (
+    MAX_VERTICES,
+    MeshExportError,
+    export_mesh_stl,
+    is_exportable,
+)
+
+
+def _check_trimesh_available():
+    """Check if trimesh is available for import."""
+    try:
+        import trimesh  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _write_binary_stl(path: Path, triangles):
+    """Write a minimal binary STL so tests do not depend on a fixture file."""
+    with path.open("wb") as fh:
+        fh.write(b"\0" * 80)
+        fh.write(struct.pack("<I", len(triangles)))
+        for tri in triangles:
+            fh.write(struct.pack("<3f", 0.0, 0.0, 1.0))
+            for vertex in tri:
+                fh.write(struct.pack("<3f", *vertex))
+            fh.write(struct.pack("<H", 0))
+
+
+def _tetrahedron():
+    """Four facets enclosing a volume — the smallest mesh worth exporting."""
+    a, b, c, d = (0, 0, 0), (10, 0, 0), (5, 9, 0), (5, 3, 8)
+    return [(a, b, c), (a, b, d), (b, c, d), (c, a, d)]
+
+
+class TestIsExportable:
+    """Which filenames the service will accept."""
+
+    def test_model_containers_are_exportable(self):
+        for name in ("part.3mf", "part.stl", "part.obj", "part.ply"):
+            assert is_exportable(name), name
+
+    def test_extension_check_is_case_insensitive(self):
+        assert is_exportable("PART.STL")
+        assert is_exportable("Part.3MF")
+
+    def test_a_sliced_three_mf_is_refused(self):
+        """A `.gcode.3mf` ends in `.3mf` and must still be refused.
+
+        It carries toolpaths, so a G-code viewer is the right way to look at it — and
+        trimesh's 3MF loader raises `KeyError: 'world'` on Bambu Studio's sliced output
+        anyway, so accepting it would only produce a confusing 422 later.
+        """
+        assert not is_exportable("part.gcode.3mf")
+        assert not is_exportable("PART.GCODE.3MF")
+
+    def test_unrelated_types_are_refused(self):
+        for name in ("notes.txt", "archive.zip", "photo.png", "noextension"):
+            assert not is_exportable(name), name
+
+
+class TestExportMeshStl:
+    """Exporting geometry, and refusing clearly when there is none."""
+
+    def test_refuses_an_unsupported_type_without_touching_disk(self):
+        """The type check precedes the existence check, so a `.txt` that does not
+        exist is still reported as the wrong TYPE rather than as missing."""
+        with pytest.raises(MeshExportError) as excinfo:
+            export_mesh_stl(Path("/nonexistent/notes.txt"))
+        assert "model container" in str(excinfo.value)
+
+    def test_refuses_a_missing_file(self):
+        with pytest.raises(MeshExportError) as excinfo:
+            export_mesh_stl(Path("/nonexistent/part.stl"))
+        assert "not found" in str(excinfo.value).lower()
+
+    def test_refuses_a_file_too_small_to_hold_a_mesh(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stub = Path(tmpdir) / "stub.stl"
+            stub.write_bytes(b"short")
+            with pytest.raises(MeshExportError) as excinfo:
+                export_mesh_stl(stub)
+            assert "too small" in str(excinfo.value).lower()
+
+    @pytest.mark.skipif(not _check_trimesh_available(), reason="trimesh not installed")
+    def test_refuses_a_file_that_is_not_a_model(self):
+        """Large enough to pass the size gate, but not parseable. The client gets a
+        sentence, not a parser internal."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bogus = Path(tmpdir) / "bogus.stl"
+            bogus.write_bytes(b"this is not an STL file " * 20)
+            with pytest.raises(MeshExportError):
+                export_mesh_stl(bogus)
+
+    @pytest.mark.skipif(not _check_trimesh_available(), reason="trimesh not installed")
+    def test_exports_a_binary_stl_from_an_stl(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "tetra.stl"
+            _write_binary_stl(src, _tetrahedron())
+
+            blob = export_mesh_stl(src)
+
+            assert isinstance(blob, bytes)
+            # Binary STL: 80-byte header, a uint32 count, then 50 bytes per triangle.
+            assert len(blob) >= 84
+            (count,) = struct.unpack("<I", blob[80:84])
+            assert count == 4
+            assert len(blob) == 84 + count * 50
+
+    @pytest.mark.skipif(not _check_trimesh_available(), reason="trimesh not installed")
+    def test_the_export_is_loadable_again(self):
+        """Round-trip: whatever we hand a client must parse as a mesh.
+
+        The point of this endpoint is that a caller needs no container handling, so an
+        output that only *looks* like an STL would defeat it.
+        """
+        import trimesh
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "tetra.stl"
+            _write_binary_stl(src, _tetrahedron())
+            out = Path(tmpdir) / "roundtrip.stl"
+            out.write_bytes(export_mesh_stl(src))
+
+            reloaded = trimesh.load(str(out), force="mesh")
+            assert len(reloaded.vertices) > 0
+            assert len(reloaded.faces) == 4
+
+    @pytest.mark.skipif(not _check_trimesh_available(), reason="trimesh not installed")
+    def test_refuses_a_three_mf_that_is_not_really_a_model(self):
+        """A ZIP with a `.3mf` name and no model part inside.
+
+        Worth its own case because the type check passes on the NAME — so this is the
+        path where the loader, not the filename, has to be what refuses.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake = Path(tmpdir) / "fake.3mf"
+            with zipfile.ZipFile(fake, "w") as zf:
+                zf.writestr("hello.txt", "not a model " * 40)
+            with pytest.raises(MeshExportError):
+                export_mesh_stl(fake)
+
+
+class TestDecimation:
+    """The vertex budget, which exists so a client is never handed an unusable mesh."""
+
+    def test_a_small_mesh_is_left_alone(self):
+        """Below the budget nothing is touched, so a simple model exports exactly."""
+        from backend.app.services.mesh_export import _decimate_if_needed
+
+        class FakeMesh:
+            vertices = [(0, 0, 0)] * 10
+
+        mesh = FakeMesh()
+        assert _decimate_if_needed(mesh) is mesh
+
+    def test_a_failed_simplification_returns_the_original(self):
+        """A mesh too awkward to simplify is still better delivered whole than
+        refused — the client can decide what to do with it."""
+        from backend.app.services.mesh_export import _decimate_if_needed
+
+        class ExplodingMesh:
+            vertices = [(0, 0, 0)] * (MAX_VERTICES + 1)
+
+            def simplify_quadric_decimation(self, _reduction):
+                raise RuntimeError("no decimator available")
+
+        mesh = ExplodingMesh()
+        assert _decimate_if_needed(mesh) is mesh
+
+    def test_a_simplification_that_empties_the_mesh_returns_the_original(self):
+        """Guards the case that would otherwise export zero triangles: a decimator
+        that "succeeds" with nothing left is worse than no decimation."""
+        from backend.app.services.mesh_export import _decimate_if_needed
+
+        class EmptyingMesh:
+            vertices = [(0, 0, 0)] * (MAX_VERTICES + 1)
+
+            def simplify_quadric_decimation(self, _reduction):
+                class Empty:
+                    vertices = []
+
+                return Empty()
+
+        mesh = EmptyingMesh()
+        assert _decimate_if_needed(mesh) is mesh
+
+    def test_a_successful_simplification_is_used(self):
+        from backend.app.services.mesh_export import _decimate_if_needed
+
+        class Reduced:
+            vertices = [(0, 0, 0)] * 100
+
+        class DenseMesh:
+            vertices = [(0, 0, 0)] * (MAX_VERTICES * 2)
+
+            def simplify_quadric_decimation(self, _reduction):
+                return Reduced()
+
+        result = _decimate_if_needed(DenseMesh())
+        assert isinstance(result, Reduced)


### PR DESCRIPTION
## Description

Adds `GET /api/v1/library/files/{file_id}/mesh` — returns a library file's geometry as a binary STL.

Bambuddy can already turn a model into a *picture*: `stl_thumbnail` and `plate_thumbnail` both load a mesh with trimesh and render it server-side. What it cannot do is hand the geometry itself to a client, so any UI that wants to let a user orbit a model has to parse the container on its own. For a `.3mf` that means shipping a ZIP reader and a 3MF XML parser into every client, to reach a mesh the server can already read.

This serves that mesh, so a client needs no container handling at all.

## Related Issue

None — this adds an endpoint rather than fixing a reported issue.

## Documentation

**Companion docs PRs**:
- Wiki: maziggy/bambuddy-wiki#72

**Pick one**:
- [x] Docs PR(s) linked above
- [ ] No docs update required — reason: ___

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test addition or update

## Changes Made

- **`backend/app/services/mesh_export.py`** (new) — loads a model with trimesh, decimates it toward a vertex budget, exports binary STL. Raises `MeshExportError` carrying a sentence fit to show a user.
- **`backend/app/api/routes/library.py`** (+70) — the route. Auth and visibility copy the adjacent `download_file` exactly: `require_ownership_permission(LIBRARY_READ_ALL, LIBRARY_READ_OWN)` plus `_ensure_library_file_visible`.
- **`backend/tests/unit/services/test_mesh_export.py`** (new) — 15 unit tests.

### Why STL

Rather than a JSON vertex payload: roughly half the bytes, every 3D toolkit reads it, and it makes the response the same shape as the `.stl` files already in the library — so a caller has one code path instead of two.

### What it refuses, and why

**Sliced `.gcode.3mf` → 400.** Those carry toolpaths, which the G-code viewer shows properly. They are also unreadable here: trimesh's 3MF loader raises `KeyError: 'world'` on Bambu Studio's sliced output, whose scene graph has no root node the loader expects. Refusing on the filename means that arrives as a specific status rather than a confusing 422 after a wasted parse.

`400` rather than `415`: `415` conventionally describes the *request* body's content type, not the type of the resource being asked about, and it is absent from the wiki's documented status codes. Happy to change it.

**No geometry / unreadable / too small → 422** with a sentence fit to show a user. Parser internals are logged, not forwarded.

### The vertex budget is deliberately half the thumbnail service's

`stl_thumbnail.MAX_VERTICES` is 100k and bounds a render that happens once, server-side, and becomes a 256 px PNG. This bounds bytes that cross a network and get parsed by a client — a different problem.

STL is an unavoidably wasteful transport: 50 bytes per triangle, every vertex duplicated three times, so the export is *larger* than the container it came from. Measured on a real 3.9 MB project 3MF:

| vertex budget | STL | gzipped |
|---|---|---|
| 100k | 10.0 MB | 4.8 MB |
| 50k (this PR) | 5.0 MB | — |

There is no `GZipMiddleware` in `main.py`, so a client fetches the uncompressed size. 50k keeps that near five megabytes, and the detail lost at that density is not visible while orbiting.

### Off the event loop

Parsing and decimating runs in `asyncio.to_thread`, matching how `system.py` and `support.py` offload blocking work. Not theoretical: one real 3.1 MB model took **10.2 s** to decimate, which would otherwise have stalled every other request.

## Screenshots

Not applicable — no UI change.

## Testing

- [x] I have tested this on my local machine
- [ ] I have tested with my printer model: not applicable — this endpoint reads a stored file and never touches a printer.

`./test_backend.sh` — ruff lint, ruff format, and the full suite: **10,084 passed**.

15 unit tests in `backend/tests/unit/services/test_mesh_export.py`, following the existing `test_stl_thumbnail.py` conventions (including its `trimesh`-available skip guard):

- the filename rules, including that `.gcode.3mf` is refused **even though it ends in `.3mf`**
- every refusal path — wrong type, missing, too small, unparseable, a ZIP with no model part
- a binary-STL header check (80-byte header, `uint32` count, 50 bytes per triangle)
- a **round-trip**: the export is reloaded with trimesh and must come back as a mesh, because an output that only *looks* like an STL would defeat the point of the endpoint
- all three decimation fallbacks — reduction that throws, that empties the mesh, and that succeeds

### Verified against real library files

Run inside a running container against that instance's own library:

| file | source | STL | faces |
|---|---|---|---|
| plain `.3mf` | 770 KB | 80 KB | 1,596 |
| plain `.3mf` | 3.1 MB | 7.3 MB | 146,914 |
| plain `.3mf` | 3.9 MB | 5.0 MB | 99,988 |
| sliced `.gcode.3mf` | 6.1 MB | *refused* | — |

The middle one decimates to 147k faces rather than the ~100k the budget asks for — quadric decimation cannot always reach its target. That is why a simplification which misses, throws, or empties the mesh falls back to delivering what it has rather than refusing: the client can decide what to do with a dense mesh, but it can do nothing with a 422.

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

- `Cache-Control: private, max-age=86400` — the mesh is a pure function of an immutable stored file, and `private` because the bytes sit behind a per-user permission check.
- Happy to change the vertex budget, the media type (`model/stl`), or the status codes if you'd prefer different conventions.
