### PR TITLE
feat(spoolbuddy): scale auto-calibration and manual recalibrate button

### DIFF
--- a/backend/app/api/routes/spoolbuddy.py
+++ b/backend/app/api/routes/spoolbuddy.py
@@ -1220,8 +1220,8 @@ async def queue_diagnostic(
     Returns:
         Status message indicating diagnostic was queued
     """
-    if diagnostic not in ("scale", "nfc", "read_tag"):
-        raise HTTPException(status_code=400, detail="Unknown diagnostic. Must be 'scale', 'nfc', or 'read_tag'")
+    if diagnostic not in ("scale", "nfc", "read_tag", "recalibrate"):
+        raise HTTPException(status_code=400, detail="Unknown diagnostic. Must be 'scale', 'nfc', 'read_tag', or 'recalibrate'")
 
     result = await db.execute(select(SpoolBuddyDevice).where(SpoolBuddyDevice.device_id == device_id))
     device = result.scalar_one_or_none()
@@ -1252,8 +1252,8 @@ async def get_diagnostic_result(
     Returns:
         Diagnostic result or 404 if not found
     """
-    if diagnostic not in ("scale", "nfc", "read_tag"):
-        raise HTTPException(status_code=400, detail="Unknown diagnostic. Must be 'scale', 'nfc', or 'read_tag'")
+    if diagnostic not in ("scale", "nfc", "read_tag", "recalibrate"):
+        raise HTTPException(status_code=400, detail="Unknown diagnostic. Must be 'scale', 'nfc', 'read_tag', or 'recalibrate'")
 
     result = await db.execute(select(SpoolBuddyDevice).where(SpoolBuddyDevice.device_id == device_id))
     device = result.scalar_one_or_none()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8739,13 +8739,13 @@ export const spoolbuddyApi = {
       body: JSON.stringify({ command }),
     }),
 
-  queueDiagnostics: (deviceId: string, type: 'nfc' | 'scale' | 'read_tag') =>
+  queueDiagnostics: (deviceId: string, type: 'nfc' | 'scale' | 'read_tag' | 'recalibrate') =>
     request<{ status: string; diagnostic: string; message: string }>(
       `/spoolbuddy/diagnostics/${deviceId}/run?diagnostic=${type}`,
       { method: 'POST', body: '{}' }
     ),
 
-  getDiagnosticResult: (deviceId: string, type: 'nfc' | 'scale' | 'read_tag') =>
+  getDiagnosticResult: (deviceId: string, type: 'nfc' | 'scale' | 'read_tag' | 'recalibrate') =>
     request<{ diagnostic: string; success: boolean; output: string; exit_code: number }>(
       `/spoolbuddy/diagnostics/${deviceId}/result?diagnostic=${type}`,
       { method: 'GET' }

--- a/frontend/src/components/SpoolBuddySettings.tsx
+++ b/frontend/src/components/SpoolBuddySettings.tsx
@@ -20,11 +20,13 @@ import {
   RefreshCw,
   RotateCw,
   Power,
+  Scale as ScaleIcon,
 } from 'lucide-react';
 import { spoolbuddyApi, type SpoolBuddyDevice } from '../api/client';
 import { Card, CardContent, CardHeader } from './Card';
 import { Button } from './Button';
 import { ConfirmModal } from './ConfirmModal';
+import { DiagnosticModal } from './spoolbuddy/DiagnosticModal';
 import { useToast } from '../contexts/ToastContext';
 import { formatRelativeTime } from '../utils/date';
 
@@ -63,6 +65,7 @@ function DeviceCard({ device, onUnregister, isDeleting }: DeviceCardProps) {
   const online = device.online;
   const [pendingAction, setPendingAction] = useState<ActionKey | null>(null);
   const [busyAction, setBusyAction] = useState<ActionKey | null>(null);
+  const [diagnosticOpen, setDiagnosticOpen] = useState<'recalibrate' | null>(null);
 
   const runAction = async (action: ActionKey) => {
     setBusyAction(action);
@@ -204,6 +207,16 @@ function DeviceCard({ device, onUnregister, isDeleting }: DeviceCardProps) {
             )}
             {t('settings.spoolbuddy.scale')}
           </span>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setDiagnosticOpen('recalibrate')}
+            disabled={!online}
+            aria-label={t('settings.spoolbuddy.recalibrateScale', 'Recalibrate Scale')}
+          >
+            <ScaleIcon className="w-3.5 h-3.5" />
+            <span>{t('settings.spoolbuddy.recalibrateScale', 'Recalibrate Scale')}</span>
+          </Button>
         </div>
 
         {/* System stats */}
@@ -284,6 +297,13 @@ function DeviceCard({ device, onUnregister, isDeleting }: DeviceCardProps) {
           isLoading={busyAction !== null}
           onConfirm={() => runAction(pendingAction)}
           onCancel={() => setPendingAction(null)}
+        />
+      )}
+      {diagnosticOpen && (
+        <DiagnosticModal
+          type={diagnosticOpen}
+          deviceId={device.device_id}
+          onClose={() => setDiagnosticOpen(null)}
         />
       )}
     </Card>

