### PR TITLE
feat: support inventory-only spool assignments

### DIFF
--- a/.github/workflows/test-image-2892.yml
+++ b/.github/workflows/test-image-2892.yml
@@ -1,0 +1,33 @@
+name: Test Bambuddy PR 2892 image
+
+on:
+  push:
+    branches:
+      - feat/inventory-only-assignment
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/mikefox303/bambuddy:1.2.5.3-test.2892.1
+          labels: |
+            org.opencontainers.image.source=https://github.com/maziggy/bambuddy
+            org.opencontainers.image.revision=15a9b323dd14de94d222663ad996c9a1067c5e21
+            org.opencontainers.image.version=1.2.5.3-test.2892.1

--- a/backend/app/api/routes/inventory.py
+++ b/backend/app/api/routes/inventory.py
@@ -1764,6 +1764,7 @@ async def assign_spool(
         tray_id=data.tray_id,
         fingerprint_color=fingerprint_color,
         fingerprint_type=fingerprint_type,
+        apply_to_printer=data.apply_to_printer,
     )
     db.add(assignment)
     await db.commit()
@@ -1804,7 +1805,7 @@ async def assign_spool(
     # source of truth for those slots.
     slot_is_definitely_empty = tray_state == 9 or tray_state == 10
     configured = False
-    if not slot_is_definitely_empty:
+    if data.apply_to_printer and not slot_is_definitely_empty:
         try:
             configured = await apply_spool_to_slot_via_mqtt(
                 db=db,
@@ -1834,7 +1835,7 @@ async def assign_spool(
     # firmware said empty, OR when MQTT couldn't actually publish (printer
     # offline, no client, transient failure). on_ams_change replay re-fires
     # the config in either case once the AMS reports a non-empty fingerprint.
-    pending_config = slot_is_definitely_empty or not configured
+    pending_config = data.apply_to_printer and (slot_is_definitely_empty or not configured)
 
     # Return assignment with spool data
     result = await db.execute(

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1312,6 +1312,19 @@ async def run_migrations(conn):
     # Migration: Add location column to printers for grouping
     await _safe_execute(conn, "ALTER TABLE printers ADD COLUMN location VARCHAR(100)")
 
+    # Migration: preserve whether an inventory assignment may write to the
+    # physical printer. Existing rows retain legacy full-write behaviour.
+    if is_sqlite():
+        await _safe_execute(
+            conn,
+            "ALTER TABLE spool_assignment ADD COLUMN apply_to_printer BOOLEAN DEFAULT 1",
+        )
+    else:
+        await _safe_execute(
+            conn,
+            "ALTER TABLE spool_assignment ADD COLUMN apply_to_printer BOOLEAN DEFAULT TRUE",
+        )
+
     # Migration: Add interval_type column to maintenance_types
     await _safe_execute(conn, "ALTER TABLE maintenance_types ADD COLUMN interval_type VARCHAR(20) DEFAULT 'hours'")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1943,7 +1943,12 @@ async def on_ams_change(printer_id: int, ams_data: list):
                     # explicit "empty" signals authoritative over any stale
                     # tray_type that might survive the relay's auto-clearing.
                     loaded = cur_state == 11 or (cur_state not in (9, 10) and cur_type.strip())
-                    if not fp_type.strip() and loaded and assignment.spool:
+                    if (
+                        assignment.apply_to_printer
+                        and not fp_type.strip()
+                        and loaded
+                        and assignment.spool
+                    ):
                         try:
                             from backend.app.api.routes.inventory import (
                                 apply_spool_to_slot_via_mqtt,
@@ -2184,7 +2189,7 @@ async def on_ams_change(printer_id: int, ams_data: list):
                                         if fallback_kp is None:
                                             fallback_kp = kp
                                     chosen_kp = matching_kp or fallback_kp
-                                    if chosen_kp is not None:
+                                    if chosen_kp is not None and assignment.apply_to_printer:
                                         live_cali_idx = tray.get("cali_idx")
                                         # Only fire MQTT when the printer's live
                                         # cali_idx differs from the stored value.
@@ -2257,6 +2262,11 @@ async def on_ams_change(printer_id: int, ams_data: list):
                                 printer_manager,
                                 db,
                                 tray_info_idx=tray_info_idx,
+                                apply_to_printer=(
+                                    existing_assignment.apply_to_printer
+                                    if existing_assignment is not None
+                                    else True
+                                ),
                             )
                             await db.commit()
                             await ws_manager.broadcast(

--- a/backend/app/models/spool_assignment.py
+++ b/backend/app/models/spool_assignment.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.app.core.database import Base
@@ -18,6 +18,11 @@ class SpoolAssignment(Base):
     tray_id: Mapped[int] = mapped_column(Integer)  # 0-3
     fingerprint_color: Mapped[str | None] = mapped_column(String(8))  # tray_color snapshot
     fingerprint_type: Mapped[str | None] = mapped_column(String(50))  # tray_type snapshot
+    # Legacy assignments remain full-write; inventory-only assignments never
+    # publish material/K-profile settings to the physical printer.
+    apply_to_printer: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="1", nullable=False
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     spool: Mapped["Spool"] = relationship(back_populates="assignments")

--- a/backend/app/schemas/spool.py
+++ b/backend/app/schemas/spool.py
@@ -226,6 +226,7 @@ class SpoolAssignmentCreate(BaseModel):
     printer_id: int
     ams_id: int
     tray_id: int
+    apply_to_printer: bool = True
 
 
 class SpoolAssignmentResponse(BaseModel):
@@ -237,6 +238,7 @@ class SpoolAssignmentResponse(BaseModel):
     tray_id: int
     fingerprint_color: str | None = None
     fingerprint_type: str | None = None
+    apply_to_printer: bool = True
     created_at: datetime
     spool: SpoolResponse | None = None
     configured: bool = False

--- a/backend/app/services/spool_tag_matcher.py
+++ b/backend/app/services/spool_tag_matcher.py
@@ -447,6 +447,7 @@ async def auto_assign_spool(
     printer_manager,
     db: AsyncSession,
     tray_info_idx: str = "",
+    apply_to_printer: bool = True,
 ) -> SpoolAssignment:
     """Create a SpoolAssignment and auto-configure the AMS slot via MQTT.
 
@@ -484,6 +485,9 @@ async def auto_assign_spool(
         )
     )
     old = existing.scalar_one_or_none()
+    if old is not None and apply_to_printer is True:
+        # Preserve an existing inventory-only policy across an RFID refresh.
+        apply_to_printer = old.apply_to_printer
     if old:
         await db.delete(old)
         await db.flush()
@@ -495,6 +499,7 @@ async def auto_assign_spool(
         tray_id=tray_id,
         fingerprint_color=fingerprint_color,
         fingerprint_type=fingerprint_type,
+        apply_to_printer=apply_to_printer,
     )
     db.add(assignment)
     await db.flush()
@@ -505,6 +510,8 @@ async def auto_assign_spool(
     # configuration from the RFID tag. Sending ams_set_filament_setting would
     # destroy the RFID-detected state (eye → pen icon in BambuStudio/OrcaSlicer).
     try:
+        if not apply_to_printer:
+            return assignment
         client = printer_manager.get_client(printer_id)
         if client:
             # Apply K-profile if available

--- a/backend/tests/integration/test_inventory_assign.py
+++ b/backend/tests/integration/test_inventory_assign.py
@@ -60,6 +60,46 @@ class TestAssignSpoolTrayInfoIdx:
 
     @pytest.mark.asyncio
     @pytest.mark.integration
+    async def test_inventory_only_persists_assignment_without_printer_writes(
+        self, async_client: AsyncClient, printer_factory, spool_factory, db_session: AsyncSession
+    ):
+        printer = await printer_factory(name="X2D")
+        spool = await spool_factory(slicer_filament="GFL99")
+        mock_client = MagicMock()
+        status = _make_mock_status(
+            ams_data=[{"id": 0, "tray": [{"id": 0, "tray_type": "PLA", "state": 11}]}]
+        )
+
+        with patch("backend.app.services.printer_manager.printer_manager") as mock_pm:
+            mock_pm.get_client.return_value = mock_client
+            mock_pm.get_status.return_value = status
+            response = await async_client.post(
+                "/api/v1/inventory/assignments",
+                json={
+                    "spool_id": spool.id,
+                    "printer_id": printer.id,
+                    "ams_id": 0,
+                    "tray_id": 0,
+                    "apply_to_printer": False,
+                },
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["apply_to_printer"] is False
+        assert body["configured"] is False
+        mock_client.ams_set_filament_setting.assert_not_called()
+        mock_client.extrusion_cali_sel.assert_not_called()
+        mock_client.register_assignment_verification.assert_not_called()
+
+        from backend.app.models.spool_assignment import SpoolAssignment
+
+        assignment = await db_session.get(SpoolAssignment, body["id"])
+        assert assignment is not None
+        assert assignment.apply_to_printer is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
     async def test_pfus_slicer_filament_falls_back_to_generic(
         self, async_client: AsyncClient, printer_factory, spool_factory
     ):


### PR DESCRIPTION
## Summary\n- add backwards-compatible apply_to_printer assignment flag (default true)\n- persist the flag and guard manual, AMS-change, and RFID K-profile writes\n- keep inventory events and usage-tracker snapshots unchanged\n\n## Validation\n- 214 targeted inventory/RFID/usage tests passed\n- ruff check passed\n- full suite on Windows is blocked by pre-existing os.geteuid collection issue in test_slice_external_folder_output.py