### PR TITLE
Let a spool keep its own empty weight (issue #2908)

### DIFF
--- a/backend/app/api/routes/spoolman_inventory.py
+++ b/backend/app/api/routes/spoolman_inventory.py
@@ -310,9 +310,12 @@ class SpoolmanInventoryCreate(BaseModel):
     color_name: str | None = Field(None, max_length=64)
     rgba: str | None = Field(None, max_length=8, description="6-digit hex (RRGGBB) or 8-digit (RRGGBBAA)")
     label_weight: int = Field(1000, ge=1, le=100_000)
-    core_weight: int = Field(
-        250, ge=0, le=10_000
-    )  # Accepted for schema parity but not persisted to Spoolman (stored on filament type, not spool)
+    # Persisted to the Spoolman spool's own `spool_weight` (tare), which takes
+    # priority over the filament-level value both in _map_spoolman_spool and in
+    # the weigh endpoint. Only written when the request actually sets it: the
+    # 250 default is the display fallback, and writing it on every create would
+    # stamp an explicit tare on spools that should keep inheriting one (#2908).
+    core_weight: int = Field(250, ge=0, le=10_000)
     weight_used: float = Field(0.0, ge=0.0, le=100_000.0)
     note: str | None = Field(None, max_length=1000)
     cost_per_kg: float | None = Field(None, ge=0.0, le=1_000_000.0)
@@ -351,9 +354,11 @@ class SpoolmanInventoryUpdate(BaseModel):
     color_name: str | None = Field(None, max_length=64)
     rgba: str | None = Field(None, max_length=8, description="6-digit hex (RRGGBB) or 8-digit (RRGGBBAA)")
     label_weight: int | None = Field(None, ge=1, le=100_000)
-    core_weight: int | None = Field(
-        None, ge=0, le=10_000
-    )  # Accepted for schema parity but not persisted to Spoolman (stored on filament type, not spool)
+    # Persisted to the spool's own `spool_weight` (see the Create schema).
+    # Omitted / null leaves the current value alone, as with every other field
+    # here. There is no per-spool "go back to inheriting" through this route;
+    # the filament-level route already owns that decision (#2908).
+    core_weight: int | None = Field(None, ge=0, le=10_000)
     weight_used: float | None = Field(None, ge=0.0, le=100_000.0)
     note: str | None = Field(None, max_length=1000)
     cost_per_kg: float | None = Field(None, ge=0.0, le=1_000_000.0)
@@ -551,6 +556,7 @@ async def create_spool(
                 remaining_weight=remaining,
                 comment=data.note or None,
                 location=storage_location or None,
+                spool_weight=(data.core_weight if "core_weight" in data.model_fields_set else None),
             )
     except HTTPException as exc:
         if exc.status_code == 404 and data.spoolman_filament_id is not None:
@@ -640,6 +646,7 @@ async def bulk_create_spools(
                 remaining_weight=remaining,
                 comment=data.note or None,
                 location=storage_location or None,
+                spool_weight=(data.core_weight if "core_weight" in data.model_fields_set else None),
             )
         except (SpoolmanUnavailableError, SpoolmanClientError, SpoolmanNotFoundError) as exc:
             logger.warning("Bulk spool creation: one spool failed: %s", exc)
@@ -853,6 +860,11 @@ async def update_spool(
                 extra=extra,
                 location=storage_location or None,
                 clear_location=storage_location_changed and not storage_location,
+                # No model_fields_set guard here, unlike create: this schema
+                # already defaults core_weight to None, and None is what
+                # update_spool_full reads as "leave the tare alone". A guard
+                # would be a second spelling of the same condition.
+                spool_weight=data.core_weight,
             )
 
     # Persist BambuStudio slicer preset AND color_name under spool.extra.

--- a/backend/app/services/spoolman.py
+++ b/backend/app/services/spoolman.py
@@ -405,6 +405,7 @@ class SpoolmanClient:
         lot_nr: str | None = None,
         comment: str | None = None,
         extra: dict | None = None,
+        spool_weight: float | None = None,
     ) -> dict:
         """Create a new spool in Spoolman."""
         data: dict = {"filament_id": filament_id}
@@ -416,6 +417,11 @@ class SpoolmanClient:
             data["lot_nr"] = lot_nr
         if comment:
             data["comment"] = comment
