### PR TITLE
Repair the tare on spools that took the arbitrary catalogue row (issue #2909)

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -4427,6 +4427,91 @@ async def run_migrations(conn):
         conn, "ALTER TABLE notification_providers ADD COLUMN on_ams_drying_suspended BOOLEAN DEFAULT TRUE"
     )
 
+    # Migration: repair the core weight of RFID-created spools that took the
+    # arbitrary "first Bambu Lab row" from the spool catalogue (#2909).
+    await _migrate_repair_rfid_core_weight(conn)
+
+
+async def _migrate_repair_rfid_core_weight(conn) -> None:
+    """Give RFID-created spools the tare of the spool they actually arrived on (#2909).
+
+    ``create_spool_from_tray`` looked the core weight up with a ``Bambu Lab%``
+    prefix query and took the first row back, with no matching step and no
+    ``ORDER BY``. On SQLite that is ``Bambu Lab - Plastic High Temp`` — 216 g
+    against the 250 g the spool actually weighs. The forward fix selects the row
+    by name; spools created before it keep the wrong value, and it is not
+    cosmetic: ``core_weight`` is the tare in SpoolBuddy's weigh flow, so every
+    scale weighing of one of these spools charges 34 g of filament that is not
+    there.
+
+    Keyed on the value, not on ``core_weight_catalog_id IS NULL``. The catalogue
+    picker in the spool form displays the first row matching the weight and
+    auto-selects it when exactly one does, and ``DEFAULT_SPOOL_CATALOG`` has
+    exactly one 216 g row — so opening a spool's form and saving any unrelated
+    field writes the High Temp id, laundering the arbitrary pick into what reads
+    as a deliberate user selection. A NULL guard would therefore skip precisely
+    the spools that have been through the form, which are the ones most likely to
+    have been weighed. It would also overwrite a user who typed a corrected weight
+    matching no catalogue row, because that same effect clears their id to NULL.
+
+    The weight comes from the catalogue row rather than a constant, so an install
+    that has corrected ``Bambu Lab - Plastic Low Temp`` to its own measurement
+    gets that value; ``core_weight_catalog_id`` is set to the row that supplied
+    it. With no such row the spools are left alone — there is nothing to say what
+    the right value is, and 216 is at least a number the user can see and edit.
+
+    One-shot via a settings flag. Without it a user who deliberately sets an
+    ``rfid_auto`` spool to 216 g would have it silently reverted on the next
+    restart.
+    """
+    from sqlalchemy import text
+
+    flag = "_backfill_2909_rfid_core_weight_done"
+
+    async with conn.begin_nested():
+        already = (
+            await conn.execute(text('SELECT value FROM settings WHERE "key" = :k'), {"k": flag})
+        ).scalar_one_or_none()
+        if already:
+            return
+
+        row = (
+            await conn.execute(
+                text("SELECT id, weight FROM spool_catalog WHERE UPPER(name) = :name ORDER BY id LIMIT 1"),
+                {"name": "BAMBU LAB - PLASTIC LOW TEMP"},
+            )
+        ).fetchone()
+
+        if row is not None:
+            result = await conn.execute(
+                text(
+                    "UPDATE spool SET core_weight = :w, core_weight_catalog_id = :cid "
+                    "WHERE data_origin = 'rfid_auto' AND core_weight = 216"
+                ),
+                {"w": row.weight, "cid": row.id},
+            )
+            if result.rowcount:
+                logger.info(
+                    "[#2909] Repaired core weight on %d RFID-created spool(s): 216 g -> %d g "
+                    "(Bambu Lab - Plastic Low Temp). SpoolBuddy weighings of these spools were "
+                    "reading %d g of filament that was not there.",
+                    result.rowcount,
+                    row.weight,
+                    216 - row.weight if row.weight < 216 else row.weight - 216,
+                )
+        else:
+            logger.info(
+                "[#2909] Skipping RFID core-weight repair: no 'Bambu Lab - Plastic Low Temp' "
+                "row in the spool catalogue to take a weight from."
+            )
+
+        # Marked done even when nothing matched, so this never re-runs and cannot
+        # revert a 216 g value a user sets on purpose later.
+        await conn.execute(
+            text('INSERT INTO settings ("key", value) VALUES (:k, :v)'),
+            {"k": flag, "v": "true"},
+        )
+
 
 async def _migrate_backfill_variant_groups(conn) -> None:
     """Build variant groups from the slice provenance already on disk (#671 / #2570).

--- a/backend/tests/unit/test_rfid_core_weight_backfill_2909.py
+++ b/backend/tests/unit/test_rfid_core_weight_backfill_2909.py
@@ -1,0 +1,219 @@
+"""Backfill for RFID-created spools carrying the wrong catalogue tare (#2909).
+
+`create_spool_from_tray` looked the core weight up with a `Bambu Lab%` prefix
+query and took the first row back, which on SQLite is `Bambu Lab - Plastic High
+Temp` — 216 g against the 250 g the spool actually weighs. The forward fix
+selects the row by name; `_migrate_repair_rfid_core_weight` repairs the spools
+created before it.
+
+`core_weight` is the tare in SpoolBuddy's weigh flow, so these are not display
+errors: every scale weighing of an affected spool charged 34 g of filament that
+was not on it.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import backend.app.models  # noqa: F401 - populate Base.metadata
+from backend.app.core.database import Base, _migrate_repair_rfid_core_weight
+from backend.app.models.spool import Spool
+from backend.app.models.spool_catalog import SpoolCatalogEntry
+
+
+@pytest.fixture
+async def engine(tmp_path):
+    eng = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield eng
+    finally:
+        await eng.dispose()
+
+
+async def _seed_catalog(db, low_temp_weight: int | None = 250) -> int | None:
+    """Seed the Bambu rows in DEFAULT_SPOOL_CATALOG order. Low Temp omitted when
+    its weight is None, which is the renamed/deleted case."""
+    db.add(SpoolCatalogEntry(name="Bambu Lab - Plastic High Temp", weight=216, is_default=True))
+    await db.flush()
+    low_id = None
+    if low_temp_weight is not None:
+        low = SpoolCatalogEntry(name="Bambu Lab - Plastic Low Temp", weight=low_temp_weight, is_default=True)
+        db.add(low)
+        await db.flush()
+        low_id = low.id
+    db.add(SpoolCatalogEntry(name="Bambu Lab - Plastic White", weight=253, is_default=True))
+    await db.flush()
+    return low_id
+
+
+def _spool(**kw) -> Spool:
+    base = {
+        "material": "PLA",
+        "label_weight": 1000,
+        "core_weight": 216,
+        "data_origin": "rfid_auto",
+    }
+    return Spool(**{**base, **kw})
+
+
+@pytest.mark.asyncio
+async def test_repairs_the_wrong_tare_and_records_the_row_used(engine):
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as db:
+        low_id = await _seed_catalog(db)
+        s = _spool()
+        db.add(s)
+        await db.commit()
+        spool_id = s.id
+
+    async with engine.begin() as conn:
+        await _migrate_repair_rfid_core_weight(conn)
+
+    async with sm() as db:
+        fixed = await db.get(Spool, spool_id)
+        assert fixed.core_weight == 250
+        assert fixed.core_weight_catalog_id == low_id
+
+
+@pytest.mark.asyncio
+async def test_repairs_a_spool_whose_form_laundered_the_wrong_row(engine):
+    """The reason this cannot key on `core_weight_catalog_id IS NULL`.
+
+    The spool form's catalogue picker auto-selects when exactly one row matches
+    the weight, and there is exactly one 216 g row — so opening a spool and
+    saving any unrelated field writes the High Temp id, which reads as a
+    deliberate user selection. Those spools are the ones most likely to have been
+    weighed, so they are exactly the ones a NULL guard must not skip.
+    """
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as db:
+        low_id = await _seed_catalog(db)
+        high_id = (
+            await db.execute(
+                text("SELECT id FROM spool_catalog WHERE name = 'Bambu Lab - Plastic High Temp'")
+            )
+        ).scalar_one()
+        s = _spool(core_weight_catalog_id=high_id)
+        db.add(s)
+        await db.commit()
+        spool_id = s.id
+
+    async with engine.begin() as conn:
+        await _migrate_repair_rfid_core_weight(conn)
+
+    async with sm() as db:
+        fixed = await db.get(Spool, spool_id)
+        assert fixed.core_weight == 250
+        assert fixed.core_weight_catalog_id == low_id
+
+
+@pytest.mark.asyncio
+async def test_leaves_a_hand_corrected_weight_alone(engine):
+    """The case the NULL guard was written to protect and would have broken.
+
+    A user who types a weight matching no catalogue row has their catalogue id
+    cleared to NULL by the same picker effect. Keying on the value leaves them
+    untouched.
+    """
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as db:
+        await _seed_catalog(db)
+        s = _spool(core_weight=207, core_weight_catalog_id=None)
+        db.add(s)
+        await db.commit()
+        spool_id = s.id
+
+    async with engine.begin() as conn:
+        await _migrate_repair_rfid_core_weight(conn)
+
+    async with sm() as db:
+        assert (await db.get(Spool, spool_id)).core_weight == 207
+
+
+@pytest.mark.asyncio
+async def test_leaves_manually_created_spools_alone(engine):
+    """216 g on a hand-added spool is a value the user chose. Only the RFID path
+    produced it without being asked."""
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as db:
+        await _seed_catalog(db)
+        s = _spool(data_origin="manual")
+        db.add(s)
+        await db.commit()
+        spool_id = s.id
+
+    async with engine.begin() as conn:
+        await _migrate_repair_rfid_core_weight(conn)
+
+    async with sm() as db:
+        assert (await db.get(Spool, spool_id)).core_weight == 216
+
+
+@pytest.mark.asyncio
+async def test_uses_a_user_edited_catalogue_weight(engine):
+    """Same rule as the forward fix: someone who has weighed their own empty
+    spool and corrected the row gets their number, not the shipped 250."""
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as db:
+        low_id = await _seed_catalog(db, low_temp_weight=244)
+        s = _spool()
+        db.add(s)
+        await db.commit()
+        spool_id = s.id
+
+    async with engine.begin() as conn:
+        await _migrate_repair_rfid_core_weight(conn)
+
+    async with sm() as db:
+        fixed = await db.get(Spool, spool_id)
+        assert fixed.core_weight == 244
+        assert fixed.core_weight_catalog_id == low_id
+
+
+@pytest.mark.asyncio
+async def test_does_nothing_when_the_catalogue_row_is_missing(engine):
+    """With no row to take a weight from there is nothing to say what the right
+    value is, and 216 is at least a number the user can see and edit."""
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as db:
+        await _seed_catalog(db, low_temp_weight=None)
+        s = _spool()
+        db.add(s)
+        await db.commit()
+        spool_id = s.id
+
+    async with engine.begin() as conn:
+        await _migrate_repair_rfid_core_weight(conn)
+
+    async with sm() as db:
+        assert (await db.get(Spool, spool_id)).core_weight == 216
+
+
+@pytest.mark.asyncio
+async def test_does_not_revert_a_216_set_after_the_repair(engine):
+    """One-shot. Without the settings flag, a user who deliberately puts an
+    rfid_auto spool on a High Temp core would have it silently reverted on the
+    next restart."""
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as db:
+        await _seed_catalog(db)
+        s = _spool()
+        db.add(s)
+        await db.commit()
+        spool_id = s.id
+
+    async with engine.begin() as conn:
+        await _migrate_repair_rfid_core_weight(conn)
+
+    async with sm() as db:
+        deliberate = await db.get(Spool, spool_id)
+        deliberate.core_weight = 216
+        await db.commit()
+
+    async with engine.begin() as conn:
+        await _migrate_repair_rfid_core_weight(conn)
+
+    async with sm() as db:
+        assert (await db.get(Spool, spool_id)).core_weight == 216


### PR DESCRIPTION
## Description

Follow-up to #2923, as agreed on that review. That PR stops `create_spool_from_tray` taking whichever `Bambu Lab%` row the database returns first; this repairs the spools created before it.

On SQLite the row it took is `Bambu Lab - Plastic High Temp` — 216 g against the 250 g the spool actually weighs. Left alone, a spool the user never opens the form for stays wrong indefinitely, and it is not a display error: `core_weight` is the tare in SpoolBuddy's weigh flow, so every scale weighing of an affected spool has reported 34 g of filament that is not on it and written `weight_used` 34 g low. Remaining weight, low-stock alerts and the pre-print filament check all read that number afterwards.

## Why it keys on the value

I offered `core_weight_catalog_id IS NULL` on #2923 and it is the wrong guard, for the reason @maziggy identified there. `AdditionalSection.tsx` displays the first catalogue row matching the weight and auto-selects it when exactly one matches — and `DEFAULT_SPOOL_CATALOG` has exactly one 216 g row (I counted: one at 216, one at 250, out of 91). So opening a spool's form and saving any unrelated field writes the High Temp id, and the arbitrary pick reads as a deliberate user selection from then on.

| spool | `IS NULL` guard | value guard (this PR) |
|---|---|---|
| never opened in the form | repaired | repaired |
| opened and saved once — id laundered to High Temp | **skipped**, and it is the one most likely to have been weighed | repaired |
| hand-typed 207 g, matching no row, so id cleared to NULL | **overwritten** — the case the guard was for | untouched |

`data_origin = 'rfid_auto' AND core_weight = 216` selects the wrong spools and only the wrong spools. All three rows above are pinned by tests.

## Shape

- **The weight comes from the catalogue row, not a constant.** An install that has corrected `Bambu Lab - Plastic Low Temp` to its own measurement gets that value, and `core_weight_catalog_id` is set to the row that supplied it — same rule as the forward fix, so the two cannot drift.
- **With no such row, nothing is touched.** There is then nothing to say what the right value is, and 216 is at least a number the user can see and edit. Logged rather than silent.
- **One-shot via a settings flag**, following `_migrate_scope_run_filament_to_plate` (#2614). Not for idempotency — the `UPDATE` is naturally idempotent once it has run — but because a user may deliberately put an `rfid_auto` spool on a High Temp core afterwards, and without the flag the next restart would silently revert it. That is pinned by a test too.

## Known limits, stated rather than papered over

- **A Postgres install may carry a different wrong value.** With no `ORDER BY` the pick was unordered there, so a spool could have landed on White (253) instead. Those are not selected: unlike 216 on SQLite there is no basis to say whether 253 was the arbitrary pick or a deliberate choice, and guessing would overwrite real data. SQLite is the default and the reported case.
- **An install that edited the High Temp row before its spools were created** carries that edited weight instead of 216 and is not selected, for the same reason.

Both leave the user where they were rather than moving the damage somewhere harder to see, and the forward fix means neither can grow.

## Related Issue

#2909 — follow-up to #2923 (the forward fix), agreed on that PR's review. Filing separately as requested.

## Documentation

**Pick one**:
- [x] No docs update required — reason: one-shot data repair. No new setting, endpoint or UI element; the value it writes is the 250 g default the wiki already documents (`docs/spoolbuddy/usage.md`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `backend/app/core/database.py` — `_migrate_repair_rfid_core_weight`, called at the end of the migration run. Reads the Low Temp row, updates `data_origin='rfid_auto' AND core_weight = 216` spools to its weight and id, marks a settings flag so it never runs twice
- `backend/tests/unit/test_rfid_core_weight_backfill_2909.py` — seven tests

## Screenshots

Not applicable — no frontend change.

## Testing

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: **X2D** — the three affected spools on my instance are its AMS RFID reads:

```
id, material, subtype, colour, core_weight, core_weight_catalog_id, origin
(1, 'PLA',  'Basic', 'Black',       216, None, 'rfid_auto')
(2, 'PLA',  'Matte', 'Ivory White', 216, None, 'rfid_auto')
(3, 'PETG', 'Basic', None,          216, None, 'rfid_auto')
```

Seven tests, one per case in the table above plus the catalogue-missing and one-shot paths. Two are verifications rather than assertions of the happy path:

- `test_repairs_a_spool_whose_form_laundered_the_wrong_row` seeds the High Temp id on the spool — it is the case an `IS NULL` guard would skip
- `test_does_not_revert_a_216_set_after_the_repair` runs the migration, sets 216 back by hand, runs it again. I confirmed the gate is load-bearing by removing the early return and watching this one fail

Full backend suite: **10634 passed, 22 skipped**. `ruff check` and `ruff format --check` clean. Run in the repo's own `backend-test` image.

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