--- a/frontend/src/components/spoolbuddy/DiagnosticModal.tsx
+++ b/frontend/src/components/spoolbuddy/DiagnosticModal.tsx
@@ -4,7 +4,7 @@ import { spoolbuddyApi } from '../../api/client';
 import { useTranslation } from 'react-i18next';
 
 interface DiagnosticModalProps {
-  type: 'scale' | 'nfc' | 'read_tag';
+  type: 'scale' | 'nfc' | 'read_tag' | 'recalibrate';
   deviceId: string;
   onClose: () => void;
 }
@@ -78,9 +78,11 @@ export function DiagnosticModal({ type, deviceId, onClose }: DiagnosticModalProp
 
   const title = type === 'scale'
     ? t('spoolbuddy.diagnostic.scaleTitle', 'Scale Diagnostic')
-    : type === 'read_tag'
-      ? t('spoolbuddy.diagnostic.readTagTitle', 'Read Tag Diagnostic')
-      : t('spoolbuddy.diagnostic.nfcTitle', 'NFC Reader Diagnostic');
+    : type === 'recalibrate'
+      ? t('spoolbuddy.diagnostic.recalibrateTitle', 'Scale Recalibration')
+      : type === 'read_tag'
+        ? t('spoolbuddy.diagnostic.readTagTitle', 'Read Tag Diagnostic')
+        : t('spoolbuddy.diagnostic.nfcTitle', 'NFC Reader Diagnostic');
 
   return (
     <div

--- a/spoolbuddy/daemon/main.py
+++ b/spoolbuddy/daemon/main.py
@@ -325,6 +325,57 @@ async def heartbeat_loop(config: Config, api: APIClient, start_time: float, shar
                         str(e),
                     )
                 continue
+            elif cmd == "run_recalibrate_diag":
+                scale = shared.get("scale")
+                lines = []
+                success = False
+                if not scale or not scale.ok:
+                    lines.append("Scale not available")
+                else:
+                    lines.append("=== Scale Recalibration ===")
+                    lines.append("")
+                    lines.append("[1] Internal offset calibration (mode=0)...")
+                    afe_ok = await asyncio.to_thread(scale.recalibrate_afe)
+                    if afe_ok:
+                        lines.append("    Internal offset cal: OK")
+                    else:
+                        lines.append("    Internal offset cal: FAILED")
+                    lines.append("")
+                    lines.append("[2] System offset calibration (mode=2)...")
+                    lines.append("    WARNING: scale must be empty for accurate results")
+                    scale._auto_zero_pending = True
+                    scale._pending_zero_avg = 0.0
+                    new_tare = await asyncio.to_thread(scale.calibrate_zero)
+                    if new_tare is not None:
+                        config.tare_offset = new_tare
+                        await api.update_tare(config.device_id, new_tare)
+                        lines.append(f"    System offset cal: OK (new tare={new_tare})")
+                    else:
+                        lines.append("    System offset cal: skipped (not pending)")
+                    lines.append("")
+                    lines.append("[3] Reading 5 samples after recalibration...")
+                    readings = []
+                    for _ in range(5):
+                        result_read = await asyncio.to_thread(scale.read)
+                        if result_read:
+                            grams, stable, raw = result_read
+                            readings.append((grams, stable, raw))
+                            lines.append(f"    {grams:>8.1f}g  raw={raw}  {'stable' if stable else 'unstable'}")
+                        else:
+                            lines.append("    (no reading)")
+                    if readings:
+                        avg = sum(r[0] for r in readings) / len(readings)
+                        spread = max(r[0] for r in readings) - min(r[0] for r in readings)
+                        lines.append(f"    Average: {avg:.1f}g  Spread: {spread:.1f}g")
+                    lines.append("")
+                    lines.append("Recalibration complete.")
+                    success = afe_ok
+                output = "\n".join(lines)
+                logger.info("Recalibration diagnostic: %s", "OK" if success else "FAILED")
+                await api.diagnostic_result(
+                    config.device_id, "recalibrate", success, output, 0 if success else 1
+                )
+                continue
             elif cmd in ("run_nfc_diag", "run_scale_diag", "run_read_tag_diag"):
                 if cmd == "run_scale_diag":
                     diagnostic = "scale"

--- a/spoolbuddy/daemon/main.py
+++ b/spoolbuddy/daemon/main.py
@@ -229,6 +229,17 @@ async def scale_poll_loop(config: Config, api: APIClient, shared: dict):
                         last_reported_grams = grams
                     last_report = now
 
+            # Auto-zero: system offset cal when scale confirmed empty (datasheet 8.6.1)
+            if scale.auto_zero_pending:
+                new_tare = await asyncio.to_thread(scale.calibrate_zero)
+                if new_tare is not None:
+                    config.tare_offset = new_tare
+                    await api.update_tare(config.device_id, new_tare)
+
+            # Periodic AFE recalibration (every ~6h)
+            if scale.afe_recal_due:
+                await asyncio.to_thread(scale.recalibrate_afe)
+
             await asyncio.sleep(config.scale_read_interval)
     finally:
         scale.close()

--- a/spoolbuddy/daemon/scale_reader.py
+++ b/spoolbuddy/daemon/scale_reader.py
@@ -1,4 +1,4 @@
-"""Scale reader wrapper with stability detection and calibration."""
+"""Scale reader wrapper with stability detection, auto-zero, and periodic recalibration."""
 
 import logging
 import time
@@ -7,6 +7,14 @@ from collections import deque
 logger = logging.getLogger(__name__)
 
 MOVING_AVG_SIZE = 20
+
+# ponytail: auto-zero corrects thermal/mechanical tare drift when scale is empty
+AUTO_ZERO_THRESHOLD_G = 5.0
+AUTO_ZERO_SETTLE_S = 10.0
+AUTO_ZERO_COOLDOWN_S = 60.0
+
+# ponytail: 6h default, raise if recal proves disruptive
+AFE_RECAL_INTERVAL_S = 6 * 3600
 
 
 class ScaleReader:
@@ -18,6 +26,12 @@ class ScaleReader:
         self._stability_history: deque[tuple[float, float]] = deque(maxlen=20)
         self._ok = False
         self._last_raw = 0
+
+        self._auto_zero_enter: float | None = None
+        self._last_auto_zero: float = -AUTO_ZERO_COOLDOWN_S
+        self._auto_zero_pending = False
+        self._pending_zero_avg: float | None = None
+        self._last_afe_recal: float = time.monotonic()
 
         try:
             from .nau7802 import NAU7802
@@ -64,6 +78,97 @@ class ScaleReader:
             logger.info("Tared at raw=%d", self._tare_offset)
         return self._tare_offset
 
+    @property
+    def auto_zero_pending(self) -> bool:
+        return self._auto_zero_pending
+
+    @property
+    def afe_recal_due(self) -> bool:
+        if not self._scale:
+            return False
+        return time.monotonic() - self._last_afe_recal >= AFE_RECAL_INTERVAL_S
+
+    def recalibrate_afe(self) -> bool:
+        """Re-run NAU7802 internal offset calibration (mode=0). Blocks ~400ms.
+
+        Safe to run any time (spool on scale or not) because internal cal
+        disconnects inputs and shorts to internal reference.
+        Per datasheet section 8.6: removes PGA gain and offset errors.
+        """
+        if not self._scale:
+            return False
+        try:
+            self._scale.calibrate_afe(timeout_ms=1000, mode=0)
+            self._scale.flush_readings(count=2, timeout_s=1.0)
+            self._samples.clear()
+            self._stability_history.clear()
+            self._last_afe_recal = time.monotonic()
+            logger.info("Periodic internal offset cal complete")
+            return True
+        except Exception as e:
+            logger.warning("Internal offset cal failed: %s", e)
+            return False
+
+    def calibrate_zero(self) -> int | None:
+        """Run zero-point calibration if auto-zero detected empty scale.
+
+        Per datasheet section 8.6.1: system offset calibration (mode=2) uses
+        the actual inputs to set the hardware zero point, removing both internal
+        PGA errors and external DC errors (load cell drift, thermal offset).
+        More precise than software tare because it corrects at 24-bit ADC level
+        before gain multiplication.
+
+        Falls back to software tare adjustment when hardware is unavailable.
+        Returns new tare offset, or None if no calibration was pending.
+        """
+        if not self._auto_zero_pending:
+            return None
+        self._auto_zero_pending = False
+
+        if self._scale:
+            try:
+                # ponytail: system offset cal (mode=2), upgrade to temp-triggered if 6h proves too coarse
+                self._scale.calibrate_afe(timeout_ms=1000, mode=2)
+                self._scale.flush_readings(count=4, timeout_s=2.0)
+                readings = []
+                for _ in range(5):
+                    if self._scale.wait_data_ready(timeout_s=0.5):
+                        readings.append(self._scale.read_raw())
+                if readings:
+                    self._tare_offset = sum(readings) // len(readings)
+                self._samples.clear()
+                self._stability_history.clear()
+                logger.info("Auto-zero: system offset cal, tare=%d", self._tare_offset)
+                return self._tare_offset
+            except Exception as e:
+                logger.warning("System offset cal failed, using software tare: %s", e)
+
+        # Fallback: software-only tare adjustment
+        if self._calibration_factor != 0 and self._pending_zero_avg is not None:
+            adjustment = int(round(self._pending_zero_avg / self._calibration_factor))
+            if adjustment != 0:
+                self._tare_offset += adjustment
+        self._samples.clear()
+        self._stability_history.clear()
+        logger.info("Auto-zero: software tare=%d", self._tare_offset)
+        return self._tare_offset
+
+    def _check_auto_zero(self, avg_grams: float, stable: bool, now: float):
+        """Detect empty-scale condition for calibrate_zero()."""
+        if stable and abs(avg_grams) <= AUTO_ZERO_THRESHOLD_G:
+            if self._auto_zero_enter is None:
+                self._auto_zero_enter = now
+            elif (
+                now - self._auto_zero_enter >= AUTO_ZERO_SETTLE_S
+                and now - self._last_auto_zero >= AUTO_ZERO_COOLDOWN_S
+            ):
+                self._auto_zero_pending = True
+                self._pending_zero_avg = avg_grams
+                self._auto_zero_enter = None
+                self._last_auto_zero = now
+        else:
+            self._auto_zero_enter = None
+
     def read(self) -> tuple[float, bool, int] | None:
         """Read current weight. Returns (grams, stable, raw_adc) or None."""
         try:
@@ -92,6 +197,8 @@ class ScaleReader:
                 if len(recent) >= 3:
                     spread = max(recent) - min(recent)
                     stable = spread < 2.0
+
+            self._check_auto_zero(avg_grams, stable, now)
 
             return round(avg_grams, 1), stable, raw
 

--- a/spoolbuddy/tests/test_scale_reader.py
+++ b/spoolbuddy/tests/test_scale_reader.py
@@ -1,0 +1,176 @@
+"""Tests for ScaleReader auto-zero, system offset cal, and periodic AFE recalibration."""
+
+from unittest.mock import MagicMock, patch
+
+from daemon.scale_reader import (
+    AUTO_ZERO_COOLDOWN_S,
+    AUTO_ZERO_SETTLE_S,
+    AUTO_ZERO_THRESHOLD_G,
+    AFE_RECAL_INTERVAL_S,
+    ScaleReader,
+)
+
+
+def _make_reader(tare=1000, cal=1.0):
+    # Init catches hardware errors gracefully; we attach a mock scale after
+    reader = ScaleReader(tare_offset=tare, calibration_factor=cal)
+    reader._scale = MagicMock()
+    reader._ok = True
+    return reader
+
+
+class TestAutoZeroDetection:
+    """_check_auto_zero sets the pending flag; calibrate_zero() acts on it."""
+
+    def test_sets_pending_after_stable_settle(self):
+        reader = _make_reader()
+        reader._check_auto_zero(avg_grams=3.0, stable=True, now=0.0)
+        assert not reader.auto_zero_pending
+
+        reader._check_auto_zero(avg_grams=3.0, stable=True, now=AUTO_ZERO_SETTLE_S + 1)
+        assert reader.auto_zero_pending
+
+    def test_not_pending_when_unstable(self):
+        reader = _make_reader()
+        reader._check_auto_zero(avg_grams=3.0, stable=False, now=0.0)
+        reader._check_auto_zero(avg_grams=3.0, stable=False, now=AUTO_ZERO_SETTLE_S + 1)
+        assert not reader.auto_zero_pending
+
+    def test_not_pending_above_threshold(self):
+        reader = _make_reader()
+        reader._check_auto_zero(avg_grams=AUTO_ZERO_THRESHOLD_G + 1, stable=True, now=0.0)
+        reader._check_auto_zero(avg_grams=AUTO_ZERO_THRESHOLD_G + 1, stable=True, now=AUTO_ZERO_SETTLE_S + 1)
+        assert not reader.auto_zero_pending
+
+    def test_cooldown_respected(self):
+        reader = _make_reader()
+
+        reader._check_auto_zero(avg_grams=3.0, stable=True, now=0.0)
+        reader._check_auto_zero(avg_grams=3.0, stable=True, now=AUTO_ZERO_SETTLE_S + 1)
+        assert reader.auto_zero_pending
+        reader._auto_zero_pending = False  # consumed
+
+        # Within cooldown
+        t = AUTO_ZERO_SETTLE_S + 2
+        reader._check_auto_zero(avg_grams=2.0, stable=True, now=t)
+        reader._check_auto_zero(avg_grams=2.0, stable=True, now=t + AUTO_ZERO_SETTLE_S + 1)
+        assert not reader.auto_zero_pending
+
+        # After cooldown
+        t2 = AUTO_ZERO_SETTLE_S + 2 + AUTO_ZERO_COOLDOWN_S + 1
+        reader._check_auto_zero(avg_grams=2.0, stable=True, now=t2)
+        reader._check_auto_zero(avg_grams=2.0, stable=True, now=t2 + AUTO_ZERO_SETTLE_S + 1)
+        assert reader.auto_zero_pending
+
+    def test_resets_on_instability(self):
+        reader = _make_reader()
+        reader._check_auto_zero(avg_grams=3.0, stable=True, now=0.0)
+        assert reader._auto_zero_enter == 0.0
+
+        reader._check_auto_zero(avg_grams=3.0, stable=False, now=5.0)
+        assert reader._auto_zero_enter is None
+
+        reader._check_auto_zero(avg_grams=3.0, stable=True, now=6.0)
+        reader._check_auto_zero(avg_grams=3.0, stable=True, now=6.0 + AUTO_ZERO_SETTLE_S + 1)
+        assert reader.auto_zero_pending
+
+
+class TestCalibrateZero:
+    """calibrate_zero() runs NAU7802 system offset cal (mode=2) per datasheet 8.6.1."""
+
+    def test_runs_system_offset_cal_mode_2(self):
+        reader = _make_reader(tare=1000)
+        nau = reader._scale
+        nau.wait_data_ready.return_value = True
+        nau.read_raw.return_value = 5  # near-zero after cal
+
+        reader._auto_zero_pending = True
+        reader._pending_zero_avg = 3.0
+
+        new_tare = reader.calibrate_zero()
+
+        nau.calibrate_afe.assert_called_once_with(timeout_ms=1000, mode=2)
+        nau.flush_readings.assert_called_once_with(count=4, timeout_s=2.0)
+        assert new_tare == 5  # average of 5 readings of value 5
+        assert reader._tare_offset == 5
+        assert not reader.auto_zero_pending
+
+    def test_returns_none_when_not_pending(self):
+        reader = _make_reader()
+        assert reader.calibrate_zero() is None
+
+    def test_falls_back_to_software_tare_on_hw_failure(self):
+        reader = _make_reader(tare=1000, cal=1.0)
+        reader._scale.calibrate_afe.side_effect = RuntimeError("timeout")
+
+        reader._auto_zero_pending = True
+        reader._pending_zero_avg = 3.0
+
+        new_tare = reader.calibrate_zero()
+
+        assert new_tare == 1003  # software fallback: 1000 + round(3.0 / 1.0)
+        assert reader._tare_offset == 1003
+
+    def test_falls_back_to_software_tare_without_hardware(self):
+        reader = _make_reader(tare=1000, cal=1.0)
+        reader._scale = None
+
+        reader._auto_zero_pending = True
+        reader._pending_zero_avg = 4.0
+
+        new_tare = reader.calibrate_zero()
+        assert new_tare == 1004
+
+    def test_software_fallback_skips_zero_adjustment(self):
+        reader = _make_reader(tare=1000, cal=1.0)
+        reader._scale = None
+
+        reader._auto_zero_pending = True
+        reader._pending_zero_avg = 0.4  # rounds to 0
+
+        new_tare = reader.calibrate_zero()
+        assert new_tare == 1000  # no adjustment
+
+
+class TestAFERecal:
+    """Periodic internal offset calibration (mode=0), safe with spool on scale."""
+
+    def test_recal_due_after_interval(self):
+        reader = _make_reader()
+        reader._last_afe_recal = 0.0
+
+        with patch("daemon.scale_reader.time") as mock_time:
+            mock_time.monotonic.return_value = AFE_RECAL_INTERVAL_S + 1
+            assert reader.afe_recal_due
+
+    def test_recal_not_due_before_interval(self):
+        reader = _make_reader()
+
+        with patch("daemon.scale_reader.time") as mock_time:
+            mock_time.monotonic.return_value = reader._last_afe_recal + 100
+            assert not reader.afe_recal_due
+
+    def test_recalibrate_uses_internal_mode_0(self):
+        reader = _make_reader()
+        nau = reader._scale
+
+        result = reader.recalibrate_afe()
+
+        assert result is True
+        nau.calibrate_afe.assert_called_once_with(timeout_ms=1000, mode=0)
+        nau.flush_readings.assert_called_once_with(count=2, timeout_s=1.0)
+        assert len(reader._samples) == 0
+
+    def test_recalibrate_handles_failure(self):
+        reader = _make_reader()
+        reader._scale.calibrate_afe.side_effect = RuntimeError("timeout")
+
+        result = reader.recalibrate_afe()
+        assert result is False
+
+    def test_no_scale_returns_false(self):
+        reader = _make_reader()
+        reader._scale = None
+
+        assert not reader.afe_recal_due
+        assert not reader.recalibrate_afe()


### PR DESCRIPTION
## Description

Adds automatic calibration for the NAU7802 + load cell scale to correct thermal and mechanical drift, plus a manual recalibration button in the SpoolBuddy settings UI.

## Related Issue

N/A

## Documentation

**Pick one**:
- [x] No docs update required — reason: SpoolBuddy scale feature, no user-facing config changes

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test addition or update

## Changes Made

- **Auto-zero detection**: when the scale reads within ±5g and is stable for 10s (with 60s cooldown), runs NAU7802 system offset calibration (mode=2) to re-tare the scale automatically
- **Periodic AFE recalibration**: runs internal offset calibration (mode=0) every 6 hours to compensate for thermal drift, safe to run with a spool on the scale
- **Manual recalibrate button**: new "Recalibrate Scale" button in SpoolBuddy settings (scale tab) that triggers both calibrations via the existing diagnostic queue/poll infrastructure and displays results in a terminal-style modal
- **Tests**: added test coverage for auto-zero detection, calibrate_zero, and AFE recalibration in scale_reader

### Files changed

- `spoolbuddy/daemon/scale_reader.py` — auto-zero detection loop, `calibrate_zero()`, `recalibrate_afe()` methods
- `spoolbuddy/daemon/main.py` — `run_recalibrate_diag` command handler
- `spoolbuddy/tests/test_scale_reader.py` — new test file (176 lines)
- `backend/app/api/routes/spoolbuddy.py` — added "recalibrate" to diagnostic validation
- `frontend/src/api/client.ts` — extended diagnostic type unions
- `frontend/src/components/SpoolBuddySettings.tsx` — recalibrate button + modal
- `frontend/src/components/spoolbuddy/DiagnosticModal.tsx` — recalibrate type + title

## Testing

- [x] I have tested this on my local machine
- [x] I have tested with my printer model: A1 Mini (SpoolBuddy with NAU7802 + load cell)

## Checklist

- [x] My code follows the project's coding style
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

All 90 daemon tests pass. The auto-zero only triggers when the scale is genuinely empty and stable, with a 60s cooldown to avoid rapid re-calibration loops. The periodic internal recal (mode=0) is safe with a spool on the scale since it only recalibrates the ADC's internal analog front-end.