+        # `is not None`, not truthiness: 0 g is a legitimate tare (a spool-less
+        # coil), and it is not the same answer as "inherit from the filament",
+        # which is what leaving the field off means to Spoolman.
+        if spool_weight is not None:
+            data["spool_weight"] = spool_weight
         if extra:
             data["extra"] = extra
             await self._ensure_extra_fields(extra)

--- a/backend/tests/integration/test_spoolman_inventory_api.py
+++ b/backend/tests/integration/test_spoolman_inventory_api.py
@@ -2813,3 +2813,129 @@ class TestGetAllSlotAssignmentsEnriched:
         assert data[0]["printer_id"] == 1
         assert data[0]["printer_name"] == "P1"
         assert data[0]["spoolman_spool_id"] == 201
+
+
+class TestPerSpoolCoreWeight:
+    """The per-spool tare reaches Spoolman now (#2908).
+
+    `core_weight` was declared on both write schemas and dropped after
+    validation, with a comment saying so. The read path never showed it: it
+    derives the value from ``spool.spool_weight ?? filament.spool_weight ?? 250``
+    (_spoolman_helpers.py), so an edit that went nowhere came back as the
+    inherited value and looked like it had simply not changed.
+
+    It is not cosmetic, because the same resolution is the tare the weigh
+    endpoint subtracts. A spool whose real empty weight differs from its
+    filament's produced a wrong remaining weight on every weigh-in -- 70 g for
+    the reporter's third-party spools against Bambu's 250 g reusable ones.
+
+    Spoolman already has the field and already gives it priority. Only the
+    write was missing.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_an_edited_tare_is_written_to_the_spools_own_field(
+        self, async_client: AsyncClient, spoolman_settings, mock_spoolman_client
+    ):
+        response = await async_client.patch("/api/v1/spoolman/inventory/spools/42", json={"core_weight": 180})
+
+        assert response.status_code == 200
+        assert mock_spoolman_client.update_spool_full.call_args.kwargs["spool_weight"] == 180
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_an_edit_that_does_not_mention_the_tare_leaves_it_inheriting(
+        self, async_client: AsyncClient, spoolman_settings, mock_spoolman_client
+    ):
+        """The reason this keys off model_fields_set rather than the value.
+
+        `core_weight` carries a default, so a PATCH that never mentions it still
+        arrives at the handler holding one. Writing that would stamp an explicit
+        tare on every spool the user edits for any reason, silently detaching it
+        from its filament -- a worse bug than the one being fixed, and an
+        invisible one, since the number displayed would not change.
+        """
+        response = await async_client.patch("/api/v1/spoolman/inventory/spools/42", json={"note": "just a note"})
+
+        assert response.status_code == 200
+        assert mock_spoolman_client.update_spool_full.call_args.kwargs["spool_weight"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_a_tare_given_at_creation_is_written(
+        self, async_client: AsyncClient, spoolman_settings, mock_spoolman_client
+    ):
+        response = await async_client.post(
+            "/api/v1/spoolman/inventory/spools",
+            json={"material": "PLA", "label_weight": 1000, "core_weight": 180},
+        )
+
+        assert response.status_code == 200
+        assert mock_spoolman_client.create_spool.call_args.kwargs["spool_weight"] == 180
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_a_creation_that_omits_the_tare_leaves_the_spool_inheriting(
+        self, async_client: AsyncClient, spoolman_settings, mock_spoolman_client
+    ):
+        """Same defaulting hazard as the update, and the commoner path: the
+        form posts without a tare far more often than with one."""
+        response = await async_client.post(
+            "/api/v1/spoolman/inventory/spools",
+            json={"material": "PLA", "label_weight": 1000},
+        )
+
+        assert response.status_code == 200
+        assert mock_spoolman_client.create_spool.call_args.kwargs["spool_weight"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_bulk_creation_persists_the_tare_on_every_spool(
+        self, async_client: AsyncClient, spoolman_settings, mock_spoolman_client
+    ):
+        """Bulk create takes the same schema, so it dropped the field the same way."""
+        response = await async_client.post(
+            "/api/v1/spoolman/inventory/spools/bulk",
+            json={"spool": {"material": "PLA", "label_weight": 1000, "core_weight": 180}, "quantity": 3},
+        )
+
+        assert response.status_code in (200, 201)
+        assert mock_spoolman_client.create_spool.await_count == 3
+        assert all(c.kwargs["spool_weight"] == 180 for c in mock_spoolman_client.create_spool.await_args_list)
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_a_zero_tare_is_a_value_not_an_absence(
+        self, async_client: AsyncClient, spoolman_settings, mock_spoolman_client
+    ):
+        """0 g is a real answer -- a coil with no spool -- and the schema allows
+        it (``ge=0``). Guarding the write on truthiness rather than ``is not
+        None`` would silently turn it into "inherit", which resolves to 250."""
+        response = await async_client.patch("/api/v1/spoolman/inventory/spools/42", json={"core_weight": 0})
+
+        assert response.status_code == 200
+        assert mock_spoolman_client.update_spool_full.call_args.kwargs["spool_weight"] == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_the_written_tare_is_the_one_the_weigh_endpoint_subtracts(
+        self, async_client: AsyncClient, spoolman_settings, mock_spoolman_client
+    ):
+        """What the fix is actually for.
+
+        The weigh endpoint resolves the tare exactly as the read path does, so
+        once the per-spool value is stored it is the number a measured gross
+        weight is reduced by. With a 180 g spool inheriting the filament's 250 g
+        this same weigh-in would have recorded 550 g remaining instead of 620 --
+        the 70 g error from the report, on every weigh-in.
+        """
+        mock_spoolman_client.get_spool.return_value = {
+            **SAMPLE_SPOOLMAN_SPOOL,
+            "spool_weight": 180.0,
+        }
+
+        response = await async_client.patch("/api/v1/spoolman/inventory/spools/42/weight", json={"weight_grams": 800.0})
+
+        assert response.status_code == 200
+        assert mock_spoolman_client.update_spool_full.call_args.kwargs["remaining_weight"] == 620.0

--- a/backend/tests/unit/test_spoolman_inventory_methods.py
+++ b/backend/tests/unit/test_spoolman_inventory_methods.py
@@ -665,3 +665,43 @@ class TestRenameLocationBulkAndFallback:
             pytest.raises(httpx.HTTPStatusError),
         ):
             await client.rename_location("Drybox 1", "Drybox 2")
+
+
+class TestCreateSpoolTare:
+    """create_spool carries the per-spool tare, and tells 0 apart from absent (#2908).
+
+    Leaving `spool_weight` off the payload is meaningful to Spoolman -- it means
+    the spool inherits its filament's value -- so the two cases have to stay
+    distinguishable all the way down to the request body.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_tare_is_sent(self, client):
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=_make_response(SAMPLE_SPOOL))
+        with patch.object(client, "_get_client", AsyncMock(return_value=mock_http)):
+            await client.create_spool(filament_id=7, spool_weight=180)
+
+        assert mock_http.post.call_args.kwargs["json"]["spool_weight"] == 180
+
+    @pytest.mark.asyncio
+    async def test_a_zero_tare_is_sent_rather_than_dropped(self, client):
+        """A guard on truthiness would silently turn 0 g into "inherit", which
+        resolves to 250 g -- a 250 g error on every weigh-in for a bare coil."""
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=_make_response(SAMPLE_SPOOL))
+        with patch.object(client, "_get_client", AsyncMock(return_value=mock_http)):
+            await client.create_spool(filament_id=7, spool_weight=0)
+
+        assert mock_http.post.call_args.kwargs["json"]["spool_weight"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_tare_leaves_the_key_off_entirely(self, client):
+        """Sending an explicit null would pin the spool to "no inheritance",
+        which is not the same as not having been told."""
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=_make_response(SAMPLE_SPOOL))
+        with patch.object(client, "_get_client", AsyncMock(return_value=mock_http)):
+            await client.create_spool(filament_id=7)
+
+        assert "spool_weight" not in mock_http.post.call_args.kwargs["json"]


