### PR TITLE
[Fix] Clear tray_uuid values read from the wrong Bambu tag blocks

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -4957,6 +4957,10 @@ async def run_migrations(conn):
     # Spoolman and the location sync then imported as storage locations.
     await _migrate_drop_ams_slot_locations(conn)
 
+    # Migration: clear tray_uuid values a SpoolBuddy daemon read from the wrong
+    # tag blocks (#984). They collide across every spool of one filament type.
+    await _migrate_clear_text_artifact_tray_uuids(conn)
+
 
 async def _migrate_rename_ha_sensor_alert_template(conn) -> None:
     """Rename the ha_sensor_alert template to "Printer Sensor Alert" (#2824).
@@ -5195,6 +5199,52 @@ async def _migrate_repair_rfid_core_weight(conn) -> None:
             text('INSERT INTO settings ("key", value) VALUES (:k, :v)'),
             {"k": flag, "v": "true"},
         )
+
+
+async def _migrate_clear_text_artifact_tray_uuids(conn) -> None:
+    """Clear tray_uuid values a SpoolBuddy daemon read from the wrong blocks (#984).
+
+    The tray UUID lives in block 9 of a Bambu tag. A daemon reading blocks 4-5
+    instead picks up the filament description, so a white PLA Basic spool
+    reports ``504C4120426173696300000000000000`` -- the hex of ``"PLA Basic"``
+    -- and so does every other spool of that product. Since the backend
+    identifies spools by tray_uuid, a scan then resolves to an arbitrary one of
+    them and its weight and assignment land on the wrong row.
+
+    Clearing is the only repair available: the real UUID exists solely on the
+    tag, so it comes back on the next scan by a daemon that reads block 9.
+    Until then the spool is still identified by its own tag_uid, which
+    ``get_spool_by_tag`` falls back to.
+
+    Deliberately *not* gated behind a settings flag, unlike the one-shot
+    backfills above. Those are gated because re-running would undo a value the
+    user has since chosen; here there is nothing to undo, and while daemons
+    that predate the fix are still in the field they keep writing new bad rows
+    that a later upgrade should also clean up. Rows holding a real UUID never
+    match the filter, so repeated runs are no-ops.
+    """
+    from sqlalchemy import bindparam, text
+
+    from backend.app.utils.tag_normalization import is_text_artifact_tray_uuid
+
+    async with conn.begin_nested():
+        rows = await conn.execute(text("SELECT id, tray_uuid FROM spool WHERE tray_uuid IS NOT NULL"))
+        bogus = [row[0] for row in rows if is_text_artifact_tray_uuid(row[1])]
+
+    if not bogus:
+        return
+
+    async with conn.begin_nested():
+        await conn.execute(
+            text("UPDATE spool SET tray_uuid = NULL WHERE id IN :ids").bindparams(bindparam("ids", expanding=True)),
+            {"ids": bogus},
+        )
+
+    logger.warning(
+        "[#984] Cleared the tray_uuid on %d spool(s); it held the filament description "
+        "rather than the tag's UUID. Rescan those spools to restore it.",
+        len(bogus),
+    )
 
 
 async def _migrate_backfill_variant_groups(conn) -> None:

--- a/backend/app/schemas/spoolbuddy.py
+++ b/backend/app/schemas/spoolbuddy.py
@@ -97,6 +97,25 @@ class TagScannedRequest(BaseModel):
     tag_type: str | None = Field(None, max_length=50)
     raw_blocks: dict | None = None
 
+    @field_validator("tray_uuid")
+    @classmethod
+    def drop_text_artifact_uuid(cls, v: str | None) -> str | None:
+        """Discard a tray_uuid a daemon read from the filament description.
+
+        SpoolBuddy daemons that predate the block-9 fix send the contents of tag
+        blocks 4-5 as tray_uuid. It is well-formed hex and passes the pattern
+        above, but it is identical for every spool of that filament, so
+        accepting it matches the scan to an arbitrary spool and writes the
+        collision onto any spool registered from that scan.
+
+        Rejecting the whole request would take a device that is otherwise
+        working offline, so drop just this field and let the unique tag_uid
+        identify the spool.
+        """
+        from backend.app.utils.tag_normalization import is_text_artifact_tray_uuid
+
+        return None if is_text_artifact_tray_uuid(v) else v
+
 
 class TagRemovedRequest(BaseModel):
     device_id: str = Field(..., max_length=50)

--- a/backend/app/services/spool_tag_matcher.py
+++ b/backend/app/services/spool_tag_matcher.py
@@ -12,6 +12,7 @@ from backend.app.schemas.spool import normalize_effect_type
 from backend.app.services.slot_nozzle import resolve_slot_nozzle
 from backend.app.services.spool_filament_preset import printer_safe_filament_id, resolve_spool_preset
 from backend.app.utils.tag_normalization import (
+    is_text_artifact_tray_uuid,
     normalize_tag_uid as _normalize_tag_uid,
     normalize_tray_uuid as _normalize_tray_uuid,
 )
@@ -412,6 +413,17 @@ async def get_spool_by_tag(db: AsyncSession, tag_uid: str, tray_uuid: str) -> Sp
     """
     tray_uuid_norm = _normalize_tray_uuid(tray_uuid)
     tag_uid_norm = _normalize_tag_uid(tag_uid)
+
+    # A tray_uuid that decodes to ASCII text came from a daemon reading tag
+    # blocks 4-5 instead of block 9, so it is the filament description and is
+    # shared by every spool of that product. Matching on it returns an
+    # arbitrary one of them; tag_uid below is unique per physical tag.
+    if is_text_artifact_tray_uuid(tray_uuid_norm):
+        logger.warning(
+            "[#984] Ignoring tray_uuid %s: filament description from a pre-block-9 SpoolBuddy read",
+            tray_uuid_norm,
+        )
+        tray_uuid_norm = ""
 
     # Try tray_uuid first (Bambu Lab spools — more reliable)
     if tray_uuid_norm and tray_uuid_norm != ZERO_TRAY_UUID and tray_uuid_norm != "0" * len(tray_uuid_norm):

--- a/backend/app/utils/tag_normalization.py
+++ b/backend/app/utils/tag_normalization.py
@@ -22,3 +22,27 @@ def normalize_tray_uuid(value: str | None) -> str:
     if len(uuid) >= 32:
         uuid = uuid[:32]
     return uuid
+
+
+def is_text_artifact_tray_uuid(value: str | None) -> bool:
+    """True when a tray_uuid is really a mis-decoded ASCII text field.
+
+    SpoolBuddy daemons that read the tray UUID from Bambu tag blocks 4-5 pick up
+    the filament description rather than the per-spool UUID in block 9. The
+    result is well-formed 32-char hex -- ``504C4120426173696300000000000000``
+    is the hex of ``"PLA Basic"`` -- and identical for every spool of that
+    product, so neither the length check nor the hex pattern on the request
+    schema rejects it.
+
+    What gives it away is the shape: printable ASCII followed by NUL padding. A
+    genuine tray UUID is 16 random bytes, so the odds of one landing in that
+    shape are around 1e-9 and treating the shape as proof is safe.
+    """
+    uuid = normalize_tray_uuid(value)
+    if len(uuid) != 32:
+        return False
+
+    text = bytes.fromhex(uuid).rstrip(b"\x00")
+    if not text:  # all zeroes -- invalid, but not a text artifact
+        return False
+    return all(0x20 <= byte <= 0x7E for byte in text)

--- a/backend/tests/unit/test_spoolbuddy_tray_uuid_artifact.py
+++ b/backend/tests/unit/test_spoolbuddy_tray_uuid_artifact.py
@@ -1,0 +1,151 @@
+"""Legacy tray_uuid values a SpoolBuddy daemon derived from the wrong tag blocks.
+
+A daemon that reads tray_uuid from Bambu tag blocks 4-5 picks up the filament
+description ("PLA Basic", colour, weight) rather than the per-spool UUID in
+block 9. Every spool of one product therefore reports the same tray_uuid --
+504C4120426173696300000000000000 for white PLA Basic -- and the backend, which
+identifies spools by tray_uuid, merges them into one row (#984).
+
+Fixing the daemon corrects new scans, but installs already carry these values
+in ``spool.tray_uuid``. They are valid 32-char hex, so no existing validation
+rejects them. What sets them apart is that they decode to printable ASCII
+followed by NUL padding, which a random 16-byte UUID practically never does.
+That shape is the marker used here to recognise them, ignore them at lookup,
+and clear them on upgrade.
+"""
+
+from sqlalchemy import text
+
+from backend.app.models.spool import Spool
+from backend.app.services.spool_tag_matcher import get_spool_by_tag
+from backend.app.utils.tag_normalization import is_text_artifact_tray_uuid
+
+# "PLA Basic" + NUL padding — what block 4 of a white PLA Basic tag contains.
+PLA_BASIC_ARTIFACT = "504C4120426173696300000000000000"
+# Block 9 of a real tag (MIFARE Classic 1K, UID E35FACA1).
+REAL_TRAY_UUID = "6B9170BB5BD84DDBA748713C159367DF"
+
+# The migration runs on raw SQL, so the inserts below have to satisfy the
+# NOT NULL columns the ORM would otherwise default for us.
+_SPOOL_COLUMNS = (
+    "id, material, label_weight, core_weight, weight_used, weight_used_baseline, weight_locked, tag_uid, tray_uuid"
+)
+_SPOOL_DEFAULTS = "'PLA', 1000, 250, 0, 0, 0"
+
+
+class TestIsTextArtifactTrayUuid:
+    def test_recognises_the_pla_basic_artifact(self):
+        assert is_text_artifact_tray_uuid(PLA_BASIC_ARTIFACT) is True
+
+    def test_recognises_other_filament_descriptions(self):
+        petg = b"PETG HF".ljust(16, b"\x00").hex().upper()
+
+        assert is_text_artifact_tray_uuid(petg) is True
+
+    def test_accepts_lowercase_and_whitespace(self):
+        assert is_text_artifact_tray_uuid(f"  {PLA_BASIC_ARTIFACT.lower()} ") is True
+
+    def test_real_uuid_is_not_an_artifact(self):
+        assert is_text_artifact_tray_uuid(REAL_TRAY_UUID) is False
+
+    def test_all_zeroes_is_not_an_artifact(self):
+        """Zeroed UUIDs are already handled as invalid elsewhere."""
+        assert is_text_artifact_tray_uuid("0" * 32) is False
+
+    def test_empty_is_not_an_artifact(self):
+        assert is_text_artifact_tray_uuid("") is False
+        assert is_text_artifact_tray_uuid(None) is False
+
+    def test_wrong_length_is_not_an_artifact(self):
+        assert is_text_artifact_tray_uuid("504C4120") is False
+
+    def test_text_after_padding_is_not_an_artifact(self):
+        """Real UUIDs may contain 0x00 bytes; only trailing padding counts."""
+        interleaved = (b"PLA\x00Basic\x00\x00\x00\x00\x00\x00\x00").hex().upper()
+
+        assert is_text_artifact_tray_uuid(interleaved) is False
+
+
+class TestTagScannedRequestDropsArtifacts:
+    """A daemon that predates the fix keeps sending the description as a UUID."""
+
+    def test_artifact_tray_uuid_is_dropped(self):
+        from backend.app.schemas.spoolbuddy import TagScannedRequest
+
+        req = TagScannedRequest(device_id="sb1", tag_uid="E35FACA1", tray_uuid=PLA_BASIC_ARTIFACT)
+
+        assert req.tray_uuid is None
+
+    def test_real_tray_uuid_is_kept(self):
+        from backend.app.schemas.spoolbuddy import TagScannedRequest
+
+        req = TagScannedRequest(device_id="sb1", tag_uid="E35FACA1", tray_uuid=REAL_TRAY_UUID)
+
+        assert req.tray_uuid == REAL_TRAY_UUID
+
+
+class TestGetSpoolByTagIgnoresArtifacts:
+    async def _spool(self, db_session, *, tag_uid, tray_uuid):
+        spool = Spool(material="PLA", subtype="Basic", tag_uid=tag_uid, tray_uuid=tray_uuid)
+        db_session.add(spool)
+        await db_session.commit()
+        await db_session.refresh(spool)
+        return spool
+
+    async def test_falls_back_to_tag_uid_when_uuid_is_an_artifact(self, db_session):
+        """Two spools share the bogus UUID; only the tag UID tells them apart."""
+        first = await self._spool(db_session, tag_uid="E35FACA1", tray_uuid=PLA_BASIC_ARTIFACT)
+        second = await self._spool(db_session, tag_uid="AABBCCDD", tray_uuid=PLA_BASIC_ARTIFACT)
+
+        found = await get_spool_by_tag(db_session, "AABBCCDD", PLA_BASIC_ARTIFACT)
+
+        assert found is not None
+        assert found.id == second.id
+        assert found.id != first.id
+
+    async def test_real_uuid_still_matches(self, db_session):
+        spool = await self._spool(db_session, tag_uid="E35FACA1", tray_uuid=REAL_TRAY_UUID)
+
+        found = await get_spool_by_tag(db_session, "", REAL_TRAY_UUID)
+
+        assert found is not None
+        assert found.id == spool.id
+
+
+class TestArtifactTrayUuidMigration:
+    async def test_clears_artifacts_and_keeps_real_uuids(self, test_engine):
+        from backend.app.core.database import _migrate_clear_text_artifact_tray_uuids
+
+        async with test_engine.begin() as conn:
+            await conn.execute(
+                text(
+                    f"INSERT INTO spool ({_SPOOL_COLUMNS}) VALUES "
+                    f"(1, {_SPOOL_DEFAULTS}, 'E35FACA1', :artifact), "
+                    f"(2, {_SPOOL_DEFAULTS}, 'AABBCCDD', :artifact), "
+                    f"(3, {_SPOOL_DEFAULTS}, 'DDEEFF00', :real), "
+                    f"(4, {_SPOOL_DEFAULTS}, '11223344', NULL)"
+                ),
+                {"artifact": PLA_BASIC_ARTIFACT, "real": REAL_TRAY_UUID},
+            )
+            await _migrate_clear_text_artifact_tray_uuids(conn)
+
+        async with test_engine.connect() as conn:
+            rows = dict((await conn.execute(text("SELECT id, tray_uuid FROM spool ORDER BY id"))).all())
+
+        assert rows == {1: None, 2: None, 3: REAL_TRAY_UUID, 4: None}
+
+    async def test_is_idempotent(self, test_engine):
+        from backend.app.core.database import _migrate_clear_text_artifact_tray_uuids
+
+        async with test_engine.begin() as conn:
+            await conn.execute(
+                text(f"INSERT INTO spool ({_SPOOL_COLUMNS}) VALUES (1, {_SPOOL_DEFAULTS}, NULL, :real)"),
+                {"real": REAL_TRAY_UUID},
+            )
+            await _migrate_clear_text_artifact_tray_uuids(conn)
+            await _migrate_clear_text_artifact_tray_uuids(conn)
+
+        async with test_engine.connect() as conn:
+            remaining = (await conn.execute(text("SELECT tray_uuid FROM spool WHERE id = 1"))).scalar_one()
+
+        assert remaining == REAL_TRAY_UUID


### PR DESCRIPTION
## Description

Complements #3022, which stops the SpoolBuddy daemon reading `tray_uuid` from the
wrong Bambu tag blocks. This handles the values already written by that bug:
existing databases still hold them, and daemons that have not been updated keep
sending new ones.

The tray UUID lives in block 9. A daemon reading blocks 4-5 picks up the filament
description instead, so a white PLA Basic spool reports
`504C4120426173696300000000000000` — the hex of `"PLA Basic"` — and so does every
other spool of that product. Since the backend identifies spools by `tray_uuid`,
a scan resolves to an arbitrary one of them and its weight and assignment land on
the wrong row.

Nothing currently rejects these values: they are 32 characters of valid hex and
pass the `^[0-9A-Fa-f]*$` pattern on `TagScannedRequest`. What sets them apart is
their shape — printable ASCII followed by NUL padding, which a random 16-byte
UUID practically never produces. `is_text_artifact_tray_uuid()` keys on that.

## Changes

- `backend/app/utils/tag_normalization.py` — `is_text_artifact_tray_uuid()`.
- `backend/app/core/database.py` — `_migrate_clear_text_artifact_tray_uuids()`
  nulls affected rows on upgrade. Clearing is the only repair available: the real
  UUID exists solely on the tag and comes back on the next scan by a fixed
  daemon. Until then the spool is still found by its own `tag_uid`.
- `backend/app/schemas/spoolbuddy.py` — drop the field on `tag_scanned` rather
  than reject the request, so an un-updated device stays usable.
- `backend/app/services/spool_tag_matcher.py` — `get_spool_by_tag()` falls
  through to `tag_uid` instead of matching on an artifact.
- `backend/tests/unit/test_spoolbuddy_tray_uuid_artifact.py` — 14 tests covering
  detection, the schema validator, lookup fallback and the migration.

The migration is deliberately not gated behind a `settings` flag, unlike the
one-shot backfills next to it. Those are gated because re-running would undo a
value the user has since chosen; here there is nothing to undo, and while
un-updated daemons are still in the field they keep writing new bad rows that a
later upgrade should also clean up. Rows holding a real UUID never match the
filter, so repeated runs are no-ops — covered by a test.

## Verification

Block layout confirmed against a real tag (MIFARE Classic 1K, UID `E35FACA1`,
white PLA Basic 1 kg), read with HKDF/Crypto1 authentication:

```
block 1: 4130302D573100004746413030000000  "A00-W1", "GFA00"
block 2: 504C4100000000000000000000000000  "PLA"
block 4: 504C4120426173696300000000000000  "PLA Basic"
block 5: FFFFFFFFE80300000000E03F00000000  colour RGBA, 1000 g, 1.75 mm
block 9: 6B9170BB5BD84DDBA748713C159367DF  tray UUID
```

Full backend suite passes; `ruff check` and `ruff format --check` are clean.

## Related Issue

Part of #984. Complements #3022 — no overlapping files. Relevant to #2685, which
needs canonical tray-UUID matching before it can prefill from a tag.