### PR DESCRIPTION
## Description

`core_weight` was declared on both Spoolman write schemas and dropped after validation, with a
comment saying so. Spoolman has the field — `spool.spool_weight`, its tare — and Bambuddy already
reads it with priority over the filament-level value. Only the write was missing.

Nothing in the UI showed the edit was ignored, because the read path derives the displayed value
from `spool.spool_weight ?? filament.spool_weight ?? 250`: an edit that went nowhere came back as
the inherited number and read as "no change".

It is not cosmetic. The weigh endpoint resolves the tare the same way and subtracts it from the
measured gross weight, so a spool whose real empty weight differs from its filament's recorded a
wrong remaining weight on every weigh-in — 70 g for my third-party 180 g spools against Bambu's
250 g reusable ones.

## Related Issue

Fixes #2908

## Documentation

**Pick one**:
- [x] No docs update required — reason: the wiki already documents this field as working
  (`docs/features/inventory.md:174`, "**Empty Spool Weight** | Select from the spool catalog or
  enter manually (for accurate remaining calculations)"). This makes the behaviour match what is
  already written rather than changing it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `SpoolmanClient.create_spool` takes `spool_weight` and sends it when given. Guarded on
  `is not None`, not truthiness: 0 g is a real tare (a bare coil) and is not the same answer as
  omitting the key, which is what tells Spoolman to inherit.
- The single-create handler passes `core_weight` through, but only when the request actually set
  it. The schema defaults it to 250, so writing it unconditionally would stamp an explicit tare on
  every spool created without one and silently detach it from its filament — a worse bug than this
  one, and invisible, since the displayed number would not change.
- `bulk_create_spools` takes the same schema and dropped the field the same way, so it gets the
  same treatment.
- The update handler passes `data.core_weight` straight through. No `model_fields_set` guard here:
  that schema already defaults to `None`, and `None` is what `update_spool_full` reads as "leave
  the tare alone", so a guard would be a second spelling of the same condition. I measured this
  rather than assuming it — see below.
- Both schema comments replaced with what the field now does, and why the create side needs the
  guard while the update side does not.

## Testing

- [x] I have tested this on my local machine
- [ ] I have tested with my printer model: not printer-related — this is the Spoolman write path.

Ten tests, seven at the route level and three on the client. `backend/tests/unit`:
**8613 passed, 22 skipped**. The two files this touches, unit and integration together: **217
passed**. `ruff check` and `ruff format --check` clean.

Mutations, run against those two files:

```
head                                                     217 passed
defect restored (write removed from all three handlers)    6 failed, 211 passed
create guard removed (writes the 250 default always)       2 failed, 215 passed
create_spool guard changed to truthiness                   1 failed, 216 passed
```

Each mutation fails only the tests that exist for it. The second one is worth
reading as a pair with the fourth bullet above: removing the guard from the
*create* handlers breaks two tests, and there is nothing to remove on the update
handler, which is how I know a guard there would have been decoration.

The route tests cover an edited tare reaching `spool_weight`, an edit that never mentions it
leaving the spool inheriting, the same pair on create, bulk create, `0` as a value rather than an
absence, and the weigh endpoint subtracting the tare that was just written — with a 180 g spool a
800 g gross weight records 620 g remaining, where inheriting 250 g would have recorded 550 g.

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

**Why this survived.** There were already three tests naming `core_weight`
(`test_create_spool_with_non_default_core_weight_accepted`,
`test_update_spool_with_non_default_core_weight_accepted`, and the no-`core_weight` case). They
assert status codes only — they were written for an earlier fix that stopped the route rejecting
values other than 250, and "accepted" is all they check. They pass identically with the write
present or absent. Every new test here asserts what reached Spoolman.

**One thing I left out.** There is no way to go back to inheriting through this route: omitting the
field means "leave alone", and the schema has no null-to-clear. `update_spool_full` already has
`clear_spool_weight`, and the filament-level route uses it, so the mechanism exists if you want the
per-spool editor to offer it — but it needs a UI affordance to mean anything, and I did not want to
invent one inside a bug fix. Happy to follow up if you want it.

**A correction on the issue text, already posted there.** The reproduction steps in #2908 are
written as if I executed them; I did not. What I verified was the source of the running build and
the Spoolman side (that `PATCH /api/v1/spool/<id> {"spool_weight": 180}` is picked up immediately
by Bambuddy's tare resolution). The UI round-trip was inferred from the handlers never referencing
`core_weight` after validation. The code-level claim is the part I stand behind, and it is
checkable without the UI.
